### PR TITLE
feat(ui): adds repo-based collapsible grouping to Issues and PRs tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest --config vitest.config.ts",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
-    "test:e2e": "playwright test"
+    "test:e2e": "E2E_PORT=$(node -e \"const s=require('net').createServer();s.listen(0,()=>{console.log(s.address().port);s.close()})\") playwright test"
   },
   "dependencies": {
     "@octokit/core": "^7.0.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const port = Number(process.env.E2E_PORT) || 5173;
+
 export default defineConfig({
   testDir: "./e2e",
   reporter: [["html", { open: "never" }]],
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${port}`,
     trace: "on-first-retry",
   },
   projects: [
@@ -14,8 +16,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
-    port: 5173,
+    command: `pnpm exec vite dev --port ${port}`,
+    url: `http://localhost:${port}`,
     timeout: 120_000,
     reuseExistingServer: !process.env.CI,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `pnpm exec vite dev --port ${port}`,
+    command: `pnpm exec vite dev --port ${port} --strictPort`,
     url: `http://localhost:${port}`,
     timeout: 120_000,
     reuseExistingServer: !process.env.CI,

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -245,6 +245,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                           {/* Workflow header */}
                           <button
                             onClick={() => toggleWorkflow(wfKey)}
+                            aria-expanded={!isWfCollapsed()}
                             class="w-full flex items-center gap-2 px-4 py-1.5 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
                           >
                             <ChevronIcon size="sm" rotated={isWfCollapsed()} />

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -8,25 +8,7 @@ import ErrorBannerList from "../shared/ErrorBannerList";
 import SkeletonRows from "../shared/SkeletonRows";
 import FilterChips from "../shared/FilterChips";
 import type { FilterChipGroupDef } from "../shared/FilterChips";
-
-function ChevronIcon(props: { size: "sm" | "md"; rotated: boolean }) {
-  const sizeClass = () => (props.size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5");
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      class={`${sizeClass()} text-gray-400 transition-transform ${props.rotated ? "-rotate-90" : ""}`}
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-        clip-rule="evenodd"
-      />
-    </svg>
-  );
-}
+import ChevronIcon from "../shared/ChevronIcon";
 
 interface ActionsTabProps {
   workflowRuns: WorkflowRun[];
@@ -262,6 +244,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                 {/* Repo header */}
                 <button
                   onClick={() => toggleRepo(repoGroup.repoFullName)}
+                  aria-expanded={!isRepoCollapsed()}
                   class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                 >
                   <ChevronIcon size="md" rotated={isRepoCollapsed()} />

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -1,4 +1,5 @@
-import { createMemo, createSignal, For, Show } from "solid-js";
+import { createMemo, For, Show } from "solid-js";
+import { createStore } from "solid-js/store";
 import type { WorkflowRun, ApiError } from "../../services/api";
 import { config } from "../../stores/config";
 import { viewState, setViewState, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, type ActionsFilterField } from "../../stores/view";
@@ -104,35 +105,15 @@ const actionsFilterGroups: FilterChipGroupDef[] = [
 ];
 
 export default function ActionsTab(props: ActionsTabProps) {
-  const [collapsedRepos, setCollapsedRepos] = createSignal<Set<string>>(
-    new Set()
-  );
-  const [collapsedWorkflows, setCollapsedWorkflows] = createSignal<Set<string>>(
-    new Set()
-  );
+  const [collapsedRepos, setCollapsedRepos] = createStore<Record<string, boolean>>({});
+  const [collapsedWorkflows, setCollapsedWorkflows] = createStore<Record<string, boolean>>({});
 
   function toggleRepo(repoFullName: string) {
-    setCollapsedRepos((prev) => {
-      const next = new Set(prev);
-      if (next.has(repoFullName)) {
-        next.delete(repoFullName);
-      } else {
-        next.add(repoFullName);
-      }
-      return next;
-    });
+    setCollapsedRepos(repoFullName, (v) => !v);
   }
 
   function toggleWorkflow(key: string) {
-    setCollapsedWorkflows((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
+    setCollapsedWorkflows(key, (v) => !v);
   }
 
   function handleIgnore(run: WorkflowRun) {
@@ -237,7 +218,7 @@ export default function ActionsTab(props: ActionsTabProps) {
         <For each={repoGroups()}>
           {(repoGroup) => {
             const isRepoCollapsed = () =>
-              collapsedRepos().has(repoGroup.repoFullName);
+              collapsedRepos[repoGroup.repoFullName];
 
             return (
               <div class="bg-white dark:bg-gray-900">
@@ -257,7 +238,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                     {(wfGroup) => {
                       const wfKey = `${repoGroup.repoFullName}:${wfGroup.workflowId}`;
                       const isWfCollapsed = () =>
-                        collapsedWorkflows().has(wfKey);
+                        collapsedWorkflows[wfKey];
 
                       return (
                         <div class="border-l-2 border-gray-100 dark:border-gray-800 ml-4">

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -162,8 +162,8 @@ export default function IssuesTab(props: IssuesTabProps) {
     return { items, meta };
   });
 
-  const filteredSorted = () => filteredSortedWithMeta().items;
-  const issueMeta = () => filteredSortedWithMeta().meta;
+  const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
+  const issueMeta = createMemo(() => filteredSortedWithMeta().meta);
 
   const pageSize = createMemo(() => config.itemsPerPage);
 

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -14,6 +14,7 @@ import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
 import { deriveInvolvementRoles } from "../../lib/format";
+import { groupByRepo, computePageLayout, slicePageGroups } from "../../lib/grouping";
 
 export interface IssuesTabProps {
   issues: Issue[];
@@ -42,57 +43,6 @@ const issueFilterGroups: FilterChipGroupDef[] = [
     ],
   },
 ];
-
-interface IssueRepoGroup {
-  repoFullName: string;
-  items: Issue[];
-}
-
-function groupByRepo(items: Issue[]): IssueRepoGroup[] {
-  const groups: IssueRepoGroup[] = [];
-  const map = new Map<string, IssueRepoGroup>();
-  for (const item of items) {
-    let group = map.get(item.repoFullName);
-    if (!group) {
-      group = { repoFullName: item.repoFullName, items: [] };
-      map.set(item.repoFullName, group);
-      groups.push(group);
-    }
-    group.items.push(item);
-  }
-  return groups;
-}
-
-function computePageLayout(
-  groups: IssueRepoGroup[],
-  approxPageSize: number,
-): { boundaries: number[]; pageCount: number } {
-  if (groups.length === 0) return { boundaries: [0], pageCount: 1 };
-
-  const boundaries: number[] = [0];
-  let currentPageItems = 0;
-  for (let i = 0; i < groups.length; i++) {
-    if (currentPageItems > 0 && currentPageItems + groups[i].items.length > approxPageSize) {
-      boundaries.push(i);
-      currentPageItems = 0;
-    }
-    currentPageItems += groups[i].items.length;
-  }
-
-  return { boundaries, pageCount: Math.max(1, boundaries.length) };
-}
-
-function slicePageGroups(
-  groups: IssueRepoGroup[],
-  boundaries: number[],
-  pageCount: number,
-  page: number,
-): IssueRepoGroup[] {
-  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
-  const start = boundaries[clampedPage];
-  const end = clampedPage + 1 < boundaries.length ? boundaries[clampedPage + 1] : groups.length;
-  return groups.slice(start, end);
-}
 
 export default function IssuesTab(props: IssuesTabProps) {
   const [page, setPage] = createSignal(0);
@@ -171,13 +121,11 @@ export default function IssuesTab(props: IssuesTabProps) {
   const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
   const issueMeta = createMemo(() => filteredSortedWithMeta().meta);
 
-  const pageSize = createMemo(() => config.itemsPerPage);
-
   const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
-  const pageLayout = createMemo(() => computePageLayout(repoGroups(), pageSize()));
-  const pageCount = () => pageLayout().pageCount;
+  const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
+  const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
-    slicePageGroups(repoGroups(), pageLayout().boundaries, pageLayout().pageCount, page())
+    slicePageGroups(repoGroups(), pageLayout().boundaries, pageCount(), page())
   );
 
   createEffect(() => {
@@ -298,43 +246,46 @@ export default function IssuesTab(props: IssuesTabProps) {
         >
           <div class="divide-y divide-gray-100 dark:divide-gray-800">
             <For each={pageGroups()}>
-              {(repoGroup) => (
-                <div class="bg-white dark:bg-gray-900">
-                  <button
-                    onClick={() => toggleRepo(repoGroup.repoFullName)}
-                    aria-expanded={!collapsedRepos[repoGroup.repoFullName]}
-                    class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                  >
-                    <ChevronIcon size="md" rotated={collapsedRepos[repoGroup.repoFullName]} />
-                    {repoGroup.repoFullName}
-                  </button>
-                  <Show when={!collapsedRepos[repoGroup.repoFullName]}>
-                    <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
-                      <For each={repoGroup.items}>
-                        {(issue) => (
-                          <div role="listitem">
-                            <ItemRow
-                              hideRepo={true}
-                              repo={issue.repoFullName}
-                              number={issue.number}
-                              title={issue.title}
-                              author={issue.userLogin}
-                              createdAt={issue.createdAt}
-                              url={issue.htmlUrl}
-                              labels={issue.labels}
-                              onIgnore={() => handleIgnore(issue)}
-                              density={config.viewDensity}
-                              commentCount={issue.comments}
-                            >
-                              <RoleBadge roles={issueMeta().get(issue.id)?.roles ?? []} />
-                            </ItemRow>
-                          </div>
-                        )}
-                      </For>
-                    </div>
-                  </Show>
-                </div>
-              )}
+              {(repoGroup) => {
+                const isRepoCollapsed = () => collapsedRepos[repoGroup.repoFullName];
+                return (
+                  <div class="bg-white dark:bg-gray-900">
+                    <button
+                      onClick={() => toggleRepo(repoGroup.repoFullName)}
+                      aria-expanded={!isRepoCollapsed()}
+                      class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                    >
+                      <ChevronIcon size="md" rotated={isRepoCollapsed()} />
+                      {repoGroup.repoFullName}
+                    </button>
+                    <Show when={!isRepoCollapsed()}>
+                      <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
+                        <For each={repoGroup.items}>
+                          {(issue) => (
+                            <div role="listitem">
+                              <ItemRow
+                                hideRepo={true}
+                                repo={issue.repoFullName}
+                                number={issue.number}
+                                title={issue.title}
+                                author={issue.userLogin}
+                                createdAt={issue.createdAt}
+                                url={issue.htmlUrl}
+                                labels={issue.labels}
+                                onIgnore={() => handleIgnore(issue)}
+                                density={config.viewDensity}
+                                commentCount={issue.comments}
+                              >
+                                <RoleBadge roles={issueMeta().get(issue.id)?.roles ?? []} />
+                              </ItemRow>
+                            </div>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
+                  </div>
+                );
+              }}
             </For>
           </div>
         </Show>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -63,29 +63,35 @@ function groupByRepo(items: Issue[]): IssueRepoGroup[] {
   return groups;
 }
 
-function paginateGroups(
+function computePageLayout(
   groups: IssueRepoGroup[],
-  page: number,
   approxPageSize: number,
-): { pageGroups: IssueRepoGroup[]; pageCount: number } {
-  if (groups.length === 0) return { pageGroups: [], pageCount: 1 };
+): { boundaries: number[]; pageCount: number } {
+  if (groups.length === 0) return { boundaries: [0], pageCount: 1 };
 
-  const pageBoundaries: number[] = [0];
+  const boundaries: number[] = [0];
   let currentPageItems = 0;
   for (let i = 0; i < groups.length; i++) {
     if (currentPageItems > 0 && currentPageItems + groups[i].items.length > approxPageSize) {
-      pageBoundaries.push(i);
+      boundaries.push(i);
       currentPageItems = 0;
     }
     currentPageItems += groups[i].items.length;
   }
 
-  const pageCount = Math.max(1, pageBoundaries.length);
-  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
-  const start = pageBoundaries[clampedPage];
-  const end = clampedPage + 1 < pageBoundaries.length ? pageBoundaries[clampedPage + 1] : groups.length;
+  return { boundaries, pageCount: Math.max(1, boundaries.length) };
+}
 
-  return { pageGroups: groups.slice(start, end), pageCount };
+function slicePageGroups(
+  groups: IssueRepoGroup[],
+  boundaries: number[],
+  pageCount: number,
+  page: number,
+): IssueRepoGroup[] {
+  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
+  const start = boundaries[clampedPage];
+  const end = clampedPage + 1 < boundaries.length ? boundaries[clampedPage + 1] : groups.length;
+  return groups.slice(start, end);
 }
 
 export default function IssuesTab(props: IssuesTabProps) {
@@ -168,8 +174,11 @@ export default function IssuesTab(props: IssuesTabProps) {
   const pageSize = createMemo(() => config.itemsPerPage);
 
   const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
-  const paginatedResult = createMemo(() => paginateGroups(repoGroups(), page(), pageSize()));
-  const pageCount = () => paginatedResult().pageCount;
+  const pageLayout = createMemo(() => computePageLayout(repoGroups(), pageSize()));
+  const pageCount = () => pageLayout().pageCount;
+  const pageGroups = createMemo(() =>
+    slicePageGroups(repoGroups(), pageLayout().boundaries, pageLayout().pageCount, page())
+  );
 
   function handleSort(field: SortField) {
     const current = sortPref();
@@ -258,7 +267,7 @@ export default function IssuesTab(props: IssuesTabProps) {
       {/* Issue rows */}
       <Show when={!props.loading || props.issues.length > 0}>
         <Show
-          when={paginatedResult().pageGroups.length > 0}
+          when={pageGroups().length > 0}
           fallback={
             <div class="flex flex-col items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400">
               <svg
@@ -283,7 +292,7 @@ export default function IssuesTab(props: IssuesTabProps) {
           }
         >
           <div class="divide-y divide-gray-100 dark:divide-gray-800">
-            <For each={paginatedResult().pageGroups}>
+            <For each={pageGroups()}>
               {(repoGroup) => (
                 <div class="bg-white dark:bg-gray-900">
                   <button

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -11,6 +11,7 @@ import FilterChips from "../shared/FilterChips";
 import type { FilterChipGroupDef } from "../shared/FilterChips";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
+import ChevronIcon from "../shared/ChevronIcon";
 import { deriveInvolvementRoles } from "../../lib/format";
 
 export interface IssuesTabProps {
@@ -41,8 +42,66 @@ const issueFilterGroups: FilterChipGroupDef[] = [
   },
 ];
 
+interface IssueRepoGroup {
+  repoFullName: string;
+  items: Issue[];
+}
+
+function groupByRepo(items: Issue[]): IssueRepoGroup[] {
+  const groups: IssueRepoGroup[] = [];
+  const map = new Map<string, IssueRepoGroup>();
+  for (const item of items) {
+    let group = map.get(item.repoFullName);
+    if (!group) {
+      group = { repoFullName: item.repoFullName, items: [] };
+      map.set(item.repoFullName, group);
+      groups.push(group);
+    }
+    group.items.push(item);
+  }
+  return groups;
+}
+
+function paginateGroups(
+  groups: IssueRepoGroup[],
+  page: number,
+  approxPageSize: number,
+): { pageGroups: IssueRepoGroup[]; pageCount: number } {
+  if (groups.length === 0) return { pageGroups: [], pageCount: 1 };
+
+  const pageBoundaries: number[] = [0];
+  let currentPageItems = 0;
+  for (let i = 0; i < groups.length; i++) {
+    if (currentPageItems > 0 && currentPageItems + groups[i].items.length > approxPageSize) {
+      pageBoundaries.push(i);
+      currentPageItems = 0;
+    }
+    currentPageItems += groups[i].items.length;
+  }
+
+  const pageCount = Math.max(1, pageBoundaries.length);
+  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
+  const start = pageBoundaries[clampedPage];
+  const end = clampedPage + 1 < pageBoundaries.length ? pageBoundaries[clampedPage + 1] : groups.length;
+
+  return { pageGroups: groups.slice(start, end), pageCount };
+}
+
 export default function IssuesTab(props: IssuesTabProps) {
   const [page, setPage] = createSignal(0);
+  const [collapsedRepos, setCollapsedRepos] = createSignal<Set<string>>(new Set());
+
+  function toggleRepo(repoFullName: string) {
+    setCollapsedRepos((prev) => {
+      const next = new Set(prev);
+      if (next.has(repoFullName)) {
+        next.delete(repoFullName);
+      } else {
+        next.add(repoFullName);
+      }
+      return next;
+    });
+  }
 
   const sortPref = createMemo(() => {
     const pref = viewState.sortPreferences["issues"];
@@ -115,16 +174,9 @@ export default function IssuesTab(props: IssuesTabProps) {
 
   const pageSize = createMemo(() => config.itemsPerPage);
 
-  const pageCount = createMemo(() =>
-    Math.max(1, Math.ceil(filteredSorted().length / pageSize()))
-  );
-
-  // Reset to first page when filters/sort change
-  const pagedItems = createMemo(() => {
-    const p = Math.min(page(), pageCount() - 1);
-    const start = p * pageSize();
-    return filteredSorted().slice(start, start + pageSize());
-  });
+  const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
+  const paginatedResult = createMemo(() => paginateGroups(repoGroups(), page(), pageSize()));
+  const pageCount = () => paginatedResult().pageCount;
 
   function handleSort(field: SortField) {
     const current = sortPref();
@@ -213,7 +265,7 @@ export default function IssuesTab(props: IssuesTabProps) {
       {/* Issue rows */}
       <Show when={!props.loading || props.issues.length > 0}>
         <Show
-          when={pagedItems().length > 0}
+          when={paginatedResult().pageGroups.length > 0}
           fallback={
             <div class="flex flex-col items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400">
               <svg
@@ -237,24 +289,43 @@ export default function IssuesTab(props: IssuesTabProps) {
             </div>
           }
         >
-          <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
-            <For each={pagedItems()}>
-              {(issue) => (
-                <div role="listitem">
-                  <ItemRow
-                    repo={issue.repoFullName}
-                    number={issue.number}
-                    title={issue.title}
-                    author={issue.userLogin}
-                    createdAt={issue.createdAt}
-                    url={issue.htmlUrl}
-                    labels={issue.labels}
-                    onIgnore={() => handleIgnore(issue)}
-                    density={config.viewDensity}
-                    commentCount={issue.comments}
+          <div class="divide-y divide-gray-100 dark:divide-gray-800">
+            <For each={paginatedResult().pageGroups}>
+              {(repoGroup) => (
+                <div class="bg-white dark:bg-gray-900">
+                  <button
+                    onClick={() => toggleRepo(repoGroup.repoFullName)}
+                    aria-expanded={!collapsedRepos().has(repoGroup.repoFullName)}
+                    class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   >
-                    <RoleBadge roles={issueMeta().get(issue.id)?.roles ?? []} />
-                  </ItemRow>
+                    <ChevronIcon size="md" rotated={collapsedRepos().has(repoGroup.repoFullName)} />
+                    {repoGroup.repoFullName}
+                  </button>
+                  <Show when={!collapsedRepos().has(repoGroup.repoFullName)}>
+                    <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
+                      <For each={repoGroup.items}>
+                        {(issue) => (
+                          <div role="listitem">
+                            <ItemRow
+                              hideRepo={true}
+                              repo={issue.repoFullName}
+                              number={issue.number}
+                              title={issue.title}
+                              author={issue.userLogin}
+                              createdAt={issue.createdAt}
+                              url={issue.htmlUrl}
+                              labels={issue.labels}
+                              onIgnore={() => handleIgnore(issue)}
+                              density={config.viewDensity}
+                              commentCount={issue.comments}
+                            >
+                              <RoleBadge roles={issueMeta().get(issue.id)?.roles ?? []} />
+                            </ItemRow>
+                          </div>
+                        )}
+                      </For>
+                    </div>
+                  </Show>
                 </div>
               )}
             </For>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
+import { createStore } from "solid-js/store";
 import { config } from "../../stores/config";
 import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, type IssueFilterField } from "../../stores/view";
 import type { Issue, ApiError } from "../../services/api";
@@ -89,18 +90,10 @@ function paginateGroups(
 
 export default function IssuesTab(props: IssuesTabProps) {
   const [page, setPage] = createSignal(0);
-  const [collapsedRepos, setCollapsedRepos] = createSignal<Set<string>>(new Set());
+  const [collapsedRepos, setCollapsedRepos] = createStore<Record<string, boolean>>({});
 
   function toggleRepo(repoFullName: string) {
-    setCollapsedRepos((prev) => {
-      const next = new Set(prev);
-      if (next.has(repoFullName)) {
-        next.delete(repoFullName);
-      } else {
-        next.add(repoFullName);
-      }
-      return next;
-    });
+    setCollapsedRepos(repoFullName, (v) => !v);
   }
 
   const sortPref = createMemo(() => {
@@ -295,13 +288,13 @@ export default function IssuesTab(props: IssuesTabProps) {
                 <div class="bg-white dark:bg-gray-900">
                   <button
                     onClick={() => toggleRepo(repoGroup.repoFullName)}
-                    aria-expanded={!collapsedRepos().has(repoGroup.repoFullName)}
+                    aria-expanded={!collapsedRepos[repoGroup.repoFullName]}
                     class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   >
-                    <ChevronIcon size="md" rotated={collapsedRepos().has(repoGroup.repoFullName)} />
+                    <ChevronIcon size="md" rotated={collapsedRepos[repoGroup.repoFullName]} />
                     {repoGroup.repoFullName}
                   </button>
-                  <Show when={!collapsedRepos().has(repoGroup.repoFullName)}>
+                  <Show when={!collapsedRepos[repoGroup.repoFullName]}>
                     <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
                       <For each={repoGroup.items}>
                         {(issue) => (

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 import { config } from "../../stores/config";
 import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, type IssueFilterField } from "../../stores/view";
@@ -179,6 +179,11 @@ export default function IssuesTab(props: IssuesTabProps) {
   const pageGroups = createMemo(() =>
     slicePageGroups(repoGroups(), pageLayout().boundaries, pageLayout().pageCount, page())
   );
+
+  createEffect(() => {
+    const max = pageCount() - 1;
+    if (page() > max) setPage(max);
+  });
 
   function handleSort(field: SortField) {
     const current = sortPref();

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -14,6 +14,7 @@ export interface ItemRowProps {
   onIgnore: () => void;
   density: "compact" | "comfortable";
   commentCount?: number;
+  hideRepo?: boolean;
 }
 
 export default function ItemRow(props: ItemRowProps) {
@@ -43,14 +44,16 @@ export default function ItemRow(props: ItemRowProps) {
         ${isCompact() ? "px-4 py-2" : "px-4 py-3"}`}
     >
       {/* Repo badge */}
-      <span
-        class={`shrink-0 inline-flex items-center rounded-full font-mono font-medium
-          bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200
-          ${isCompact() ? "text-xs px-2 py-0.5" : "text-xs px-2.5 py-1"}`}
-        title={props.repo}
-      >
-        {props.repo}
-      </span>
+      <Show when={!props.hideRepo}>
+        <span
+          class={`shrink-0 inline-flex items-center rounded-full font-mono font-medium
+            bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200
+            ${isCompact() ? "text-xs px-2 py-0.5" : "text-xs px-2.5 py-1"}`}
+          title={props.repo}
+        >
+          {props.repo}
+        </span>
+      </Show>
 
       {/* Main content */}
       <div class="flex-1 min-w-0">

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -123,29 +123,35 @@ function groupByRepo(items: PullRequest[]): PrRepoGroup[] {
   return groups;
 }
 
-function paginateGroups(
+function computePageLayout(
   groups: PrRepoGroup[],
-  page: number,
   approxPageSize: number,
-): { pageGroups: PrRepoGroup[]; pageCount: number } {
-  if (groups.length === 0) return { pageGroups: [], pageCount: 1 };
+): { boundaries: number[]; pageCount: number } {
+  if (groups.length === 0) return { boundaries: [0], pageCount: 1 };
 
-  const pageBoundaries: number[] = [0];
+  const boundaries: number[] = [0];
   let currentPageItems = 0;
   for (let i = 0; i < groups.length; i++) {
     if (currentPageItems > 0 && currentPageItems + groups[i].items.length > approxPageSize) {
-      pageBoundaries.push(i);
+      boundaries.push(i);
       currentPageItems = 0;
     }
     currentPageItems += groups[i].items.length;
   }
 
-  const pageCount = Math.max(1, pageBoundaries.length);
-  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
-  const start = pageBoundaries[clampedPage];
-  const end = clampedPage + 1 < pageBoundaries.length ? pageBoundaries[clampedPage + 1] : groups.length;
+  return { boundaries, pageCount: Math.max(1, boundaries.length) };
+}
 
-  return { pageGroups: groups.slice(start, end), pageCount };
+function slicePageGroups(
+  groups: PrRepoGroup[],
+  boundaries: number[],
+  pageCount: number,
+  page: number,
+): PrRepoGroup[] {
+  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
+  const start = boundaries[clampedPage];
+  const end = clampedPage + 1 < boundaries.length ? boundaries[clampedPage + 1] : groups.length;
+  return groups.slice(start, end);
 }
 
 export default function PullRequestsTab(props: PullRequestsTabProps) {
@@ -248,8 +254,11 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const pageSize = createMemo(() => config.itemsPerPage);
 
   const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
-  const paginatedResult = createMemo(() => paginateGroups(repoGroups(), page(), pageSize()));
-  const pageCount = () => paginatedResult().pageCount;
+  const pageLayout = createMemo(() => computePageLayout(repoGroups(), pageSize()));
+  const pageCount = () => pageLayout().pageCount;
+  const pageGroups = createMemo(() =>
+    slicePageGroups(repoGroups(), pageLayout().boundaries, pageLayout().pageCount, page())
+  );
 
   function handleSort(field: SortField) {
     const current = sortPref();
@@ -330,7 +339,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
       {/* PR rows */}
       <Show when={!props.loading || props.pullRequests.length > 0}>
         <Show
-          when={paginatedResult().pageGroups.length > 0}
+          when={pageGroups().length > 0}
           fallback={
             <div class="flex flex-col items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400">
               <svg
@@ -355,7 +364,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
           }
         >
           <div class="divide-y divide-gray-100 dark:divide-gray-800">
-            <For each={paginatedResult().pageGroups}>
+            <For each={pageGroups()}>
               {(repoGroup) => (
                 <div class="bg-white dark:bg-gray-900">
                   <button

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -15,6 +15,7 @@ import ReviewBadge from "../shared/ReviewBadge";
 import SizeBadge from "../shared/SizeBadge";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
+import ChevronIcon from "../shared/ChevronIcon";
 
 export interface PullRequestsTabProps {
   pullRequests: PullRequest[];
@@ -101,8 +102,66 @@ const prFilterGroups: FilterChipGroupDef[] = [
   },
 ];
 
+interface PrRepoGroup {
+  repoFullName: string;
+  items: PullRequest[];
+}
+
+function groupByRepo(items: PullRequest[]): PrRepoGroup[] {
+  const groups: PrRepoGroup[] = [];
+  const map = new Map<string, PrRepoGroup>();
+  for (const item of items) {
+    let group = map.get(item.repoFullName);
+    if (!group) {
+      group = { repoFullName: item.repoFullName, items: [] };
+      map.set(item.repoFullName, group);
+      groups.push(group);
+    }
+    group.items.push(item);
+  }
+  return groups;
+}
+
+function paginateGroups(
+  groups: PrRepoGroup[],
+  page: number,
+  approxPageSize: number,
+): { pageGroups: PrRepoGroup[]; pageCount: number } {
+  if (groups.length === 0) return { pageGroups: [], pageCount: 1 };
+
+  const pageBoundaries: number[] = [0];
+  let currentPageItems = 0;
+  for (let i = 0; i < groups.length; i++) {
+    if (currentPageItems > 0 && currentPageItems + groups[i].items.length > approxPageSize) {
+      pageBoundaries.push(i);
+      currentPageItems = 0;
+    }
+    currentPageItems += groups[i].items.length;
+  }
+
+  const pageCount = Math.max(1, pageBoundaries.length);
+  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
+  const start = pageBoundaries[clampedPage];
+  const end = clampedPage + 1 < pageBoundaries.length ? pageBoundaries[clampedPage + 1] : groups.length;
+
+  return { pageGroups: groups.slice(start, end), pageCount };
+}
+
 export default function PullRequestsTab(props: PullRequestsTabProps) {
   const [page, setPage] = createSignal(0);
+  const [collapsedRepos, setCollapsedRepos] = createSignal<Set<string>>(new Set());
+
+  function toggleRepo(repoFullName: string) {
+    setCollapsedRepos((prev) => {
+      const next = new Set(prev);
+      if (next.has(repoFullName)) {
+        next.delete(repoFullName);
+      } else {
+        next.add(repoFullName);
+      }
+      return next;
+    });
+  }
 
   const sortPref = createMemo(() => {
     const pref = viewState.sortPreferences["pullRequests"];
@@ -195,15 +254,9 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
 
   const pageSize = createMemo(() => config.itemsPerPage);
 
-  const pageCount = createMemo(() =>
-    Math.max(1, Math.ceil(filteredSorted().length / pageSize()))
-  );
-
-  const pagedItems = createMemo(() => {
-    const p = Math.min(page(), pageCount() - 1);
-    const start = p * pageSize();
-    return filteredSorted().slice(start, start + pageSize());
-  });
+  const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
+  const paginatedResult = createMemo(() => paginateGroups(repoGroups(), page(), pageSize()));
+  const pageCount = () => paginatedResult().pageCount;
 
   function handleSort(field: SortField) {
     const current = sortPref();
@@ -284,7 +337,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
       {/* PR rows */}
       <Show when={!props.loading || props.pullRequests.length > 0}>
         <Show
-          when={pagedItems().length > 0}
+          when={paginatedResult().pageGroups.length > 0}
           fallback={
             <div class="flex flex-col items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400">
               <svg
@@ -308,41 +361,60 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
             </div>
           }
         >
-          <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
-            <For each={pagedItems()}>
-              {(pr) => (
-                <div role="listitem">
-                  <ItemRow
-                    repo={pr.repoFullName}
-                    number={pr.number}
-                    title={pr.title}
-                    author={pr.userLogin}
-                    createdAt={pr.createdAt}
-                    url={pr.htmlUrl}
-                    labels={pr.labels}
-                    commentCount={pr.comments + pr.reviewComments}
-                    onIgnore={() => handleIgnore(pr)}
-                    density={config.viewDensity}
+          <div class="divide-y divide-gray-100 dark:divide-gray-800">
+            <For each={paginatedResult().pageGroups}>
+              {(repoGroup) => (
+                <div class="bg-white dark:bg-gray-900">
+                  <button
+                    onClick={() => toggleRepo(repoGroup.repoFullName)}
+                    aria-expanded={!collapsedRepos().has(repoGroup.repoFullName)}
+                    class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   >
-                    <div class="flex items-center gap-2 flex-wrap">
-                      <RoleBadge roles={prMeta().get(pr.id)?.roles ?? []} />
-                      <ReviewBadge decision={pr.reviewDecision} />
-                      <SizeBadge additions={pr.additions} deletions={pr.deletions} changedFiles={pr.changedFiles} category={prMeta().get(pr.id)?.sizeCategory} />
-                      <StatusDot status={pr.checkStatus} />
-                      <Show when={pr.draft}>
-                        <span class="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs px-2 py-0.5 font-medium">
-                          Draft
-                        </span>
-                      </Show>
-                      <Show when={pr.reviewerLogins.length > 0}>
-                        <span class="text-xs text-gray-500 dark:text-gray-400" title={pr.reviewerLogins.join(", ")}>
-                          Reviewers: {pr.reviewerLogins.slice(0, 5).join(", ")}
-                          {pr.reviewerLogins.length > 5 && ` +${pr.reviewerLogins.length - 5} more`}
-                          {pr.totalReviewCount > pr.reviewerLogins.length && ` (${pr.totalReviewCount} total)`}
-                        </span>
-                      </Show>
+                    <ChevronIcon size="md" rotated={collapsedRepos().has(repoGroup.repoFullName)} />
+                    {repoGroup.repoFullName}
+                  </button>
+                  <Show when={!collapsedRepos().has(repoGroup.repoFullName)}>
+                    <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
+                      <For each={repoGroup.items}>
+                        {(pr) => (
+                          <div role="listitem">
+                            <ItemRow
+                              hideRepo={true}
+                              repo={pr.repoFullName}
+                              number={pr.number}
+                              title={pr.title}
+                              author={pr.userLogin}
+                              createdAt={pr.createdAt}
+                              url={pr.htmlUrl}
+                              labels={pr.labels}
+                              commentCount={pr.comments + pr.reviewComments}
+                              onIgnore={() => handleIgnore(pr)}
+                              density={config.viewDensity}
+                            >
+                              <div class="flex items-center gap-2 flex-wrap">
+                                <RoleBadge roles={prMeta().get(pr.id)?.roles ?? []} />
+                                <ReviewBadge decision={pr.reviewDecision} />
+                                <SizeBadge additions={pr.additions} deletions={pr.deletions} changedFiles={pr.changedFiles} category={prMeta().get(pr.id)?.sizeCategory} />
+                                <StatusDot status={pr.checkStatus} />
+                                <Show when={pr.draft}>
+                                  <span class="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs px-2 py-0.5 font-medium">
+                                    Draft
+                                  </span>
+                                </Show>
+                                <Show when={pr.reviewerLogins.length > 0}>
+                                  <span class="text-xs text-gray-500 dark:text-gray-400" title={pr.reviewerLogins.join(", ")}>
+                                    Reviewers: {pr.reviewerLogins.slice(0, 5).join(", ")}
+                                    {pr.reviewerLogins.length > 5 && ` +${pr.reviewerLogins.length - 5} more`}
+                                    {pr.totalReviewCount > pr.reviewerLogins.length && ` (${pr.totalReviewCount} total)`}
+                                  </span>
+                                </Show>
+                              </div>
+                            </ItemRow>
+                          </div>
+                        )}
+                      </For>
                     </div>
-                  </ItemRow>
+                  </Show>
                 </div>
               )}
             </For>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -17,6 +17,7 @@ import SizeBadge from "../shared/SizeBadge";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
+import { groupByRepo, computePageLayout, slicePageGroups } from "../../lib/grouping";
 
 export interface PullRequestsTabProps {
   pullRequests: PullRequest[];
@@ -102,57 +103,6 @@ const prFilterGroups: FilterChipGroupDef[] = [
     ],
   },
 ];
-
-interface PrRepoGroup {
-  repoFullName: string;
-  items: PullRequest[];
-}
-
-function groupByRepo(items: PullRequest[]): PrRepoGroup[] {
-  const groups: PrRepoGroup[] = [];
-  const map = new Map<string, PrRepoGroup>();
-  for (const item of items) {
-    let group = map.get(item.repoFullName);
-    if (!group) {
-      group = { repoFullName: item.repoFullName, items: [] };
-      map.set(item.repoFullName, group);
-      groups.push(group);
-    }
-    group.items.push(item);
-  }
-  return groups;
-}
-
-function computePageLayout(
-  groups: PrRepoGroup[],
-  approxPageSize: number,
-): { boundaries: number[]; pageCount: number } {
-  if (groups.length === 0) return { boundaries: [0], pageCount: 1 };
-
-  const boundaries: number[] = [0];
-  let currentPageItems = 0;
-  for (let i = 0; i < groups.length; i++) {
-    if (currentPageItems > 0 && currentPageItems + groups[i].items.length > approxPageSize) {
-      boundaries.push(i);
-      currentPageItems = 0;
-    }
-    currentPageItems += groups[i].items.length;
-  }
-
-  return { boundaries, pageCount: Math.max(1, boundaries.length) };
-}
-
-function slicePageGroups(
-  groups: PrRepoGroup[],
-  boundaries: number[],
-  pageCount: number,
-  page: number,
-): PrRepoGroup[] {
-  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
-  const start = boundaries[clampedPage];
-  const end = clampedPage + 1 < boundaries.length ? boundaries[clampedPage + 1] : groups.length;
-  return groups.slice(start, end);
-}
 
 export default function PullRequestsTab(props: PullRequestsTabProps) {
   const [page, setPage] = createSignal(0);
@@ -251,13 +201,11 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
   const prMeta = createMemo(() => filteredSortedWithMeta().meta);
 
-  const pageSize = createMemo(() => config.itemsPerPage);
-
   const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
-  const pageLayout = createMemo(() => computePageLayout(repoGroups(), pageSize()));
-  const pageCount = () => pageLayout().pageCount;
+  const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
+  const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
-    slicePageGroups(repoGroups(), pageLayout().boundaries, pageLayout().pageCount, page())
+    slicePageGroups(repoGroups(), pageLayout().boundaries, pageCount(), page())
   );
 
   createEffect(() => {
@@ -330,9 +278,18 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
         <FilterChips
           groups={prFilterGroups}
           values={viewState.tabFilters.pullRequests}
-          onChange={(field, value) => { setTabFilter("pullRequests", field as PullRequestFilterField, value); setPage(0); }}
-          onReset={(field) => { resetTabFilter("pullRequests", field as PullRequestFilterField); setPage(0); }}
-          onResetAll={() => { resetAllTabFilters("pullRequests"); setPage(0); }}
+          onChange={(field, value) => {
+            setTabFilter("pullRequests", field as PullRequestFilterField, value);
+            setPage(0);
+          }}
+          onReset={(field) => {
+            resetTabFilter("pullRequests", field as PullRequestFilterField);
+            setPage(0);
+          }}
+          onResetAll={() => {
+            resetAllTabFilters("pullRequests");
+            setPage(0);
+          }}
         />
       </div>
 
@@ -370,60 +327,63 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
         >
           <div class="divide-y divide-gray-100 dark:divide-gray-800">
             <For each={pageGroups()}>
-              {(repoGroup) => (
-                <div class="bg-white dark:bg-gray-900">
-                  <button
-                    onClick={() => toggleRepo(repoGroup.repoFullName)}
-                    aria-expanded={!collapsedRepos[repoGroup.repoFullName]}
-                    class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                  >
-                    <ChevronIcon size="md" rotated={collapsedRepos[repoGroup.repoFullName]} />
-                    {repoGroup.repoFullName}
-                  </button>
-                  <Show when={!collapsedRepos[repoGroup.repoFullName]}>
-                    <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
-                      <For each={repoGroup.items}>
-                        {(pr) => (
-                          <div role="listitem">
-                            <ItemRow
-                              hideRepo={true}
-                              repo={pr.repoFullName}
-                              number={pr.number}
-                              title={pr.title}
-                              author={pr.userLogin}
-                              createdAt={pr.createdAt}
-                              url={pr.htmlUrl}
-                              labels={pr.labels}
-                              commentCount={pr.comments + pr.reviewComments}
-                              onIgnore={() => handleIgnore(pr)}
-                              density={config.viewDensity}
-                            >
-                              <div class="flex items-center gap-2 flex-wrap">
-                                <RoleBadge roles={prMeta().get(pr.id)?.roles ?? []} />
-                                <ReviewBadge decision={pr.reviewDecision} />
-                                <SizeBadge additions={pr.additions} deletions={pr.deletions} changedFiles={pr.changedFiles} category={prMeta().get(pr.id)?.sizeCategory} />
-                                <StatusDot status={pr.checkStatus} />
-                                <Show when={pr.draft}>
-                                  <span class="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs px-2 py-0.5 font-medium">
-                                    Draft
-                                  </span>
-                                </Show>
-                                <Show when={pr.reviewerLogins.length > 0}>
-                                  <span class="text-xs text-gray-500 dark:text-gray-400" title={pr.reviewerLogins.join(", ")}>
-                                    Reviewers: {pr.reviewerLogins.slice(0, 5).join(", ")}
-                                    {pr.reviewerLogins.length > 5 && ` +${pr.reviewerLogins.length - 5} more`}
-                                    {pr.totalReviewCount > pr.reviewerLogins.length && ` (${pr.totalReviewCount} total)`}
-                                  </span>
-                                </Show>
-                              </div>
-                            </ItemRow>
-                          </div>
-                        )}
-                      </For>
-                    </div>
-                  </Show>
-                </div>
-              )}
+              {(repoGroup) => {
+                const isRepoCollapsed = () => collapsedRepos[repoGroup.repoFullName];
+                return (
+                  <div class="bg-white dark:bg-gray-900">
+                    <button
+                      onClick={() => toggleRepo(repoGroup.repoFullName)}
+                      aria-expanded={!isRepoCollapsed()}
+                      class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                    >
+                      <ChevronIcon size="md" rotated={isRepoCollapsed()} />
+                      {repoGroup.repoFullName}
+                    </button>
+                    <Show when={!isRepoCollapsed()}>
+                      <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
+                        <For each={repoGroup.items}>
+                          {(pr) => (
+                            <div role="listitem">
+                              <ItemRow
+                                hideRepo={true}
+                                repo={pr.repoFullName}
+                                number={pr.number}
+                                title={pr.title}
+                                author={pr.userLogin}
+                                createdAt={pr.createdAt}
+                                url={pr.htmlUrl}
+                                labels={pr.labels}
+                                commentCount={pr.comments + pr.reviewComments}
+                                onIgnore={() => handleIgnore(pr)}
+                                density={config.viewDensity}
+                              >
+                                <div class="flex items-center gap-2 flex-wrap">
+                                  <RoleBadge roles={prMeta().get(pr.id)?.roles ?? []} />
+                                  <ReviewBadge decision={pr.reviewDecision} />
+                                  <SizeBadge additions={pr.additions} deletions={pr.deletions} changedFiles={pr.changedFiles} category={prMeta().get(pr.id)?.sizeCategory} />
+                                  <StatusDot status={pr.checkStatus} />
+                                  <Show when={pr.draft}>
+                                    <span class="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs px-2 py-0.5 font-medium">
+                                      Draft
+                                    </span>
+                                  </Show>
+                                  <Show when={pr.reviewerLogins.length > 0}>
+                                    <span class="text-xs text-gray-500 dark:text-gray-400" title={pr.reviewerLogins.join(", ")}>
+                                      Reviewers: {pr.reviewerLogins.slice(0, 5).join(", ")}
+                                      {pr.reviewerLogins.length > 5 && ` +${pr.reviewerLogins.length - 5} more`}
+                                      {pr.totalReviewCount > pr.reviewerLogins.length && ` (${pr.totalReviewCount} total)`}
+                                    </span>
+                                  </Show>
+                                </div>
+                              </ItemRow>
+                            </div>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
+                  </div>
+                );
+              }}
             </For>
           </div>
         </Show>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
+import { createStore } from "solid-js/store";
 import { config } from "../../stores/config";
 import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, type PullRequestFilterField } from "../../stores/view";
 import type { PullRequest, ApiError } from "../../services/api";
@@ -149,18 +150,10 @@ function paginateGroups(
 
 export default function PullRequestsTab(props: PullRequestsTabProps) {
   const [page, setPage] = createSignal(0);
-  const [collapsedRepos, setCollapsedRepos] = createSignal<Set<string>>(new Set());
+  const [collapsedRepos, setCollapsedRepos] = createStore<Record<string, boolean>>({});
 
   function toggleRepo(repoFullName: string) {
-    setCollapsedRepos((prev) => {
-      const next = new Set(prev);
-      if (next.has(repoFullName)) {
-        next.delete(repoFullName);
-      } else {
-        next.add(repoFullName);
-      }
-      return next;
-    });
+    setCollapsedRepos(repoFullName, (v) => !v);
   }
 
   const sortPref = createMemo(() => {
@@ -367,13 +360,13 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                 <div class="bg-white dark:bg-gray-900">
                   <button
                     onClick={() => toggleRepo(repoGroup.repoFullName)}
-                    aria-expanded={!collapsedRepos().has(repoGroup.repoFullName)}
+                    aria-expanded={!collapsedRepos[repoGroup.repoFullName]}
                     class="w-full flex items-center gap-2 px-4 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   >
-                    <ChevronIcon size="md" rotated={collapsedRepos().has(repoGroup.repoFullName)} />
+                    <ChevronIcon size="md" rotated={collapsedRepos[repoGroup.repoFullName]} />
                     {repoGroup.repoFullName}
                   </button>
-                  <Show when={!collapsedRepos().has(repoGroup.repoFullName)}>
+                  <Show when={!collapsedRepos[repoGroup.repoFullName]}>
                     <div role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
                       <For each={repoGroup.items}>
                         {(pr) => (

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 import { config } from "../../stores/config";
 import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, type PullRequestFilterField } from "../../stores/view";
@@ -259,6 +259,11 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const pageGroups = createMemo(() =>
     slicePageGroups(repoGroups(), pageLayout().boundaries, pageLayout().pageCount, page())
   );
+
+  createEffect(() => {
+    const max = pageCount() - 1;
+    if (page() > max) setPage(max);
+  });
 
   function handleSort(field: SortField) {
     const current = sortPref();

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -242,8 +242,8 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     return { items, meta };
   });
 
-  const filteredSorted = () => filteredSortedWithMeta().items;
-  const prMeta = () => filteredSortedWithMeta().meta;
+  const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
+  const prMeta = createMemo(() => filteredSortedWithMeta().meta);
 
   const pageSize = createMemo(() => config.itemsPerPage);
 

--- a/src/app/components/shared/ChevronIcon.tsx
+++ b/src/app/components/shared/ChevronIcon.tsx
@@ -1,0 +1,18 @@
+export default function ChevronIcon(props: { size: "sm" | "md"; rotated: boolean }) {
+  const sizeClass = () => (props.size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5");
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class={`${sizeClass()} text-gray-400 transition-transform ${props.rotated ? "-rotate-90" : ""}`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/src/app/components/shared/ChevronIcon.tsx
+++ b/src/app/components/shared/ChevronIcon.tsx
@@ -1,7 +1,5 @@
-import { createMemo } from "solid-js";
-
 export default function ChevronIcon(props: { size: "sm" | "md"; rotated: boolean }) {
-  const sizeClass = createMemo(() => (props.size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5"));
+  const sizeClass = () => (props.size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5");
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/app/components/shared/ChevronIcon.tsx
+++ b/src/app/components/shared/ChevronIcon.tsx
@@ -1,5 +1,7 @@
+import { createMemo } from "solid-js";
+
 export default function ChevronIcon(props: { size: "sm" | "md"; rotated: boolean }) {
-  const sizeClass = () => (props.size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5");
+  const sizeClass = createMemo(() => (props.size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5"));
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/app/lib/grouping.ts
+++ b/src/app/lib/grouping.ts
@@ -1,0 +1,50 @@
+export interface RepoGroup<T> {
+  repoFullName: string;
+  items: T[];
+}
+
+export function groupByRepo<T extends { repoFullName: string }>(items: T[]): RepoGroup<T>[] {
+  const groups: RepoGroup<T>[] = [];
+  const map = new Map<string, RepoGroup<T>>();
+  for (const item of items) {
+    let group = map.get(item.repoFullName);
+    if (!group) {
+      group = { repoFullName: item.repoFullName, items: [] };
+      map.set(item.repoFullName, group);
+      groups.push(group);
+    }
+    group.items.push(item);
+  }
+  return groups;
+}
+
+export function computePageLayout<T>(
+  groups: RepoGroup<T>[],
+  approxPageSize: number,
+): { boundaries: number[]; pageCount: number } {
+  if (groups.length === 0) return { boundaries: [0], pageCount: 1 };
+
+  const boundaries: number[] = [0];
+  let currentPageItems = 0;
+  for (let i = 0; i < groups.length; i++) {
+    if (currentPageItems > 0 && currentPageItems + groups[i].items.length > approxPageSize) {
+      boundaries.push(i);
+      currentPageItems = 0;
+    }
+    currentPageItems += groups[i].items.length;
+  }
+
+  return { boundaries, pageCount: Math.max(1, boundaries.length) };
+}
+
+export function slicePageGroups<T>(
+  groups: RepoGroup<T>[],
+  boundaries: number[],
+  pageCount: number,
+  page: number,
+): RepoGroup<T>[] {
+  const clampedPage = Math.max(0, Math.min(page, pageCount - 1));
+  const start = boundaries[clampedPage];
+  const end = clampedPage + 1 < boundaries.length ? boundaries[clampedPage + 1] : groups.length;
+  return groups.slice(start, end);
+}

--- a/tests/components/ActionsTab.test.tsx
+++ b/tests/components/ActionsTab.test.tsx
@@ -192,4 +192,62 @@ describe("ActionsTab", () => {
     screen.getByText("push-run");
     expect(screen.queryByText("schedule-run")).toBeNull();
   });
+
+  it("sets aria-expanded on repo group header", () => {
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "CI" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+    const repoHeader = screen.getByText("owner/repo").closest("button")!;
+    expect(repoHeader.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("toggles repo aria-expanded on click", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "CI" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+    const repoHeader = screen.getByText("owner/repo").closest("button")!;
+    expect(repoHeader.getAttribute("aria-expanded")).toBe("true");
+
+    await user.click(repoHeader);
+    expect(repoHeader.getAttribute("aria-expanded")).toBe("false");
+
+    await user.click(repoHeader);
+    expect(repoHeader.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("sets aria-expanded on workflow group header", () => {
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "MyWorkflow" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+    const buttons = screen.getAllByRole("button");
+    const wfHeader = buttons.find(
+      (b) => b.textContent?.includes("MyWorkflow") && !b.textContent?.includes("owner/repo")
+    )!;
+    expect(wfHeader.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("toggles workflow aria-expanded on click", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "MyWorkflow", displayTitle: "wf-run" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+    const buttons = screen.getAllByRole("button");
+    const wfHeader = buttons.find(
+      (b) => b.textContent?.includes("MyWorkflow") && !b.textContent?.includes("owner/repo")
+    )!;
+    expect(wfHeader.getAttribute("aria-expanded")).toBe("true");
+
+    await user.click(wfHeader);
+    expect(wfHeader.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("wf-run")).toBeNull();
+
+    await user.click(wfHeader);
+    expect(wfHeader.getAttribute("aria-expanded")).toBe("true");
+    screen.getByText("wf-run");
+  });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -267,6 +267,36 @@ describe("IssuesTab", () => {
     screen.getByText(/Page 2 of 2/);
   });
 
+  it("preserves collapse state across filter changes", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Alice issue", repoFullName: "org/repo-a", userLogin: "alice" }),
+      makeIssue({ id: 2, title: "Bob issue", repoFullName: "org/repo-b", userLogin: "bob" }),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="alice" />);
+
+    // Collapse repo-a
+    const repoHeader = screen.getByText("org/repo-a").closest("button")!;
+    await user.click(repoHeader);
+    expect(screen.queryByText("Alice issue")).toBeNull();
+    expect(repoHeader.getAttribute("aria-expanded")).toBe("false");
+
+    // Apply role filter that keeps only alice's issue (repo-a)
+    viewStore.setTabFilter("issues", "role", "author");
+    // repo-a still visible (collapsed), repo-b filtered out
+    screen.getByText("org/repo-a");
+    expect(screen.queryByText("org/repo-b")).toBeNull();
+    // Items still hidden because collapse state persists
+    expect(screen.queryByText("Alice issue")).toBeNull();
+
+    // Clear filter — repo-b reappears, repo-a stays collapsed
+    viewStore.resetTabFilter("issues", "role");
+    screen.getByText("org/repo-a");
+    screen.getByText("org/repo-b");
+    expect(screen.queryByText("Alice issue")).toBeNull();
+    screen.getByText("Bob issue");
+  });
+
   it("keeps a large single-repo group on one page without splitting", () => {
     updateConfig({ itemsPerPage: 10 });
     const issues = Array.from({ length: 15 }, (_, i) =>

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -5,9 +5,11 @@ import IssuesTab from "../../src/app/components/dashboard/IssuesTab";
 import type { ApiError } from "../../src/app/services/api";
 import { makeIssue, resetViewStore } from "../helpers/index";
 import * as viewStore from "../../src/app/stores/view";
+import { updateConfig, resetConfig } from "../../src/app/stores/config";
 
 beforeEach(() => {
   resetViewStore();
+  resetConfig();
 });
 
 describe("IssuesTab", () => {
@@ -222,5 +224,60 @@ describe("IssuesTab", () => {
     render(() => <IssuesTab issues={issues} userLogin="" />);
     const header = screen.getByText("org/repo-a").closest("button")!;
     expect(header.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("toggles aria-expanded to false on collapse and back to true on re-expand", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Toggle issue", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    const header = screen.getByText("org/repo-a").closest("button")!;
+
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    await user.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Toggle issue")).toBeNull();
+
+    await user.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    screen.getByText("Toggle issue");
+  });
+
+  it("paginates repo groups across pages", async () => {
+    const user = userEvent.setup();
+    updateConfig({ itemsPerPage: 10 });
+    const issues = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeIssue({ id: 100 + i, title: `Repo A issue ${i}`, repoFullName: "org/repo-a" })
+      ),
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeIssue({ id: 200 + i, title: `Repo B issue ${i}`, repoFullName: "org/repo-b" })
+      ),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    // Page 1: repo-a (6 items), Page 2: repo-b (6 items) — 12 total > pageSize 10
+    screen.getByText("org/repo-a");
+    screen.getByText(/Page 1 of 2/);
+    expect(screen.queryByText("org/repo-b")).toBeNull();
+
+    const nextBtn = screen.getByLabelText("Next page");
+    await user.click(nextBtn);
+    screen.getByText("org/repo-b");
+    screen.getByText(/Page 2 of 2/);
+  });
+
+  it("keeps a large single-repo group on one page without splitting", () => {
+    updateConfig({ itemsPerPage: 10 });
+    const issues = Array.from({ length: 15 }, (_, i) =>
+      makeIssue({ id: 300 + i, title: `Big repo issue ${i}`, repoFullName: "org/big-repo" })
+    );
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    // All 15 items in one group — whole-groups-only pagination keeps them together
+    screen.getByText("org/big-repo");
+    screen.getByText("Big repo issue 0");
+    screen.getByText("Big repo issue 14");
+    // No pagination controls (single page with oversized group)
+    expect(screen.queryByLabelText("Next page")).toBeNull();
   });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -184,4 +184,43 @@ describe("IssuesTab", () => {
     render(() => <IssuesTab issues={[]} userLogin="" />);
     screen.getByLabelText("Sort by Comments");
   });
+
+  it("groups issues by repo with collapsible headers", () => {
+    const issues = [
+      makeIssue({ id: 1, title: "Issue in repo A", repoFullName: "org/repo-a" }),
+      makeIssue({ id: 2, title: "Issue in repo B", repoFullName: "org/repo-b" }),
+      makeIssue({ id: 3, title: "Another in repo A", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    screen.getByText("org/repo-a");
+    screen.getByText("org/repo-b");
+    screen.getByText("Issue in repo A");
+    screen.getByText("Another in repo A");
+    screen.getByText("Issue in repo B");
+  });
+
+  it("collapses a repo group when header is clicked", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Visible issue", repoFullName: "org/repo-a" }),
+      makeIssue({ id: 2, title: "Other repo issue", repoFullName: "org/repo-b" }),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    screen.getByText("Visible issue");
+
+    const repoHeader = screen.getByText("org/repo-a");
+    await user.click(repoHeader);
+
+    expect(screen.queryByText("Visible issue")).toBeNull();
+    screen.getByText("Other repo issue");
+  });
+
+  it("sets aria-expanded on repo group headers", () => {
+    const issues = [
+      makeIssue({ id: 1, title: "Test issue", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    const header = screen.getByText("org/repo-a").closest("button")!;
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+  });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -82,7 +82,7 @@ describe("IssuesTab", () => {
   it("filters by globalFilter.org", () => {
     const issues = [
       makeIssue({ number: 1, title: "In org", repoFullName: "myorg/repo-a" }),
-      makeIssue({ number: 2, title: "Outside org", repoFullName: "otherorge/repo-b" }),
+      makeIssue({ number: 2, title: "Outside org", repoFullName: "otherorg/repo-b" }),
     ];
     viewStore.setGlobalFilter("myorg", null);
     render(() => <IssuesTab issues={issues} userLogin="" />);
@@ -118,19 +118,16 @@ describe("IssuesTab", () => {
 
   it("toggles sort direction on second click of same column", async () => {
     const user = userEvent.setup();
-    const setSortSpy = vi.spyOn(viewStore, "setSortPreference");
     const issues = [makeIssue({ title: "Issue A" })];
     render(() => <IssuesTab issues={issues} userLogin="" />);
 
     const titleHeader = screen.getByLabelText(/Sort by Title/i);
-    // First click: sets desc
+    // First click: title was not active, so sets desc
     await user.click(titleHeader);
-    // Simulate sort pref being updated to title/desc (spy already called)
-    // Second click should toggle to asc
+    expect(viewStore.viewState.sortPreferences["issues"]).toEqual({ field: "title", direction: "desc" });
+    // Second click on same column: toggles to asc
     await user.click(titleHeader);
-
-    expect(setSortSpy).toHaveBeenCalledTimes(2);
-    setSortSpy.mockRestore();
+    expect(viewStore.viewState.sortPreferences["issues"]).toEqual({ field: "title", direction: "asc" });
   });
 
   it("does not show pagination when there is only one page", () => {

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
 import IssuesTab from "../../src/app/components/dashboard/IssuesTab";
-import type { ApiError } from "../../src/app/services/api";
+import type { Issue, ApiError } from "../../src/app/services/api";
 import { makeIssue, resetViewStore } from "../helpers/index";
 import * as viewStore from "../../src/app/stores/view";
 import { updateConfig, resetConfig } from "../../src/app/stores/config";
@@ -292,6 +293,31 @@ describe("IssuesTab", () => {
     screen.getByText("org/repo-b");
     expect(screen.queryByText("Alice issue")).toBeNull();
     screen.getByText("Bob issue");
+  });
+
+  it("resets page when data shrinks below current page", async () => {
+    const user = userEvent.setup();
+    updateConfig({ itemsPerPage: 10 });
+    const repoAIssues = Array.from({ length: 6 }, (_, i) =>
+      makeIssue({ id: 100 + i, title: `Repo A issue ${i}`, repoFullName: "org/repo-a" })
+    );
+    const repoBIssues = Array.from({ length: 6 }, (_, i) =>
+      makeIssue({ id: 200 + i, title: `Repo B issue ${i}`, repoFullName: "org/repo-b" })
+    );
+    const [issues, setIssues] = createSignal<Issue[]>([...repoAIssues, ...repoBIssues]);
+    render(() => <IssuesTab issues={issues()} userLogin="" />);
+
+    // Navigate to page 2
+    screen.getByText(/Page 1 of 2/);
+    await user.click(screen.getByLabelText("Next page"));
+    screen.getByText(/Page 2 of 2/);
+    screen.getByText("org/repo-b");
+
+    // Shrink data to fit on 1 page — page should reset
+    setIssues(repoAIssues);
+    expect(screen.queryByLabelText("Next page")).toBeNull();
+    screen.getByText("org/repo-a");
+    screen.getByText("Repo A issue 0");
   });
 
   it("keeps a large single-repo group on one page without splitting", () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -120,4 +120,15 @@ describe("ItemRow", () => {
     render(() => <ItemRow {...defaultProps} labels={[]} />);
     expect(screen.queryByText("bug")).toBeNull();
   });
+
+  it("hides repo badge when hideRepo is true", () => {
+    render(() => <ItemRow {...defaultProps} hideRepo={true} />);
+    expect(screen.queryByText("octocat/Hello-World")).toBeNull();
+    screen.getByText("Fix a bug");
+  });
+
+  it("shows repo badge when hideRepo is false", () => {
+    render(() => <ItemRow {...defaultProps} hideRepo={false} />);
+    screen.getByText("octocat/Hello-World");
+  });
 });

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
 import PullRequestsTab from "../../src/app/components/dashboard/PullRequestsTab";
-import type { ApiError } from "../../src/app/services/api";
+import type { PullRequest, ApiError } from "../../src/app/services/api";
 import * as viewStore from "../../src/app/stores/view";
 import { makePullRequest, resetViewStore } from "../helpers/index";
 import { updateConfig, resetConfig } from "../../src/app/stores/config";
@@ -354,5 +355,30 @@ describe("PullRequestsTab", () => {
     screen.getByText("Big repo PR 0");
     screen.getByText("Big repo PR 14");
     expect(screen.queryByLabelText("Next page")).toBeNull();
+  });
+
+  it("resets page when data shrinks below current page", async () => {
+    const user = userEvent.setup();
+    updateConfig({ itemsPerPage: 10 });
+    const repoAPrs = Array.from({ length: 6 }, (_, i) =>
+      makePullRequest({ id: 100 + i, title: `Repo A PR ${i}`, repoFullName: "org/repo-a" })
+    );
+    const repoBPrs = Array.from({ length: 6 }, (_, i) =>
+      makePullRequest({ id: 200 + i, title: `Repo B PR ${i}`, repoFullName: "org/repo-b" })
+    );
+    const [prs, setPrs] = createSignal<PullRequest[]>([...repoAPrs, ...repoBPrs]);
+    render(() => <PullRequestsTab pullRequests={prs()} userLogin="" />);
+
+    // Navigate to page 2
+    screen.getByText(/Page 1 of 2/);
+    await user.click(screen.getByLabelText("Next page"));
+    screen.getByText(/Page 2 of 2/);
+    screen.getByText("org/repo-b");
+
+    // Shrink data to fit on 1 page — page should reset
+    setPrs(repoAPrs);
+    expect(screen.queryByLabelText("Next page")).toBeNull();
+    screen.getByText("org/repo-a");
+    screen.getByText("Repo A PR 0");
   });
 });

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -5,9 +5,11 @@ import PullRequestsTab from "../../src/app/components/dashboard/PullRequestsTab"
 import type { ApiError } from "../../src/app/services/api";
 import * as viewStore from "../../src/app/stores/view";
 import { makePullRequest, resetViewStore } from "../helpers/index";
+import { updateConfig, resetConfig } from "../../src/app/stores/config";
 
 beforeEach(() => {
   resetViewStore();
+  resetConfig();
 });
 
 describe("PullRequestsTab", () => {
@@ -301,5 +303,57 @@ describe("PullRequestsTab", () => {
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     const header = screen.getByText("org/repo-a").closest("button")!;
     expect(header.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("toggles aria-expanded to false on collapse and back to true on re-expand", async () => {
+    const user = userEvent.setup();
+    const prs = [
+      makePullRequest({ id: 1, title: "Toggle PR", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    const header = screen.getByText("org/repo-a").closest("button")!;
+
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    await user.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Toggle PR")).toBeNull();
+
+    await user.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    screen.getByText("Toggle PR");
+  });
+
+  it("paginates repo groups across pages", async () => {
+    const user = userEvent.setup();
+    updateConfig({ itemsPerPage: 10 });
+    const prs = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        makePullRequest({ id: 100 + i, title: `Repo A PR ${i}`, repoFullName: "org/repo-a" })
+      ),
+      ...Array.from({ length: 6 }, (_, i) =>
+        makePullRequest({ id: 200 + i, title: `Repo B PR ${i}`, repoFullName: "org/repo-b" })
+      ),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    screen.getByText("org/repo-a");
+    screen.getByText(/Page 1 of 2/);
+    expect(screen.queryByText("org/repo-b")).toBeNull();
+
+    const nextBtn = screen.getByLabelText("Next page");
+    await user.click(nextBtn);
+    screen.getByText("org/repo-b");
+    screen.getByText(/Page 2 of 2/);
+  });
+
+  it("keeps a large single-repo group on one page without splitting", () => {
+    updateConfig({ itemsPerPage: 10 });
+    const prs = Array.from({ length: 15 }, (_, i) =>
+      makePullRequest({ id: 300 + i, title: `Big repo PR ${i}`, repoFullName: "org/big-repo" })
+    );
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    screen.getByText("org/big-repo");
+    screen.getByText("Big repo PR 0");
+    screen.getByText("Big repo PR 14");
+    expect(screen.queryByLabelText("Next page")).toBeNull();
   });
 });

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -81,7 +81,7 @@ describe("PullRequestsTab", () => {
   it("filters by globalFilter.org", () => {
     const prs = [
       makePullRequest({ number: 1, title: "In org", repoFullName: "myorg/repo-a" }),
-      makePullRequest({ number: 2, title: "Outside org", repoFullName: "otherorge/repo-b" }),
+      makePullRequest({ number: 2, title: "Outside org", repoFullName: "otherorg/repo-b" }),
     ];
     viewStore.setGlobalFilter("myorg", null);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
@@ -208,7 +208,6 @@ describe("PullRequestsTab", () => {
     render(() => <PullRequestsTab pullRequests={prs} userLogin="alice" />);
     screen.getByText("My PR");
     expect(screen.queryByText("Other PR")).toBeNull();
-    viewStore.resetTabFilter("pullRequests", "role");
   });
 
   it("filters by reviewDecision tab filter", () => {

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -263,4 +263,43 @@ describe("PullRequestsTab", () => {
     screen.getByText("Small PR");
     expect(screen.queryByText("Large PR")).toBeNull();
   });
+
+  it("groups PRs by repo with collapsible headers", () => {
+    const prs = [
+      makePullRequest({ id: 1, title: "PR in repo A", repoFullName: "org/repo-a" }),
+      makePullRequest({ id: 2, title: "PR in repo B", repoFullName: "org/repo-b" }),
+      makePullRequest({ id: 3, title: "Another in repo A", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    screen.getByText("org/repo-a");
+    screen.getByText("org/repo-b");
+    screen.getByText("PR in repo A");
+    screen.getByText("Another in repo A");
+    screen.getByText("PR in repo B");
+  });
+
+  it("collapses a repo group when header is clicked", async () => {
+    const user = userEvent.setup();
+    const prs = [
+      makePullRequest({ id: 1, title: "Visible PR", repoFullName: "org/repo-a" }),
+      makePullRequest({ id: 2, title: "Other repo PR", repoFullName: "org/repo-b" }),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    screen.getByText("Visible PR");
+
+    const repoHeader = screen.getByText("org/repo-a");
+    await user.click(repoHeader);
+
+    expect(screen.queryByText("Visible PR")).toBeNull();
+    screen.getByText("Other repo PR");
+  });
+
+  it("sets aria-expanded on repo group headers", () => {
+    const prs = [
+      makePullRequest({ id: 1, title: "Test PR", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    const header = screen.getByText("org/repo-a").closest("button")!;
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+  });
 });

--- a/tests/lib/grouping.test.ts
+++ b/tests/lib/grouping.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { groupByRepo, computePageLayout, slicePageGroups, type RepoGroup } from "../../src/app/lib/grouping";
+
+interface Item {
+  repoFullName: string;
+  id: number;
+}
+
+function makeItem(repo: string, id: number): Item {
+  return { repoFullName: repo, id };
+}
+
+function makeGroup(repo: string, count: number): RepoGroup<Item> {
+  return {
+    repoFullName: repo,
+    items: Array.from({ length: count }, (_, i) => makeItem(repo, i)),
+  };
+}
+
+describe("groupByRepo", () => {
+  it("groups items by repoFullName preserving insertion order", () => {
+    const items = [
+      makeItem("org/a", 1),
+      makeItem("org/b", 2),
+      makeItem("org/a", 3),
+    ];
+    const groups = groupByRepo(items);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].repoFullName).toBe("org/a");
+    expect(groups[0].items).toHaveLength(2);
+    expect(groups[1].repoFullName).toBe("org/b");
+    expect(groups[1].items).toHaveLength(1);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupByRepo([])).toEqual([]);
+  });
+
+  it("returns single group when all items share a repo", () => {
+    const items = [makeItem("org/repo", 1), makeItem("org/repo", 2)];
+    const groups = groupByRepo(items);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items).toHaveLength(2);
+  });
+});
+
+describe("computePageLayout", () => {
+  it("returns single page for empty groups", () => {
+    const result = computePageLayout([], 10);
+    expect(result).toEqual({ boundaries: [0], pageCount: 1 });
+  });
+
+  it("keeps all groups on one page when total items <= pageSize", () => {
+    const groups = [makeGroup("org/a", 3), makeGroup("org/b", 4)];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0], pageCount: 1 });
+  });
+
+  it("splits groups across pages when total exceeds pageSize", () => {
+    const groups = [makeGroup("org/a", 6), makeGroup("org/b", 6)];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0, 1], pageCount: 2 });
+  });
+
+  it("does not split a single oversized group", () => {
+    const groups = [makeGroup("org/big", 20)];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0], pageCount: 1 });
+  });
+
+  it("keeps groups exactly at pageSize on one page", () => {
+    const groups = [makeGroup("org/a", 5), makeGroup("org/b", 5)];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0], pageCount: 1 });
+  });
+
+  it("splits when adding next group exceeds pageSize", () => {
+    const groups = [makeGroup("org/a", 5), makeGroup("org/b", 6)];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0, 1], pageCount: 2 });
+  });
+
+  it("handles three pages", () => {
+    const groups = [
+      makeGroup("org/a", 6),
+      makeGroup("org/b", 6),
+      makeGroup("org/c", 6),
+    ];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0, 1, 2], pageCount: 3 });
+  });
+
+  it("packs multiple small groups onto one page", () => {
+    const groups = [
+      makeGroup("org/a", 2),
+      makeGroup("org/b", 3),
+      makeGroup("org/c", 4),
+    ];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0], pageCount: 1 });
+  });
+
+  it("splits when small groups accumulate past pageSize", () => {
+    const groups = [
+      makeGroup("org/a", 4),
+      makeGroup("org/b", 4),
+      makeGroup("org/c", 4),
+    ];
+    const result = computePageLayout(groups, 10);
+    expect(result).toEqual({ boundaries: [0, 2], pageCount: 2 });
+  });
+});
+
+describe("slicePageGroups", () => {
+  const groups = [
+    makeGroup("org/a", 6),
+    makeGroup("org/b", 6),
+    makeGroup("org/c", 6),
+  ];
+  const boundaries = [0, 1, 2];
+  const pageCount = 3;
+
+  it("returns first page groups", () => {
+    const result = slicePageGroups(groups, boundaries, pageCount, 0);
+    expect(result).toHaveLength(1);
+    expect(result[0].repoFullName).toBe("org/a");
+  });
+
+  it("returns middle page groups", () => {
+    const result = slicePageGroups(groups, boundaries, pageCount, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].repoFullName).toBe("org/b");
+  });
+
+  it("returns last page groups", () => {
+    const result = slicePageGroups(groups, boundaries, pageCount, 2);
+    expect(result).toHaveLength(1);
+    expect(result[0].repoFullName).toBe("org/c");
+  });
+
+  it("clamps page below zero", () => {
+    const result = slicePageGroups(groups, boundaries, pageCount, -1);
+    expect(result).toHaveLength(1);
+    expect(result[0].repoFullName).toBe("org/a");
+  });
+
+  it("clamps page above max", () => {
+    const result = slicePageGroups(groups, boundaries, pageCount, 99);
+    expect(result).toHaveLength(1);
+    expect(result[0].repoFullName).toBe("org/c");
+  });
+
+  it("returns all groups when single page", () => {
+    const singleBoundaries = [0];
+    const result = slicePageGroups(groups, singleBoundaries, 1, 0);
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns multiple groups packed on one page", () => {
+    // boundaries [0, 2] means page 0 has groups 0-1, page 1 has group 2
+    const result = slicePageGroups(groups, [0, 2], 2, 0);
+    expect(result).toHaveLength(2);
+    expect(result[0].repoFullName).toBe("org/a");
+    expect(result[1].repoFullName).toBe("org/b");
+  });
+});

--- a/tests/services/api.test.ts
+++ b/tests/services/api.test.ts
@@ -715,6 +715,41 @@ describe("fetchWorkflowRuns", () => {
     });
   });
 
+  it("sorts workflows by most recent activity descending", async () => {
+    const octokit = makeOctokitForRuns();
+
+    const { workflowRuns } = await fetchWorkflowRuns(
+      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      [testRepo],
+      5,
+      10
+    );
+
+    // CI workflow (id 1001) has latestAt 2024-01-15T10:05 (from run 9002)
+    // Deploy workflow (id 1002) has latestAt 2024-01-15T09:25 (from run 9004)
+    // CI should appear first (more recent)
+    const firstCiIndex = workflowRuns.findIndex((r) => r.workflowId === 1001);
+    const firstDeployIndex = workflowRuns.findIndex((r) => r.workflowId === 1002);
+    expect(firstCiIndex).toBeLessThan(firstDeployIndex);
+  });
+
+  it("sorts runs within a workflow by created_at descending", async () => {
+    const octokit = makeOctokitForRuns();
+
+    const { workflowRuns } = await fetchWorkflowRuns(
+      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      [testRepo],
+      5,
+      10
+    );
+
+    // CI runs: 9002 (10:00), 9001 (09:00), 9003 (Jan 14 15:00) — descending by created_at
+    const ciRuns = workflowRuns.filter((r) => r.workflowId === 1001);
+    expect(ciRuns[0].id).toBe(9002);
+    expect(ciRuns[1].id).toBe(9001);
+    expect(ciRuns[2].id).toBe(9003);
+  });
+
   it("throws when octokit is null", async () => {
     await expect(
       fetchWorkflowRuns(null, [testRepo], 5, 3)


### PR DESCRIPTION
## Summary
- Adds collapsible repo-based grouping to IssuesTab and PullRequestsTab, matching ActionsTab's existing pattern
- Extracts ChevronIcon to shared component, adds hideRepo prop to ItemRow, whole-group pagination with page-boundary splitting
- Fixes pre-existing issues: inverted workflow sort comparators in api.ts, stale page signal on data shrink, plain-fn reactive accessors upgraded to createMemo, collapsedRepos migrated from createSignal<Set> to createStore for per-repo fine-grained reactivity
