### PR TITLE
feat(onboarding): simplifies wizard to single-step and adds re-auth flow

### DIFF
--- a/src/app/components/onboarding/OnboardingWizard.tsx
+++ b/src/app/components/onboarding/OnboardingWizard.tsx
@@ -121,7 +121,7 @@ export default function OnboardingWizard() {
               type="button"
               onClick={handleFinish}
               disabled={selectedRepos().length === 0}
-              class="ml-auto rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
+              class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
             >
               {selectedRepos().length === 0
                 ? "Finish Setup"

--- a/src/app/components/onboarding/OnboardingWizard.tsx
+++ b/src/app/components/onboarding/OnboardingWizard.tsx
@@ -41,6 +41,10 @@ export default function OnboardingWizard() {
   }
 
   onMount(() => {
+    if (config.onboardingComplete) {
+      window.location.replace("/dashboard");
+      return;
+    }
     void loadOrgs();
   });
 

--- a/src/app/components/onboarding/OnboardingWizard.tsx
+++ b/src/app/components/onboarding/OnboardingWizard.tsx
@@ -1,29 +1,52 @@
-import { createSignal, Show } from "solid-js";
+import {
+  createSignal,
+  createMemo,
+  onMount,
+  Switch,
+  Match,
+} from "solid-js";
 import { config, updateConfig, CONFIG_STORAGE_KEY } from "../../stores/config";
-import { RepoRef } from "../../services/api";
-import OrgSelector from "./OrgSelector";
+import { fetchOrgs, type OrgEntry, type RepoRef } from "../../services/api";
+import { getClient } from "../../services/github";
 import RepoSelector from "./RepoSelector";
-
-const STEPS = ["Select Organizations", "Select Repositories"] as const;
+import LoadingSpinner from "../shared/LoadingSpinner";
 
 export default function OnboardingWizard() {
-  const [step, setStep] = createSignal(0);
-  const [selectedOrgs, setSelectedOrgs] = createSignal<string[]>(
-    config.selectedOrgs.length > 0 ? [...config.selectedOrgs] : []
-  );
   const [selectedRepos, setSelectedRepos] = createSignal<RepoRef[]>(
     config.selectedRepos.length > 0 ? [...config.selectedRepos] : []
   );
 
-  function handleNext() {
-    if (step() === 0) {
-      updateConfig({ selectedOrgs: selectedOrgs() });
-      setStep(1);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal<string | null>(null);
+  const [orgEntries, setOrgEntries] = createSignal<OrgEntry[]>([]);
+
+  const allOrgLogins = createMemo(() => orgEntries().map((o) => o.login));
+
+  async function loadOrgs() {
+    setLoading(true);
+    setError(null);
+    try {
+      const client = getClient();
+      if (!client) throw new Error("No GitHub client available");
+      const result = await fetchOrgs(client);
+      setOrgEntries(result);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load organizations"
+      );
+    } finally {
+      setLoading(false);
     }
   }
 
+  onMount(() => {
+    void loadOrgs();
+  });
+
   function handleFinish() {
+    const uniqueOrgs = [...new Set(selectedRepos().map((r) => r.owner))];
     updateConfig({
+      selectedOrgs: uniqueOrgs,
       selectedRepos: selectedRepos(),
       onboardingComplete: true,
     });
@@ -31,15 +54,6 @@ export default function OnboardingWizard() {
     localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
     window.location.replace("/dashboard");
   }
-
-  function handleBack() {
-    setStep((s) => Math.max(0, s - 1));
-  }
-
-  const canProceed = () => {
-    if (step() === 0) return selectedOrgs().length > 0;
-    return selectedRepos().length > 0;
-  };
 
   return (
     <div class="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -50,135 +64,63 @@ export default function OnboardingWizard() {
             GitHub Tracker Setup
           </h1>
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Step {step() + 1} of {STEPS.length}
+            Select the repositories you want to track.
           </p>
         </div>
 
-        {/* Step indicator */}
-        <nav class="mb-8" aria-label="Progress">
-          <ol class="flex items-center justify-center gap-4">
-            {STEPS.map((label, i) => (
-              <li class="flex items-center gap-2">
-                <span
-                  class={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold ${
-                    i < step()
-                      ? "bg-blue-600 text-white dark:bg-blue-500"
-                      : i === step()
-                        ? "bg-blue-600 text-white ring-4 ring-blue-100 dark:bg-blue-500 dark:ring-blue-900"
-                        : "bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400"
-                  }`}
-                  aria-current={i === step() ? "step" : undefined}
-                >
-                  {i < step() ? (
-                    <svg
-                      class="h-4 w-4"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
-                  ) : (
-                    i + 1
-                  )}
-                </span>
-                <span
-                  class={`text-sm font-medium ${
-                    i === step()
-                      ? "text-gray-900 dark:text-gray-100"
-                      : "text-gray-400 dark:text-gray-500"
-                  }`}
-                >
-                  {label}
-                </span>
-                {i < STEPS.length - 1 && (
-                  <span class="mx-2 text-gray-300 dark:text-gray-600">
-                    &rsaquo;
-                  </span>
-                )}
-              </li>
-            ))}
-          </ol>
-        </nav>
-
-        {/* Step content */}
+        {/* Content */}
         <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-          <Show when={step() === 0}>
-            <div class="mb-5">
-              <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                Select Organizations
-              </h2>
-              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                Choose the GitHub organizations and personal account to track.
-              </p>
-            </div>
-            <OrgSelector
-              selected={selectedOrgs()}
-              onChange={setSelectedOrgs}
-            />
-          </Show>
-
-          <Show when={step() === 1}>
-            <div class="mb-5">
-              <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                Select Repositories
-              </h2>
-              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                Choose which repositories to track within your selected
-                organizations.
-              </p>
-            </div>
-            <RepoSelector
-              selectedOrgs={selectedOrgs()}
-              selected={selectedRepos()}
-              onChange={setSelectedRepos}
-            />
-          </Show>
+          <Switch>
+            <Match when={error()}>
+              <div class="flex flex-col items-center gap-3 py-12">
+                <p class="text-sm text-red-600 dark:text-red-400">
+                  {error()}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void loadOrgs()}
+                  class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  Retry
+                </button>
+              </div>
+            </Match>
+            <Match when={loading()}>
+              <div class="flex items-center justify-center py-12">
+                <LoadingSpinner size="md" label="Loading organizations..." />
+              </div>
+            </Match>
+            <Match when={!loading() && !error()}>
+              <div class="mb-5">
+                <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  Select Repositories
+                </h2>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  Choose which repositories to track.
+                </p>
+              </div>
+              <RepoSelector
+                selectedOrgs={allOrgLogins()}
+                orgEntries={orgEntries()}
+                selected={selectedRepos()}
+                onChange={setSelectedRepos}
+              />
+            </Match>
+          </Switch>
         </div>
 
         {/* Navigation buttons */}
-        <div class="mt-6 flex items-center justify-between">
-          <Show
-            when={step() > 0}
-            fallback={<div />}
+        <div class="mt-6 flex items-center justify-end">
+          <button
+            type="button"
+            onClick={handleFinish}
+            disabled={selectedRepos().length === 0}
+            class="ml-auto rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
           >
-            <button
-              type="button"
-              onClick={handleBack}
-              class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
-            >
-              Back
-            </button>
-          </Show>
-
-          <Show
-            when={step() === STEPS.length - 1}
-            fallback={
-              <button
-                type="button"
-                onClick={handleNext}
-                disabled={!canProceed()}
-                class="ml-auto rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
-              >
-                Next
-              </button>
-            }
-          >
-            <button
-              type="button"
-              onClick={handleFinish}
-              disabled={selectedRepos().length === 0}
-              class="ml-auto rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
-            >
-              {selectedRepos().length === 0
-                ? "Finish Setup"
-                : `Finish Setup (${selectedRepos().length} ${selectedRepos().length === 1 ? "repo" : "repos"})`}
-            </button>
-          </Show>
+            {selectedRepos().length === 0
+              ? "Finish Setup"
+              : `Finish Setup (${selectedRepos().length} ${selectedRepos().length === 1 ? "repo" : "repos"})`}
+          </button>
         </div>
       </div>
     </div>

--- a/src/app/components/onboarding/OnboardingWizard.tsx
+++ b/src/app/components/onboarding/OnboardingWizard.tsx
@@ -2,6 +2,7 @@ import {
   createSignal,
   createMemo,
   onMount,
+  Show,
   Switch,
   Match,
 } from "solid-js";
@@ -109,19 +110,21 @@ export default function OnboardingWizard() {
           </Switch>
         </div>
 
-        {/* Navigation buttons */}
-        <div class="mt-6 flex items-center justify-end">
-          <button
-            type="button"
-            onClick={handleFinish}
-            disabled={selectedRepos().length === 0}
-            class="ml-auto rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
-          >
-            {selectedRepos().length === 0
-              ? "Finish Setup"
-              : `Finish Setup (${selectedRepos().length} ${selectedRepos().length === 1 ? "repo" : "repos"})`}
-          </button>
-        </div>
+        {/* Navigation buttons — hidden during loading/error to avoid confusion */}
+        <Show when={!loading() && !error()}>
+          <div class="mt-6 flex items-center justify-end">
+            <button
+              type="button"
+              onClick={handleFinish}
+              disabled={selectedRepos().length === 0}
+              class="ml-auto rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              {selectedRepos().length === 0
+                ? "Finish Setup"
+                : `Finish Setup (${selectedRepos().length} ${selectedRepos().length === 1 ? "repo" : "repos"})`}
+            </button>
+          </div>
+        </Show>
       </div>
     </div>
   );

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -31,6 +31,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
   const [filter, setFilter] = createSignal("");
   const [orgStates, setOrgStates] = createSignal<OrgRepoState[]>([]);
   const [loadedCount, setLoadedCount] = createSignal(0);
+  let effectVersion = 0;
 
   // Initialize org states and fetch repos on mount / when selectedOrgs change
   createEffect(() => {
@@ -40,6 +41,9 @@ export default function RepoSelector(props: RepoSelectorProps) {
     // it happens to work today (before any await) but would silently break
     // if the check were moved after an await.
     const preloadedEntries = props.orgEntries;
+    // Version counter: if selectedOrgs changes while fetches are in-flight,
+    // stale callbacks check this and bail out instead of writing to state.
+    const version = ++effectVersion;
     if (orgs.length === 0) {
       setOrgStates([]);
       setLoadedCount(0);
@@ -86,6 +90,8 @@ export default function RepoSelector(props: RepoSelectorProps) {
         }
       }
 
+      if (version !== effectVersion) return;
+
       const typeMap = new Map<string, "org" | "user">(
         entries.map((e) => [e.login, e.type])
       );
@@ -95,12 +101,14 @@ export default function RepoSelector(props: RepoSelectorProps) {
         const type = typeMap.get(org) ?? "org";
         try {
           const repos = await fetchRepos(client, org, type);
+          if (version !== effectVersion) return;
           setOrgStates((prev) =>
             prev.map((s) =>
               s.org === org ? { ...s, type, repos, loading: false } : s
             )
           );
         } catch (err) {
+          if (version !== effectVersion) return;
           const message =
             err instanceof Error ? err.message : "Failed to load repositories";
           setOrgStates((prev) =>
@@ -111,7 +119,9 @@ export default function RepoSelector(props: RepoSelectorProps) {
             )
           );
         } finally {
-          setLoadedCount((c) => c + 1);
+          if (version === effectVersion) {
+            setLoadedCount((c) => c + 1);
+          }
         }
       });
 

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -132,6 +132,8 @@ export default function RepoSelector(props: RepoSelectorProps) {
     const client = getClient();
     if (!client) return;
 
+    const version = effectVersion;
+
     setOrgStates((prev) =>
       prev.map((s) =>
         s.org === org ? { ...s, loading: true, error: null } : s
@@ -143,6 +145,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
 
     void fetchRepos(client, org, type)
       .then((repos) => {
+        if (version !== effectVersion) return;
         setOrgStates((prev) =>
           prev.map((s) =>
             s.org === org ? { ...s, repos, loading: false, error: null } : s
@@ -150,6 +153,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
         );
       })
       .catch((err) => {
+        if (version !== effectVersion) return;
         const message =
           err instanceof Error ? err.message : "Failed to load repositories";
         setOrgStates((prev) =>
@@ -370,7 +374,6 @@ export default function RepoSelector(props: RepoSelectorProps) {
                     class="max-h-[300px] overflow-y-auto"
                     role="region"
                     aria-label={`${state().org} repositories`}
-                    data-testid={`repo-scroll-${state().org}`}
                   >
                     <ul class="divide-y divide-gray-100 dark:divide-gray-700">
                       <Index each={visible()}>

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -2,7 +2,6 @@ import {
   createSignal,
   createEffect,
   createMemo,
-  For,
   Show,
   Index,
 } from "solid-js";
@@ -290,23 +289,24 @@ export default function RepoSelector(props: RepoSelectorProps) {
         </div>
       </Show>
 
-      {/* Per-org repo lists */}
-      <For each={sortedOrgStates()}>
+      {/* Per-org repo lists — Index (not For) avoids tearing down every org's
+           DOM subtree when a single org's state updates via setOrgStates(prev.map(...)) */}
+      <Index each={sortedOrgStates()}>
         {(state) => {
-          const visible = createMemo(() => filteredReposForOrg(state));
+          const visible = createMemo(() => filteredReposForOrg(state()));
 
           return (
             <div class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
               {/* Org header */}
               <div class="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-800/60">
                 <span class="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                  {state.org}
+                  {state().org}
                 </span>
-                <Show when={!state.loading && !state.error}>
+                <Show when={!state().loading && !state().error}>
                   <div class="flex gap-2">
                     <button
                       type="button"
-                      onClick={() => selectAllInOrg(state)}
+                      onClick={() => selectAllInOrg(state())}
                       disabled={
                         visible().length === 0 ||
                         visible().every((r) => isSelected(r.fullName))
@@ -318,7 +318,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
                     <span class="text-gray-300 dark:text-gray-600">·</span>
                     <button
                       type="button"
-                      onClick={() => deselectAllInOrg(state)}
+                      onClick={() => deselectAllInOrg(state())}
                       disabled={
                         visible().length === 0 ||
                         visible().every((r) => !isSelected(r.fullName))
@@ -332,21 +332,21 @@ export default function RepoSelector(props: RepoSelectorProps) {
               </div>
 
               {/* Loading state for this org */}
-              <Show when={state.loading}>
+              <Show when={state().loading}>
                 <div class="flex justify-center py-6">
                   <LoadingSpinner size="sm" label="Loading..." />
                 </div>
               </Show>
 
               {/* Error state for this org */}
-              <Show when={!state.loading && state.error !== null}>
+              <Show when={!state().loading && state().error !== null}>
                 <div class="flex items-center justify-between px-4 py-3">
                   <span class="text-sm text-red-600 dark:text-red-400">
-                    {state.error}
+                    {state().error}
                   </span>
                   <button
                     type="button"
-                    onClick={() => retryOrg(state.org)}
+                    onClick={() => retryOrg(state().org)}
                     class="ml-3 text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
                   >
                     Retry
@@ -355,7 +355,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
               </Show>
 
               {/* Repo list */}
-              <Show when={!state.loading && state.error === null}>
+              <Show when={!state().loading && state().error === null}>
                 <Show
                   when={visible().length > 0}
                   fallback={
@@ -369,8 +369,8 @@ export default function RepoSelector(props: RepoSelectorProps) {
                   <div
                     class="max-h-[300px] overflow-y-auto"
                     role="region"
-                    aria-label={`${state.org} repositories`}
-                    data-testid={`repo-scroll-${state.org}`}
+                    aria-label={`${state().org} repositories`}
+                    data-testid={`repo-scroll-${state().org}`}
                   >
                     <ul class="divide-y divide-gray-100 dark:divide-gray-700">
                       <Index each={visible()}>
@@ -408,7 +408,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
             </div>
           );
         }}
-      </For>
+      </Index>
 
       {/* Total count */}
       <Show when={!isLoadingAny() && props.selected.length > 0}>

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -14,6 +14,7 @@ import FilterInput from "../shared/FilterInput";
 
 interface RepoSelectorProps {
   selectedOrgs: string[];
+  orgEntries?: OrgEntry[]; // Pre-fetched org entries — skip internal fetchOrgs when provided
   selected: RepoRef[];
   onChange: (selected: RepoRef[]) => void;
 }
@@ -69,15 +70,19 @@ export default function RepoSelector(props: RepoSelectorProps) {
 
     // Fetch org type info first, then repos incrementally
     void (async () => {
-      let orgEntries: OrgEntry[] = [];
-      try {
-        orgEntries = await fetchOrgs(client);
-      } catch {
-        // If fetchOrgs fails, treat all as "org" type
+      let entries: OrgEntry[];
+      if (props.orgEntries != null) {
+        entries = props.orgEntries;
+      } else {
+        try {
+          entries = await fetchOrgs(client);
+        } catch {
+          entries = [];
+        }
       }
 
       const typeMap = new Map<string, "org" | "user">(
-        orgEntries.map((e) => [e.login, e.type])
+        entries.map((e) => [e.login, e.type])
       );
 
       // Fetch repos for each org independently so results trickle in
@@ -346,36 +351,41 @@ export default function RepoSelector(props: RepoSelectorProps) {
                     </p>
                   }
                 >
-                  <ul class="divide-y divide-gray-100 dark:divide-gray-700">
-                    <Index each={visible()}>
-                      {(repo) => {
-                        return (
-                          <li>
-                            <label class="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                              <input
-                                type="checkbox"
-                                checked={isSelected(repo().fullName)}
-                                onChange={() => toggleRepo(repo())}
-                                class="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:ring-blue-400"
-                              />
-                              <div class="min-w-0 flex-1">
-                                <div class="flex items-center gap-2">
-                                  <span class="min-w-0 truncate text-sm font-medium text-gray-900 dark:text-gray-100">
-                                    {repo().name}
-                                  </span>
-                                  <Show when={repo().pushedAt}>
-                                    <span class="ml-auto shrink-0 text-xs text-gray-500 dark:text-gray-400">
-                                      {relativeTime(repo().pushedAt!)}
+                  <div
+                    class="max-h-[300px] overflow-y-auto"
+                    data-testid={`repo-scroll-${state.org}`}
+                  >
+                    <ul class="divide-y divide-gray-100 dark:divide-gray-700">
+                      <Index each={visible()}>
+                        {(repo) => {
+                          return (
+                            <li>
+                              <label class="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                                <input
+                                  type="checkbox"
+                                  checked={isSelected(repo().fullName)}
+                                  onChange={() => toggleRepo(repo())}
+                                  class="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:ring-blue-400"
+                                />
+                                <div class="min-w-0 flex-1">
+                                  <div class="flex items-center gap-2">
+                                    <span class="min-w-0 truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+                                      {repo().name}
                                     </span>
-                                  </Show>
+                                    <Show when={repo().pushedAt}>
+                                      <span class="ml-auto shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                                        {relativeTime(repo().pushedAt!)}
+                                      </span>
+                                    </Show>
+                                  </div>
                                 </div>
-                              </div>
-                            </label>
-                          </li>
-                        );
-                      }}
-                    </Index>
-                  </ul>
+                              </label>
+                            </li>
+                          );
+                        }}
+                      </Index>
+                    </ul>
+                  </div>
                 </Show>
               </Show>
             </div>

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -189,7 +189,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
 
   // ── Filtering ──────────────────────────────────────────────────────────────
 
-  const q = () => filter().toLowerCase().trim();
+  const q = createMemo(() => filter().toLowerCase().trim());
 
   function filteredReposForOrg(state: OrgRepoState): RepoEntry[] {
     const query = q();

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -35,6 +35,11 @@ export default function RepoSelector(props: RepoSelectorProps) {
   // Initialize org states and fetch repos on mount / when selectedOrgs change
   createEffect(() => {
     const orgs = props.selectedOrgs;
+    // Capture orgEntries synchronously so SolidJS tracks it as a reactive
+    // dependency. Reading it inside the async IIFE below would be fragile —
+    // it happens to work today (before any await) but would silently break
+    // if the check were moved after an await.
+    const preloadedEntries = props.orgEntries;
     if (orgs.length === 0) {
       setOrgStates([]);
       setLoadedCount(0);
@@ -71,8 +76,8 @@ export default function RepoSelector(props: RepoSelectorProps) {
     // Fetch org type info first, then repos incrementally
     void (async () => {
       let entries: OrgEntry[];
-      if (props.orgEntries != null) {
-        entries = props.orgEntries;
+      if (preloadedEntries != null) {
+        entries = preloadedEntries;
       } else {
         try {
           entries = await fetchOrgs(client);
@@ -353,6 +358,8 @@ export default function RepoSelector(props: RepoSelectorProps) {
                 >
                   <div
                     class="max-h-[300px] overflow-y-auto"
+                    role="region"
+                    aria-label={`${state.org} repositories`}
                     data-testid={`repo-scroll-${state.org}`}
                   >
                     <ul class="divide-y divide-gray-100 dark:divide-gray-700">

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -205,18 +205,19 @@ export default function SettingsPage() {
   async function mergeNewOrgs() {
     const client = getClient();
     if (!client) return;
+    const snapshot = [...config.selectedOrgs];
     try {
       const allOrgs = await fetchOrgs(client);
       // Case-insensitive comparison — GitHub logins are case-insensitive
-      const currentSet = new Set(config.selectedOrgs.map((o) => o.toLowerCase()));
+      const currentSet = new Set(snapshot.map((o) => o.toLowerCase()));
       const newOrgs = allOrgs
         .map((o) => o.login)
         .filter((login) => !currentSet.has(login.toLowerCase()));
       if (newOrgs.length > 0) {
-        const merged = [...config.selectedOrgs, ...newOrgs];
+        const merged = [...snapshot, ...newOrgs];
         setLocalOrgs(merged);
         saveWithFeedback({ selectedOrgs: merged });
-        console.info(`[settings] merged ${newOrgs.length} new org(s): ${newOrgs.join(", ")}`);
+        console.info(`[settings] merged ${newOrgs.length} new org(s)`);
       }
     } catch {
       // Non-fatal — user can manually manage orgs
@@ -421,25 +422,27 @@ export default function SettingsPage() {
               </div>
             </div>
 
-            <div class="border-t border-gray-100 pt-3 dark:border-gray-700 flex items-center justify-between">
-              <div>
-                <p class="text-sm font-medium text-gray-900 dark:text-gray-100">Repositories</p>
-                <p class="text-xs text-gray-500 dark:text-gray-400">
-                  {localRepos().length} selected
-                </p>
-                <Show when={localRepos().length > 50}>
-                  <p class="text-xs text-amber-600 dark:text-amber-400">
-                    Tracking {localRepos().length} repos will use significant API quota per poll cycle
+            <div class="border-t border-gray-100 pt-3 dark:border-gray-700">
+              <div class="flex items-center justify-between">
+                <div>
+                  <p class="text-sm font-medium text-gray-900 dark:text-gray-100">Repositories</p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
+                    {localRepos().length} selected
                   </p>
-                </Show>
+                  <Show when={localRepos().length > 50}>
+                    <p class="text-xs text-amber-600 dark:text-amber-400">
+                      Tracking {localRepos().length} repos will use significant API quota per poll cycle
+                    </p>
+                  </Show>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setRepoPanelOpen((v) => !v)}
+                  class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                >
+                  Manage Repositories
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={() => setRepoPanelOpen((v) => !v)}
-                class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-              >
-                Manage Repositories
-              </button>
             </div>
             <Show when={repoPanelOpen()}>
               <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -3,6 +3,9 @@ import { useNavigate } from "@solidjs/router";
 import { config, updateConfig } from "../../stores/config";
 import { clearAuth } from "../../stores/auth";
 import { clearCache } from "../../stores/cache";
+import { buildAuthorizeUrl, MERGE_ORGS_KEY } from "../../lib/oauth";
+import { fetchOrgs } from "../../services/api";
+import { getClient } from "../../services/github";
 import OrgSelector from "../onboarding/OrgSelector";
 import RepoSelector from "../onboarding/RepoSelector";
 import type { RepoRef } from "../../services/api";
@@ -150,6 +153,7 @@ export default function SettingsPage() {
   const [confirmClearCache, setConfirmClearCache] = createSignal(false);
   const [confirmReset, setConfirmReset] = createSignal(false);
   const [cacheClearing, setCacheClearing] = createSignal(false);
+  const [reauthing, setReauthing] = createSignal(false);
   const [notifPermission, setNotifPermission] = createSignal<NotificationPermission>(
     typeof Notification !== "undefined" ? Notification.permission : "default"
   );
@@ -187,9 +191,43 @@ export default function SettingsPage() {
     };
     mq.addEventListener("change", handler);
     onCleanup(() => mq.removeEventListener("change", handler));
+
+    // Auto-merge newly accessible orgs after re-auth redirect
+    const shouldMerge = sessionStorage.getItem(MERGE_ORGS_KEY);
+    if (shouldMerge) {
+      sessionStorage.removeItem(MERGE_ORGS_KEY);
+      void mergeNewOrgs();
+    }
   });
 
   // ── Helpers ──────────────────────────────────────────────────────────────
+
+  async function mergeNewOrgs() {
+    const client = getClient();
+    if (!client) return;
+    try {
+      const allOrgs = await fetchOrgs(client);
+      // Case-insensitive comparison — GitHub logins are case-insensitive
+      const currentSet = new Set(config.selectedOrgs.map((o) => o.toLowerCase()));
+      const newOrgs = allOrgs
+        .map((o) => o.login)
+        .filter((login) => !currentSet.has(login.toLowerCase()));
+      if (newOrgs.length > 0) {
+        const merged = [...config.selectedOrgs, ...newOrgs];
+        setLocalOrgs(merged);
+        saveWithFeedback({ selectedOrgs: merged });
+        console.info(`[settings] merged ${newOrgs.length} new org(s): ${newOrgs.join(", ")}`);
+      }
+    } catch {
+      // Non-fatal — user can manually manage orgs
+    }
+  }
+
+  function handleReAuth() {
+    setReauthing(true);
+    sessionStorage.setItem(MERGE_ORGS_KEY, "true");
+    window.location.href = buildAuthorizeUrl({ returnTo: "/settings" });
+  }
 
   function handleOrgsChange(orgs: string[]) {
     setLocalOrgs(orgs);
@@ -359,6 +397,27 @@ export default function SettingsPage() {
                 />
               </div>
             </Show>
+
+            <div class="border-t border-gray-100 pt-3 dark:border-gray-700">
+              <div class="flex items-center justify-between">
+                <div>
+                  <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    Organization Access
+                  </p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
+                    Re-authorize with GitHub to grant access to additional organizations
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleReAuth}
+                  disabled={reauthing()}
+                  class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                >
+                  Grant more orgs
+                </button>
+              </div>
+            </div>
 
             <div class="border-t border-gray-100 pt-3 dark:border-gray-700 flex items-center justify-between">
               <div>

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -225,6 +225,8 @@ export default function SettingsPage() {
 
   function handleReAuth() {
     setReauthing(true);
+    // Reset if navigation doesn't happen (e.g., beforeunload dialog blocks redirect)
+    setTimeout(() => setReauthing(false), 3000);
     sessionStorage.setItem(MERGE_ORGS_KEY, "true");
     window.location.href = buildAuthorizeUrl({ returnTo: "/settings" });
   }

--- a/src/app/lib/oauth.ts
+++ b/src/app/lib/oauth.ts
@@ -10,6 +10,12 @@ export function generateOAuthState(): string {
     .replace(/=/g, "");
 }
 
+export function sanitizeReturnTo(returnTo: string | null): string {
+  return returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
+    ? returnTo
+    : "/";
+}
+
 export function buildAuthorizeUrl(options?: { returnTo?: string }): string {
   const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string;
   const state = generateOAuthState();

--- a/src/app/lib/oauth.ts
+++ b/src/app/lib/oauth.ts
@@ -1,0 +1,32 @@
+export const OAUTH_STATE_KEY = "github-tracker:oauth-state";
+export const OAUTH_RETURN_TO_KEY = "github-tracker:oauth-return-to";
+export const MERGE_ORGS_KEY = "github-tracker:merge-orgs";
+
+export function generateOAuthState(): string {
+  const stateBytes = crypto.getRandomValues(new Uint8Array(16));
+  return btoa(String.fromCharCode(...stateBytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+export function buildAuthorizeUrl(options?: { returnTo?: string }): string {
+  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string;
+  const state = generateOAuthState();
+  sessionStorage.setItem(OAUTH_STATE_KEY, state);
+  if (options?.returnTo) {
+    sessionStorage.setItem(OAUTH_RETURN_TO_KEY, options.returnTo);
+  } else {
+    // Clear any stale returnTo from a previous re-auth attempt
+    sessionStorage.removeItem(OAUTH_RETURN_TO_KEY);
+  }
+  const redirectUri = `${window.location.origin}/oauth/callback`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    // repo: read issues/PRs; read:org: list orgs; notifications: gate
+    scope: "repo read:org notifications",
+    state,
+  });
+  return `https://github.com/login/oauth/authorize?${params.toString()}`;
+}

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -1,26 +1,8 @@
+import { buildAuthorizeUrl } from "../lib/oauth";
+
 export default function LoginPage() {
   function handleLogin() {
-    const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string;
-
-    // Generate cryptographically random state for CSRF protection (SDR-002)
-    const stateBytes = crypto.getRandomValues(new Uint8Array(16));
-    const state = btoa(String.fromCharCode(...stateBytes))
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=/g, "");
-
-    sessionStorage.setItem("github-tracker:oauth-state", state);
-
-    const redirectUri = `${window.location.origin}/oauth/callback`;
-    const params = new URLSearchParams({
-      client_id: clientId,
-      redirect_uri: redirectUri,
-      state,
-      // repo: read issues/PRs; read:org: list orgs; notifications: gate
-      scope: "repo read:org notifications",
-    });
-
-    window.location.href = `https://github.com/login/oauth/authorize?${params.toString()}`;
+    window.location.href = buildAuthorizeUrl();
   }
 
   return (

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -20,6 +20,7 @@ export default function LoginPage() {
           </div>
 
           <button
+            type="button"
             onClick={handleLogin}
             class="w-full flex items-center justify-center gap-3 px-4 py-2.5 bg-gray-900 dark:bg-gray-700 text-white rounded-lg font-medium hover:bg-gray-700 dark:hover:bg-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
           >

--- a/src/app/pages/OAuthCallback.tsx
+++ b/src/app/pages/OAuthCallback.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { setAuth, validateToken, clearAuth } from "../stores/auth";
 import { OAUTH_STATE_KEY, OAUTH_RETURN_TO_KEY } from "../lib/oauth";
@@ -77,7 +77,37 @@ export default function OAuthCallback() {
   return (
     <div class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
       <div class="max-w-sm w-full mx-4 text-center">
-        {error() ? (
+        <Show
+          when={error()}
+          fallback={
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 flex flex-col items-center gap-4">
+              <svg
+                class="animate-spin h-8 w-8 text-gray-500"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-label="Loading"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                />
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              <p class="text-gray-600 dark:text-gray-400">
+                Completing sign in...
+              </p>
+            </div>
+          }
+        >
           <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 flex flex-col items-center gap-4">
             <p class="text-red-600 dark:text-red-400 font-medium">{error()}</p>
             <a
@@ -87,34 +117,7 @@ export default function OAuthCallback() {
               Return to sign in
             </a>
           </div>
-        ) : (
-          <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 flex flex-col items-center gap-4">
-            <svg
-              class="animate-spin h-8 w-8 text-gray-500"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              aria-label="Loading"
-            >
-              <circle
-                class="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-              />
-              <path
-                class="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-              />
-            </svg>
-            <p class="text-gray-600 dark:text-gray-400">
-              Completing sign in...
-            </p>
-          </div>
-        )}
+        </Show>
       </div>
     </div>
   );

--- a/src/app/pages/OAuthCallback.tsx
+++ b/src/app/pages/OAuthCallback.tsx
@@ -1,6 +1,7 @@
 import { createSignal, onMount } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { setAuth, validateToken, clearAuth } from "../stores/auth";
+import { OAUTH_STATE_KEY, OAUTH_RETURN_TO_KEY } from "../lib/oauth";
 
 interface TokenResponse {
   access_token: string;
@@ -19,8 +20,12 @@ export default function OAuthCallback() {
     const stateFromUrl = params.get("state");
 
     // Retrieve and immediately clear stored state (single-use, SDR-002)
-    const storedState = sessionStorage.getItem("github-tracker:oauth-state");
-    sessionStorage.removeItem("github-tracker:oauth-state");
+    const storedState = sessionStorage.getItem(OAUTH_STATE_KEY);
+    sessionStorage.removeItem(OAUTH_STATE_KEY);
+
+    // Read and clear returnTo before CSRF check — always consumed, even on failure
+    const returnTo = sessionStorage.getItem(OAUTH_RETURN_TO_KEY);
+    sessionStorage.removeItem(OAUTH_RETURN_TO_KEY);
 
     // Validate state before anything else (CSRF protection)
     if (!stateFromUrl || !storedState || stateFromUrl !== storedState) {
@@ -58,7 +63,12 @@ export default function OAuthCallback() {
         return;
       }
 
-      navigate("/", { replace: true });
+      // Only allow internal paths (prevent open redirect)
+      const target =
+        returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
+          ? returnTo
+          : "/";
+      navigate(target, { replace: true });
     } catch {
       setError("A network error occurred. Please try again.");
     }

--- a/src/app/pages/OAuthCallback.tsx
+++ b/src/app/pages/OAuthCallback.tsx
@@ -1,7 +1,8 @@
 import { createSignal, onMount, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { setAuth, validateToken, clearAuth } from "../stores/auth";
-import { OAUTH_STATE_KEY, OAUTH_RETURN_TO_KEY } from "../lib/oauth";
+import { OAUTH_STATE_KEY, OAUTH_RETURN_TO_KEY, sanitizeReturnTo } from "../lib/oauth";
+import LoadingSpinner from "../components/shared/LoadingSpinner";
 
 interface TokenResponse {
   access_token: string;
@@ -63,12 +64,7 @@ export default function OAuthCallback() {
         return;
       }
 
-      // Only allow internal paths (prevent open redirect)
-      const target =
-        returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
-          ? returnTo
-          : "/";
-      navigate(target, { replace: true });
+      navigate(sanitizeReturnTo(returnTo), { replace: true });
     } catch {
       setError("A network error occurred. Please try again.");
     }
@@ -81,30 +77,7 @@ export default function OAuthCallback() {
           when={error()}
           fallback={
             <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 flex flex-col items-center gap-4">
-              <svg
-                class="animate-spin h-8 w-8 text-gray-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-label="Loading"
-              >
-                <circle
-                  class="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  stroke-width="4"
-                />
-                <path
-                  class="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                />
-              </svg>
-              <p class="text-gray-600 dark:text-gray-400">
-                Completing sign in...
-              </p>
+              <LoadingSpinner size="md" label="Completing sign in..." />
             </div>
           }
         >

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import LoginPage from "../../src/app/pages/LoginPage";
+import { OAUTH_STATE_KEY } from "../../src/app/lib/oauth";
 
 describe("LoginPage", () => {
   beforeEach(() => {
@@ -70,7 +71,7 @@ describe("LoginPage", () => {
     render(() => <LoginPage />);
     const button = screen.getByText("Sign in with GitHub");
     await user.click(button);
-    const stored = sessionStorage.getItem("github-tracker:oauth-state");
+    const stored = sessionStorage.getItem(OAUTH_STATE_KEY);
     expect(stored).toBeTruthy();
   });
 
@@ -81,7 +82,7 @@ describe("LoginPage", () => {
     await user.click(button);
     const url = new URL(window.location.href);
     const urlState = url.searchParams.get("state");
-    const storedState = sessionStorage.getItem("github-tracker:oauth-state");
+    const storedState = sessionStorage.getItem(OAUTH_STATE_KEY);
     expect(urlState).toBe(storedState);
   });
 

--- a/tests/components/OAuthCallback.test.tsx
+++ b/tests/components/OAuthCallback.test.tsx
@@ -373,26 +373,6 @@ describe("OAuthCallback", () => {
     expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
   });
 
-  // Verify the returnTo validation logic directly — the navigate() call itself
-  // cannot be intercepted due to SolidJS router limitations (partial mock of
-  // @solidjs/router renders empty div — project gotcha), but we can verify
-  // the logic by testing the validation conditions match the implementation.
-  it("returnTo validation accepts internal paths and rejects external URLs", () => {
-    // This tests the SAME validation logic used on OAuthCallback line 67-70:
-    // returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
-    const validate = (returnTo: string | null) =>
-      returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
-        ? returnTo
-        : "/";
-
-    expect(validate("/settings")).toBe("/settings");
-    expect(validate("/dashboard")).toBe("/dashboard");
-    expect(validate("/")).toBe("/");
-    expect(validate("https://evil.com")).toBe("/");
-    expect(validate("//evil.com")).toBe("/");
-    expect(validate("javascript:alert(1)")).toBe("/");
-    expect(validate(null)).toBe("/");
-    expect(validate("")).toBe("/");
-  });
+  // returnTo validation is tested via sanitizeReturnTo in tests/lib/oauth.test.ts
 
 });

--- a/tests/components/OAuthCallback.test.tsx
+++ b/tests/components/OAuthCallback.test.tsx
@@ -306,25 +306,19 @@ describe("OAuthCallback", () => {
   it("navigates to returnTo path when OAUTH_RETURN_TO_KEY is set to /settings", async () => {
     sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "/settings");
     setupSuccessfulCallback();
-
-    const navigated: string[] = [];
-    // We can't intercept useNavigate directly, so we verify via the MemoryRouter state.
-    // Render inside a MemoryRouter with a catch-all route that records navigation.
     renderCallback();
 
     await waitFor(() => {
       expect(authStore.validateToken).toHaveBeenCalled();
     });
-    // OAUTH_RETURN_TO_KEY should be cleared after use
     expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
-    void navigated; // suppress unused variable warning
   });
 
   it("OAUTH_RETURN_TO_KEY is removed from sessionStorage after reading", async () => {
     sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "/settings");
     setupValidState();
     setWindowSearch({ code: "fakecode", state: "teststate" });
-    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {}))); // keep pending
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
 
     renderCallback();
 
@@ -336,7 +330,7 @@ describe("OAuthCallback", () => {
   it("OAUTH_RETURN_TO_KEY is cleared even when CSRF check fails (stale key protection)", async () => {
     sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "/settings");
     sessionStorage.setItem(OAUTH_STATE_KEY, "expected-state");
-    setWindowSearch({ code: "fakecode", state: "wrong-state" }); // CSRF fail
+    setWindowSearch({ code: "fakecode", state: "wrong-state" });
 
     renderCallback();
 
@@ -347,7 +341,6 @@ describe("OAuthCallback", () => {
   });
 
   it("navigates to / when OAUTH_RETURN_TO_KEY is not set", async () => {
-    // No OAUTH_RETURN_TO_KEY set — should navigate to /
     setupSuccessfulCallback();
     renderCallback();
 
@@ -357,7 +350,7 @@ describe("OAuthCallback", () => {
     expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
   });
 
-  it("navigates to / when OAUTH_RETURN_TO_KEY is an absolute URL (open-redirect protection)", async () => {
+  it("rejects absolute URL returnTo (open-redirect protection)", async () => {
     sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "https://evil.com");
     setupSuccessfulCallback();
     renderCallback();
@@ -365,10 +358,11 @@ describe("OAuthCallback", () => {
     await waitFor(() => {
       expect(authStore.validateToken).toHaveBeenCalled();
     });
+    // Key consumed regardless
     expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
   });
 
-  it("navigates to / when OAUTH_RETURN_TO_KEY is a protocol-relative URL (// attack)", async () => {
+  it("rejects protocol-relative URL returnTo (// attack)", async () => {
     sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "//evil.com");
     setupSuccessfulCallback();
     renderCallback();
@@ -377,6 +371,28 @@ describe("OAuthCallback", () => {
       expect(authStore.validateToken).toHaveBeenCalled();
     });
     expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+  });
+
+  // Verify the returnTo validation logic directly — the navigate() call itself
+  // cannot be intercepted due to SolidJS router limitations (partial mock of
+  // @solidjs/router renders empty div — project gotcha), but we can verify
+  // the logic by testing the validation conditions match the implementation.
+  it("returnTo validation accepts internal paths and rejects external URLs", () => {
+    // This tests the SAME validation logic used on OAuthCallback line 67-70:
+    // returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
+    const validate = (returnTo: string | null) =>
+      returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
+        ? returnTo
+        : "/";
+
+    expect(validate("/settings")).toBe("/settings");
+    expect(validate("/dashboard")).toBe("/dashboard");
+    expect(validate("/")).toBe("/");
+    expect(validate("https://evil.com")).toBe("/");
+    expect(validate("//evil.com")).toBe("/");
+    expect(validate("javascript:alert(1)")).toBe("/");
+    expect(validate(null)).toBe("/");
+    expect(validate("")).toBe("/");
   });
 
 });

--- a/tests/components/OAuthCallback.test.tsx
+++ b/tests/components/OAuthCallback.test.tsx
@@ -198,7 +198,7 @@ describe("OAuthCallback", () => {
   });
 
   it("shows CSRF error when state param does not match sessionStorage", async () => {
-    sessionStorage.setItem("github-tracker:oauth-state", "expected-state");
+    sessionStorage.setItem(OAUTH_STATE_KEY, "expected-state");
     setWindowSearch({ code: "fakecode", state: "wrong-state" });
 
     renderCallback();

--- a/tests/components/OAuthCallback.test.tsx
+++ b/tests/components/OAuthCallback.test.tsx
@@ -11,6 +11,7 @@ vi.mock("../../src/app/stores/auth", () => ({
 
 import * as authStore from "../../src/app/stores/auth";
 import OAuthCallback from "../../src/app/pages/OAuthCallback";
+import { OAUTH_STATE_KEY, OAUTH_RETURN_TO_KEY } from "../../src/app/lib/oauth";
 
 /** Render OAuthCallback inside a proper router context (useNavigate requires a Route). */
 function renderCallback() {
@@ -55,7 +56,7 @@ describe("OAuthCallback", () => {
   }
 
   function setupValidState() {
-    sessionStorage.setItem("github-tracker:oauth-state", "teststate");
+    sessionStorage.setItem(OAUTH_STATE_KEY, "teststate");
   }
 
   it("shows loading state while exchanging code", async () => {
@@ -186,7 +187,7 @@ describe("OAuthCallback", () => {
   });
 
   it("shows CSRF error when state param is missing from URL", async () => {
-    sessionStorage.setItem("github-tracker:oauth-state", "teststate");
+    sessionStorage.setItem(OAUTH_STATE_KEY, "teststate");
     setWindowSearch({ code: "fakecode" }); // no state param
 
     renderCallback();
@@ -228,7 +229,7 @@ describe("OAuthCallback", () => {
 
     // onMount runs asynchronously — wait for the key to be cleared
     await waitFor(() => {
-      expect(sessionStorage.getItem("github-tracker:oauth-state")).toBeNull();
+      expect(sessionStorage.getItem(OAUTH_STATE_KEY)).toBeNull();
     });
   });
 
@@ -241,7 +242,7 @@ describe("OAuthCallback", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(() => {
-        expect(sessionStorage.getItem("github-tracker:oauth-state")).toBeNull();
+        expect(sessionStorage.getItem(OAUTH_STATE_KEY)).toBeNull();
         return new Promise(() => {}); // keep pending
       })
     );
@@ -254,7 +255,7 @@ describe("OAuthCallback", () => {
   });
 
   it("handles missing code param", async () => {
-    sessionStorage.setItem("github-tracker:oauth-state", "teststate");
+    sessionStorage.setItem(OAUTH_STATE_KEY, "teststate");
     setWindowSearch({ state: "teststate" });
 
     renderCallback();
@@ -285,6 +286,97 @@ describe("OAuthCallback", () => {
       expect(authStore.clearAuth).toHaveBeenCalled();
       screen.getByText(/Could not verify token/i);
     });
+  });
+
+  // ── returnTo redirect tests ────────────────────────────────────────────────
+
+  function setupSuccessfulCallback() {
+    setupValidState();
+    setWindowSearch({ code: "fakecode", state: "teststate" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: "tok123" }),
+      })
+    );
+    vi.mocked(authStore.validateToken).mockResolvedValue(true);
+  }
+
+  it("navigates to returnTo path when OAUTH_RETURN_TO_KEY is set to /settings", async () => {
+    sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "/settings");
+    setupSuccessfulCallback();
+
+    const navigated: string[] = [];
+    // We can't intercept useNavigate directly, so we verify via the MemoryRouter state.
+    // Render inside a MemoryRouter with a catch-all route that records navigation.
+    renderCallback();
+
+    await waitFor(() => {
+      expect(authStore.validateToken).toHaveBeenCalled();
+    });
+    // OAUTH_RETURN_TO_KEY should be cleared after use
+    expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+    void navigated; // suppress unused variable warning
+  });
+
+  it("OAUTH_RETURN_TO_KEY is removed from sessionStorage after reading", async () => {
+    sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "/settings");
+    setupValidState();
+    setWindowSearch({ code: "fakecode", state: "teststate" });
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {}))); // keep pending
+
+    renderCallback();
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+    });
+  });
+
+  it("OAUTH_RETURN_TO_KEY is cleared even when CSRF check fails (stale key protection)", async () => {
+    sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "/settings");
+    sessionStorage.setItem(OAUTH_STATE_KEY, "expected-state");
+    setWindowSearch({ code: "fakecode", state: "wrong-state" }); // CSRF fail
+
+    renderCallback();
+
+    await waitFor(() => {
+      screen.getByText(/Invalid OAuth state/i);
+    });
+    expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+  });
+
+  it("navigates to / when OAUTH_RETURN_TO_KEY is not set", async () => {
+    // No OAUTH_RETURN_TO_KEY set — should navigate to /
+    setupSuccessfulCallback();
+    renderCallback();
+
+    await waitFor(() => {
+      expect(authStore.validateToken).toHaveBeenCalled();
+    });
+    expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+  });
+
+  it("navigates to / when OAUTH_RETURN_TO_KEY is an absolute URL (open-redirect protection)", async () => {
+    sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "https://evil.com");
+    setupSuccessfulCallback();
+    renderCallback();
+
+    await waitFor(() => {
+      expect(authStore.validateToken).toHaveBeenCalled();
+    });
+    expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+  });
+
+  it("navigates to / when OAUTH_RETURN_TO_KEY is a protocol-relative URL (// attack)", async () => {
+    sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "//evil.com");
+    setupSuccessfulCallback();
+    renderCallback();
+
+    await waitFor(() => {
+      expect(authStore.validateToken).toHaveBeenCalled();
+    });
+    expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
   });
 
 });

--- a/tests/components/onboarding/OnboardingWizard.test.tsx
+++ b/tests/components/onboarding/OnboardingWizard.test.tsx
@@ -198,6 +198,24 @@ describe("OnboardingWizard", () => {
     );
   });
 
+  it("on finish: flushes config to localStorage", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
+    render(() => <OnboardingWizard />);
+    await waitFor(() => {
+      screen.getByTestId("repo-selector");
+    });
+    await user.click(screen.getByText("Select Repo"));
+    await waitFor(() => {
+      screen.getByText(/Finish Setup \(1 repo\)/);
+    });
+    await user.click(screen.getByText(/Finish Setup \(1 repo\)/));
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "github-tracker:config",
+      expect.any(String)
+    );
+  });
+
   it("on finish: navigates to /dashboard via window.location.replace", async () => {
     const user = userEvent.setup();
     vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);

--- a/tests/components/onboarding/OnboardingWizard.test.tsx
+++ b/tests/components/onboarding/OnboardingWizard.test.tsx
@@ -68,23 +68,16 @@ describe("OnboardingWizard", () => {
       writable: true,
       value: { replace: vi.fn(), href: "" },
     });
-    if (
-      typeof localStorage === "undefined" ||
-      typeof localStorage.setItem !== "function"
-    ) {
-      Object.defineProperty(window, "localStorage", {
-        configurable: true,
-        writable: true,
-        value: {
-          setItem: vi.fn(),
-          getItem: vi.fn(() => null),
-          removeItem: vi.fn(),
-          clear: vi.fn(),
-        },
-      });
-    } else {
-      vi.spyOn(localStorage, "setItem").mockImplementation(() => {});
-    }
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      writable: true,
+      value: {
+        setItem: vi.fn(),
+        getItem: vi.fn(() => null),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      },
+    });
   });
 
   afterEach(() => {

--- a/tests/components/onboarding/OnboardingWizard.test.tsx
+++ b/tests/components/onboarding/OnboardingWizard.test.tsx
@@ -117,7 +117,42 @@ describe("OnboardingWizard", () => {
     vi.mocked(apiModule.fetchOrgs).mockReturnValue(new Promise(() => {}));
     render(() => <OnboardingWizard />);
     await waitFor(() => {
-      expect(screen.getByTestId("loading-spinner")).toBeDefined();
+      screen.getByTestId("loading-spinner");
+    });
+  });
+
+  it("redirects to /dashboard when onboardingComplete is already true", async () => {
+    Object.assign(configStore.config, { onboardingComplete: true });
+    render(() => <OnboardingWizard />);
+    await waitFor(() => {
+      expect(window.location.replace).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(apiModule.fetchOrgs).not.toHaveBeenCalled();
+    Object.assign(configStore.config, { onboardingComplete: false });
+  });
+
+  it("retry clears error and shows RepoSelector on success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiModule.fetchOrgs)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce(mockOrgs);
+    render(() => <OnboardingWizard />);
+    await waitFor(() => {
+      screen.getByText("Retry");
+    });
+    await user.click(screen.getByText("Retry"));
+    await waitFor(() => {
+      screen.getByTestId("repo-selector");
+    });
+    expect(screen.queryByText(/Network error/i)).toBeNull();
+  });
+
+  it("shows error when getClient returns null", async () => {
+    const { getClient } = await import("../../../src/app/services/github");
+    vi.mocked(getClient).mockReturnValueOnce(null);
+    render(() => <OnboardingWizard />);
+    await waitFor(() => {
+      screen.getByText(/No GitHub client available/i);
     });
   });
 

--- a/tests/components/onboarding/OnboardingWizard.test.tsx
+++ b/tests/components/onboarding/OnboardingWizard.test.tsx
@@ -1,34 +1,46 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
-import type { RepoRef } from "../../../src/app/services/api";
+import type { RepoRef, OrgEntry } from "../../../src/app/services/api";
 
-// Mock OrgSelector and RepoSelector to avoid their internal fetching
-vi.mock("../../../src/app/components/onboarding/OrgSelector", () => ({
-  default: (props: { selected: string[]; onChange: (s: string[]) => void }) => (
-    <div data-testid="org-selector">
-      <button onClick={() => props.onChange(["myorg"])}>Select Org</button>
-      <span>Selected: {props.selected.join(",")}</span>
-    </div>
-  ),
+// Mock fetchOrgs and getClient
+vi.mock("../../../src/app/services/api", () => ({
+  fetchOrgs: vi.fn(),
+}));
+vi.mock("../../../src/app/services/github", () => ({
+  getClient: vi.fn(() => ({})),
 }));
 
+// Mock RepoSelector to avoid internal fetching
 vi.mock("../../../src/app/components/onboarding/RepoSelector", () => ({
   default: (props: {
     selectedOrgs: string[];
+    orgEntries?: OrgEntry[];
     selected: RepoRef[];
     onChange: (s: RepoRef[]) => void;
   }) => (
     <div data-testid="repo-selector">
+      <span data-testid="repo-selector-orgs">
+        {props.selectedOrgs.join(",")}
+      </span>
       <button
         onClick={() =>
-          props.onChange([{ owner: "myorg", name: "myrepo", fullName: "myorg/myrepo" }])
+          props.onChange([
+            { owner: "myorg", name: "myrepo", fullName: "myorg/myrepo" },
+          ])
         }
       >
         Select Repo
       </button>
       <span>Repos: {props.selected.length}</span>
     </div>
+  ),
+}));
+
+// Mock LoadingSpinner
+vi.mock("../../../src/app/components/shared/LoadingSpinner", () => ({
+  default: (props: { label?: string }) => (
+    <div data-testid="loading-spinner">{props.label ?? "Loading..."}</div>
   ),
 }));
 
@@ -40,7 +52,13 @@ vi.mock("../../../src/app/stores/config", () => ({
 }));
 
 import * as configStore from "../../../src/app/stores/config";
+import * as apiModule from "../../../src/app/services/api";
 import OnboardingWizard from "../../../src/app/components/onboarding/OnboardingWizard";
+
+const mockOrgs: OrgEntry[] = [
+  { login: "myorg", avatarUrl: "", type: "org" },
+  { login: "otherog", avatarUrl: "", type: "org" },
+];
 
 describe("OnboardingWizard", () => {
   beforeEach(() => {
@@ -50,12 +68,19 @@ describe("OnboardingWizard", () => {
       writable: true,
       value: { replace: vi.fn(), href: "" },
     });
-    // Ensure localStorage.setItem is available (happy-dom may not expose it in all contexts)
-    if (typeof localStorage === "undefined" || typeof localStorage.setItem !== "function") {
+    if (
+      typeof localStorage === "undefined" ||
+      typeof localStorage.setItem !== "function"
+    ) {
       Object.defineProperty(window, "localStorage", {
         configurable: true,
         writable: true,
-        value: { setItem: vi.fn(), getItem: vi.fn(() => null), removeItem: vi.fn(), clear: vi.fn() },
+        value: {
+          setItem: vi.fn(),
+          getItem: vi.fn(() => null),
+          removeItem: vi.fn(),
+          clear: vi.fn(),
+        },
       });
     } else {
       vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {});
@@ -66,161 +91,125 @@ describe("OnboardingWizard", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders wizard with step indicator", () => {
+  it('renders "GitHub Tracker Setup" heading', async () => {
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
     render(() => <OnboardingWizard />);
     screen.getByText("GitHub Tracker Setup");
-    screen.getByText(/Step 1 of 2/i);
   });
 
-  it("first step shows OrgSelector", () => {
+  it('renders "Select the repositories you want to track" subtitle', async () => {
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
     render(() => <OnboardingWizard />);
-    screen.getByTestId("org-selector");
+    screen.getByText("Select the repositories you want to track.");
   });
 
-  it("shows Select Organizations step label in progress indicator", () => {
+  it("does NOT render OrgSelector or step indicator", async () => {
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
     render(() => <OnboardingWizard />);
-    // Text appears twice (step indicator + section heading): use getAllByText
-    const matches = screen.getAllByText("Select Organizations");
-    expect(matches.length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByTestId("org-selector")).toBeNull();
+    expect(screen.queryByText(/Step \d of \d/i)).toBeNull();
+    expect(
+      screen.queryByRole("navigation", { name: /progress/i })
+    ).toBeNull();
   });
 
-  it("Next button is disabled when no orgs selected", () => {
+  it("shows loading spinner while fetching orgs", async () => {
+    vi.mocked(apiModule.fetchOrgs).mockReturnValue(new Promise(() => {}));
     render(() => <OnboardingWizard />);
-    const nextButton = screen.getByText("Next");
-    expect(nextButton.hasAttribute("disabled")).toBe(true);
-  });
-
-  it("Next button enables after org selection", async () => {
-    const user = userEvent.setup();
-    render(() => <OnboardingWizard />);
-    await user.click(screen.getByText("Select Org"));
-
     await waitFor(() => {
-      const nextButton = screen.getByText("Next");
-      expect(nextButton.hasAttribute("disabled")).toBe(false);
+      expect(screen.getByTestId("loading-spinner")).toBeDefined();
     });
   });
 
-  it("clicking Next advances to step 2", async () => {
-    const user = userEvent.setup();
+  it("shows error state with retry button when fetchOrgs fails", async () => {
+    vi.mocked(apiModule.fetchOrgs).mockRejectedValue(
+      new Error("Network error")
+    );
     render(() => <OnboardingWizard />);
-    await user.click(screen.getByText("Select Org"));
-
     await waitFor(() => {
-      expect(screen.getByText("Next").hasAttribute("disabled")).toBe(false);
+      screen.getByText(/Network error/i);
+      screen.getByText("Retry");
     });
+  });
 
-    await user.click(screen.getByText("Next"));
-
+  it("renders RepoSelector with all fetched org logins once loaded", async () => {
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
+    render(() => <OnboardingWizard />);
     await waitFor(() => {
-      screen.getByText(/Step 2 of 2/i);
+      const orgsSpan = screen.getByTestId("repo-selector-orgs");
+      expect(orgsSpan.textContent).toBe("myorg,otherog");
+    });
+  });
+
+  it('"Finish Setup" button is disabled when no repos are selected', async () => {
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
+    render(() => <OnboardingWizard />);
+    await waitFor(() => {
       screen.getByTestId("repo-selector");
     });
+    const btn = screen.getByText("Finish Setup");
+    expect(btn.hasAttribute("disabled")).toBe(true);
   });
 
-  it("calls updateConfig with selected orgs on Next", async () => {
+  it('"Finish Setup" button shows selected repo count', async () => {
     const user = userEvent.setup();
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
     render(() => <OnboardingWizard />);
-    await user.click(screen.getByText("Select Org"));
-
     await waitFor(() => {
-      expect(screen.getByText("Next").hasAttribute("disabled")).toBe(false);
+      screen.getByTestId("repo-selector");
     });
+    await user.click(screen.getByText("Select Repo"));
+    await waitFor(() => {
+      screen.getByText(/Finish Setup \(1 repo\)/);
+    });
+  });
 
-    await user.click(screen.getByText("Next"));
-
+  it("on finish: selectedOrgs is derived from unique repo owners", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
+    render(() => <OnboardingWizard />);
+    await waitFor(() => {
+      screen.getByTestId("repo-selector");
+    });
+    await user.click(screen.getByText("Select Repo"));
+    await waitFor(() => {
+      screen.getByText(/Finish Setup \(1 repo\)/);
+    });
+    await user.click(screen.getByText(/Finish Setup \(1 repo\)/));
     expect(vi.mocked(configStore.updateConfig)).toHaveBeenCalledWith(
       expect.objectContaining({ selectedOrgs: ["myorg"] })
     );
   });
 
-  it("Back button visible on step 2", async () => {
+  it("on finish: onboardingComplete is set to true", async () => {
     const user = userEvent.setup();
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
     render(() => <OnboardingWizard />);
-    await user.click(screen.getByText("Select Org"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Next").hasAttribute("disabled")).toBe(false);
-    });
-
-    await user.click(screen.getByText("Next"));
-
-    await waitFor(() => {
-      screen.getByText("Back");
-    });
-  });
-
-  it("clicking Back returns to step 1", async () => {
-    const user = userEvent.setup();
-    render(() => <OnboardingWizard />);
-    await user.click(screen.getByText("Select Org"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Next").hasAttribute("disabled")).toBe(false);
-    });
-
-    await user.click(screen.getByText("Next"));
-
-    await waitFor(() => {
-      screen.getByText("Back");
-    });
-
-    await user.click(screen.getByText("Back"));
-
-    await waitFor(() => {
-      screen.getByTestId("org-selector");
-      screen.getByText(/Step 1 of 2/i);
-    });
-  });
-
-  it("Finish Setup button disabled when no repos selected", async () => {
-    const user = userEvent.setup();
-    render(() => <OnboardingWizard />);
-    await user.click(screen.getByText("Select Org"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Next").hasAttribute("disabled")).toBe(false);
-    });
-
-    await user.click(screen.getByText("Next"));
-
-    await waitFor(() => {
-      const finishButton = screen.getByText("Finish Setup");
-      expect(finishButton.hasAttribute("disabled")).toBe(true);
-    });
-  });
-
-  it("completing final step calls updateConfig and window.location.replace", async () => {
-    const user = userEvent.setup();
-    render(() => <OnboardingWizard />);
-
-    // Step 1: select org, advance
-    await user.click(screen.getByText("Select Org"));
-    await waitFor(() => {
-      expect(screen.getByText("Next").hasAttribute("disabled")).toBe(false);
-    });
-    await user.click(screen.getByText("Next"));
-
-    // Step 2: select repo, finish
     await waitFor(() => {
       screen.getByTestId("repo-selector");
     });
     await user.click(screen.getByText("Select Repo"));
-
     await waitFor(() => {
-      const finishBtn = screen.queryByText(/Finish Setup \(1 repo\)/);
-      expect(finishBtn).toBeDefined();
-      expect(finishBtn?.hasAttribute("disabled")).toBe(false);
+      screen.getByText(/Finish Setup \(1 repo\)/);
     });
-
     await user.click(screen.getByText(/Finish Setup \(1 repo\)/));
-
-    expect(vi.mocked(configStore.updateConfig)).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        selectedRepos: [{ owner: "myorg", name: "myrepo", fullName: "myorg/myrepo" }],
-        onboardingComplete: true,
-      })
+    expect(vi.mocked(configStore.updateConfig)).toHaveBeenCalledWith(
+      expect.objectContaining({ onboardingComplete: true })
     );
+  });
+
+  it("on finish: navigates to /dashboard via window.location.replace", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
+    render(() => <OnboardingWizard />);
+    await waitFor(() => {
+      screen.getByTestId("repo-selector");
+    });
+    await user.click(screen.getByText("Select Repo"));
+    await waitFor(() => {
+      screen.getByText(/Finish Setup \(1 repo\)/);
+    });
+    await user.click(screen.getByText(/Finish Setup \(1 repo\)/));
     expect(window.location.replace).toHaveBeenCalledWith("/dashboard");
   });
 });

--- a/tests/components/onboarding/OnboardingWizard.test.tsx
+++ b/tests/components/onboarding/OnboardingWizard.test.tsx
@@ -83,7 +83,7 @@ describe("OnboardingWizard", () => {
         },
       });
     } else {
-      vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {});
+      vi.spyOn(localStorage, "setItem").mockImplementation(() => {});
     }
   });
 

--- a/tests/components/onboarding/RepoSelector.test.tsx
+++ b/tests/components/onboarding/RepoSelector.test.tsx
@@ -312,4 +312,33 @@ describe("RepoSelector", () => {
     expect(orgHeaders[0].textContent).toBe("stale-org");
     expect(orgHeaders[1].textContent).toBe("active-org");
   });
+
+  it("each org group has a scroll container with data-testid=repo-scroll-{org}", async () => {
+    vi.mocked(api.fetchRepos).mockImplementation((_client, org) => {
+      if (org === "myorg") return Promise.resolve(myorgRepos);
+      return Promise.resolve(otherorgRepos);
+    });
+    render(() => (
+      <RepoSelector selectedOrgs={["myorg", "otherog"]} selected={[]} onChange={vi.fn()} />
+    ));
+    await waitFor(() => {
+      screen.getByText("repo-a");
+      screen.getByText("repo-c");
+    });
+    expect(screen.getByTestId("repo-scroll-myorg")).toBeDefined();
+    expect(screen.getByTestId("repo-scroll-otherog")).toBeDefined();
+  });
+
+  it("scroll container has max-h-[300px] and overflow-y-auto classes", async () => {
+    vi.mocked(api.fetchRepos).mockResolvedValue(myorgRepos);
+    render(() => (
+      <RepoSelector selectedOrgs={["myorg"]} selected={[]} onChange={vi.fn()} />
+    ));
+    await waitFor(() => {
+      screen.getByText("repo-a");
+    });
+    const scrollContainer = screen.getByTestId("repo-scroll-myorg");
+    expect(scrollContainer.classList.contains("max-h-[300px]")).toBe(true);
+    expect(scrollContainer.classList.contains("overflow-y-auto")).toBe(true);
+  });
 });

--- a/tests/components/onboarding/RepoSelector.test.tsx
+++ b/tests/components/onboarding/RepoSelector.test.tsx
@@ -313,7 +313,7 @@ describe("RepoSelector", () => {
     expect(orgHeaders[1].textContent).toBe("active-org");
   });
 
-  it("each org group has a scroll container with data-testid=repo-scroll-{org}", async () => {
+  it("each org group has a scrollable region with aria-label", async () => {
     vi.mocked(api.fetchRepos).mockImplementation((_client, org) => {
       if (org === "myorg") return Promise.resolve(myorgRepos);
       return Promise.resolve(otherorgRepos);
@@ -325,8 +325,8 @@ describe("RepoSelector", () => {
       screen.getByText("repo-a");
       screen.getByText("repo-c");
     });
-    expect(screen.getByTestId("repo-scroll-myorg")).toBeDefined();
-    expect(screen.getByTestId("repo-scroll-otherog")).toBeDefined();
+    screen.getByRole("region", { name: "myorg repositories" });
+    screen.getByRole("region", { name: "otherog repositories" });
   });
 
   it("scroll container has max-h-[300px] and overflow-y-auto classes", async () => {
@@ -337,8 +337,28 @@ describe("RepoSelector", () => {
     await waitFor(() => {
       screen.getByText("repo-a");
     });
-    const scrollContainer = screen.getByTestId("repo-scroll-myorg");
+    const scrollContainer = screen.getByRole("region", { name: "myorg repositories" });
     expect(scrollContainer.classList.contains("max-h-[300px]")).toBe(true);
     expect(scrollContainer.classList.contains("overflow-y-auto")).toBe(true);
+  });
+
+  it("skips internal fetchOrgs when orgEntries prop is provided", async () => {
+    vi.mocked(api.fetchOrgs).mockClear();
+    vi.mocked(api.fetchRepos).mockResolvedValue(myorgRepos);
+    const preloaded = [
+      { login: "myorg", avatarUrl: "", type: "org" as const },
+    ];
+    render(() => (
+      <RepoSelector
+        selectedOrgs={["myorg"]}
+        orgEntries={preloaded}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+    await waitFor(() => {
+      screen.getByText("repo-a");
+    });
+    expect(api.fetchOrgs).not.toHaveBeenCalled();
   });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -33,7 +33,7 @@ vi.mock("../../../src/app/stores/cache", () => ({
 }));
 
 vi.mock("../../../src/app/services/github", () => ({
-  getClient: () => ({}),
+  getClient: vi.fn(() => ({})),
 }));
 
 vi.mock("../../../src/app/services/api", () => ({
@@ -143,7 +143,6 @@ describe("SettingsPage — rendering", () => {
   it("renders a back to dashboard link", () => {
     renderSettings();
     const backLink = screen.getByRole("link", { name: /back to dashboard/i });
-    expect(backLink).toBeDefined();
     expect(backLink.getAttribute("href")).toBe("/dashboard");
   });
 
@@ -193,8 +192,7 @@ describe("SettingsPage — rendering", () => {
 describe("SettingsPage — Refresh interval", () => {
   it("shows current refresh interval value", () => {
     renderSettings();
-    const select = screen.getByDisplayValue("5 minutes (default)");
-    expect(select).toBeDefined();
+    screen.getByDisplayValue("5 minutes (default)");
   });
 
   it("changing refresh interval calls updateConfig", async () => {
@@ -284,6 +282,8 @@ describe("SettingsPage — GitHub Actions", () => {
     expect(workflowInput).toBeDefined();
   });
 
+  // NumberInput uses onInput — fireEvent.input sets the value atomically, while
+  // userEvent.type fires per-keystroke triggering intermediate valid values.
   it("changing max workflows per repo updates config", () => {
     renderSettings();
     const inputs = screen.getAllByRole("spinbutton");
@@ -557,14 +557,18 @@ describe("SettingsPage — Re-auth button", () => {
     vi.unstubAllEnvs();
   });
 
-  it("'Grant more orgs' button is disabled after click (reentrancy guard)", async () => {
-    const user = userEvent.setup();
+  it("'Grant more orgs' button is disabled after click and re-enables after timeout", async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
     renderSettings();
     const btn = screen.getByRole("button", { name: "Grant more orgs" });
     await user.click(btn);
     expect(btn.hasAttribute("disabled")).toBe(true);
+    vi.advanceTimersByTime(3000);
+    expect(btn.hasAttribute("disabled")).toBe(false);
     vi.unstubAllEnvs();
+    vi.useRealTimers();
   });
 });
 
@@ -613,6 +617,30 @@ describe("SettingsPage — Auto-merge orgs on mount", () => {
   it("does not call fetchOrgs when MERGE_ORGS_KEY is not in sessionStorage", () => {
     // No MERGE_ORGS_KEY set
     renderSettings();
+    expect(apiModule.fetchOrgs).not.toHaveBeenCalled();
+  });
+
+  it("silently handles fetchOrgs rejection without breaking", async () => {
+    sessionStorage.setItem(MERGE_ORGS_KEY, "true");
+    updateConfig({ selectedOrgs: ["existing-org"] });
+    vi.mocked(apiModule.fetchOrgs).mockRejectedValue(new Error("Network error"));
+    renderSettings();
+    await waitFor(() => {
+      expect(apiModule.fetchOrgs).toHaveBeenCalled();
+    });
+    // Config unchanged — error was swallowed
+    expect(config.selectedOrgs).toEqual(["existing-org"]);
+  });
+
+  it("skips merge when getClient returns null", async () => {
+    sessionStorage.setItem(MERGE_ORGS_KEY, "true");
+    const github = await import("../../../src/app/services/github");
+    vi.mocked(github.getClient).mockReturnValueOnce(null);
+    renderSettings();
+    // MERGE_ORGS_KEY still removed synchronously before mergeNewOrgs
+    await waitFor(() => {
+      expect(sessionStorage.getItem(MERGE_ORGS_KEY)).toBeNull();
+    });
     expect(apiModule.fetchOrgs).not.toHaveBeenCalled();
   });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -48,7 +48,9 @@ import { MemoryRouter, Route } from "@solidjs/router";
 import SettingsPage from "../../../src/app/components/settings/SettingsPage";
 import * as authStore from "../../../src/app/stores/auth";
 import * as cacheStore from "../../../src/app/stores/cache";
+import * as apiModule from "../../../src/app/services/api";
 import { updateConfig, config } from "../../../src/app/stores/config";
+import { MERGE_ORGS_KEY, OAUTH_STATE_KEY } from "../../../src/app/lib/oauth";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -102,10 +104,18 @@ beforeEach(() => {
     selectedRepos: [],
   });
 
-  // Mock window.location.reload
+  // Clear sessionStorage — re-auth tests set MERGE_ORGS_KEY and OAUTH_STATE_KEY
+  sessionStorage.clear();
+
+  // Mock window.location with both reload and href
   Object.defineProperty(window, "location", {
-    value: { ...window.location, reload: vi.fn() },
+    configurable: true,
     writable: true,
+    value: {
+      reload: vi.fn(),
+      href: "",
+      origin: "http://localhost",
+    },
   });
 
   // Clear localStorage
@@ -508,5 +518,101 @@ describe("SettingsPage — Theme application", () => {
     updateConfig({ theme: "system" });
     renderSettings();
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+});
+
+describe("SettingsPage — Re-auth button", () => {
+  it("renders 'Grant more orgs' button in Organizations & Repositories section", () => {
+    renderSettings();
+    screen.getByRole("button", { name: "Grant more orgs" });
+  });
+
+  it("clicking 'Grant more orgs' sets MERGE_ORGS_KEY in sessionStorage", async () => {
+    const user = userEvent.setup();
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+    renderSettings();
+    const btn = screen.getByRole("button", { name: "Grant more orgs" });
+    await user.click(btn);
+    expect(sessionStorage.getItem(MERGE_ORGS_KEY)).toBe("true");
+    vi.unstubAllEnvs();
+  });
+
+  it("clicking 'Grant more orgs' sets window.location.href to GitHub authorize URL", async () => {
+    const user = userEvent.setup();
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+    renderSettings();
+    const btn = screen.getByRole("button", { name: "Grant more orgs" });
+    await user.click(btn);
+    expect(window.location.href).toContain("https://github.com/login/oauth/authorize");
+    vi.unstubAllEnvs();
+  });
+
+  it("clicking 'Grant more orgs' also sets OAUTH_STATE_KEY in sessionStorage", async () => {
+    const user = userEvent.setup();
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+    renderSettings();
+    const btn = screen.getByRole("button", { name: "Grant more orgs" });
+    await user.click(btn);
+    expect(sessionStorage.getItem(OAUTH_STATE_KEY)).toBeTruthy();
+    vi.unstubAllEnvs();
+  });
+
+  it("'Grant more orgs' button is disabled after click (reentrancy guard)", async () => {
+    const user = userEvent.setup();
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+    renderSettings();
+    const btn = screen.getByRole("button", { name: "Grant more orgs" });
+    await user.click(btn);
+    expect(btn.hasAttribute("disabled")).toBe(true);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("SettingsPage — Auto-merge orgs on mount", () => {
+  it("calls fetchOrgs and merges new orgs when MERGE_ORGS_KEY is in sessionStorage", async () => {
+    sessionStorage.setItem(MERGE_ORGS_KEY, "true");
+    updateConfig({ selectedOrgs: ["existing-org"] });
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue([
+      { login: "existing-org", avatarUrl: "", type: "org" },
+      { login: "new-org", avatarUrl: "", type: "org" },
+    ]);
+    renderSettings();
+    await waitFor(() => {
+      expect(apiModule.fetchOrgs).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(config.selectedOrgs).toContain("new-org");
+    });
+  });
+
+  it("preserves existing selectedOrgs when merging", async () => {
+    sessionStorage.setItem(MERGE_ORGS_KEY, "true");
+    updateConfig({ selectedOrgs: ["existing-org"] });
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue([
+      { login: "existing-org", avatarUrl: "", type: "org" },
+      { login: "new-org", avatarUrl: "", type: "org" },
+    ]);
+    renderSettings();
+    await waitFor(() => {
+      expect(config.selectedOrgs).toContain("existing-org");
+    });
+  });
+
+  it("removes MERGE_ORGS_KEY from sessionStorage after processing", async () => {
+    sessionStorage.setItem(MERGE_ORGS_KEY, "true");
+    updateConfig({ selectedOrgs: [] });
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue([
+      { login: "new-org", avatarUrl: "", type: "org" },
+    ]);
+    renderSettings();
+    await waitFor(() => {
+      expect(sessionStorage.getItem(MERGE_ORGS_KEY)).toBeNull();
+    });
+  });
+
+  it("does not call fetchOrgs when MERGE_ORGS_KEY is not in sessionStorage", () => {
+    // No MERGE_ORGS_KEY set
+    renderSettings();
+    expect(apiModule.fetchOrgs).not.toHaveBeenCalled();
   });
 });

--- a/tests/lib/oauth.test.ts
+++ b/tests/lib/oauth.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  generateOAuthState,
+  buildAuthorizeUrl,
+  OAUTH_STATE_KEY,
+  OAUTH_RETURN_TO_KEY,
+} from "../../src/app/lib/oauth";
+
+describe("oauth helpers", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "", origin: "http://localhost" },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("generateOAuthState", () => {
+    it("returns a non-empty string", () => {
+      const state = generateOAuthState();
+      expect(state).toBeTruthy();
+      expect(state.length).toBeGreaterThan(0);
+    });
+
+    it("returns a base64url string — no +, /, or = characters", () => {
+      const state = generateOAuthState();
+      expect(state).not.toMatch(/[+/=]/);
+    });
+
+    it("generates unique values each call", () => {
+      const s1 = generateOAuthState();
+      const s2 = generateOAuthState();
+      expect(s1).not.toBe(s2);
+    });
+  });
+
+  describe("buildAuthorizeUrl", () => {
+    it("stores state in sessionStorage under OAUTH_STATE_KEY", () => {
+      buildAuthorizeUrl();
+      expect(sessionStorage.getItem(OAUTH_STATE_KEY)).toBeTruthy();
+    });
+
+    it("stores returnTo in sessionStorage when provided", () => {
+      buildAuthorizeUrl({ returnTo: "/settings" });
+      expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBe("/settings");
+    });
+
+    it("does not set OAUTH_RETURN_TO_KEY when returnTo not provided", () => {
+      buildAuthorizeUrl();
+      expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+    });
+
+    it("clears a pre-existing OAUTH_RETURN_TO_KEY when returnTo not provided", () => {
+      sessionStorage.setItem(OAUTH_RETURN_TO_KEY, "/settings");
+      buildAuthorizeUrl();
+      expect(sessionStorage.getItem(OAUTH_RETURN_TO_KEY)).toBeNull();
+    });
+
+    it("URL contains client_id param", () => {
+      const url = new URL(buildAuthorizeUrl());
+      expect(url.searchParams.get("client_id")).toBe("test-client-id");
+    });
+
+    it("URL contains redirect_uri param with /oauth/callback", () => {
+      const url = new URL(buildAuthorizeUrl());
+      expect(url.searchParams.get("redirect_uri")).toContain("/oauth/callback");
+    });
+
+    it("URL contains scope param", () => {
+      const url = new URL(buildAuthorizeUrl());
+      expect(url.searchParams.get("scope")).toBeTruthy();
+    });
+
+    it("scope value is 'repo read:org notifications'", () => {
+      const url = new URL(buildAuthorizeUrl());
+      expect(url.searchParams.get("scope")).toBe("repo read:org notifications");
+    });
+
+    it("URL contains state param matching sessionStorage", () => {
+      const url = new URL(buildAuthorizeUrl());
+      const urlState = url.searchParams.get("state");
+      const storedState = sessionStorage.getItem(OAUTH_STATE_KEY);
+      expect(urlState).toBeTruthy();
+      expect(urlState).toBe(storedState);
+    });
+
+    it("URL points to GitHub authorize endpoint", () => {
+      const url = buildAuthorizeUrl();
+      expect(url).toContain("https://github.com/login/oauth/authorize");
+    });
+  });
+});

--- a/tests/lib/oauth.test.ts
+++ b/tests/lib/oauth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   generateOAuthState,
   buildAuthorizeUrl,
+  sanitizeReturnTo,
   OAUTH_STATE_KEY,
   OAUTH_RETURN_TO_KEY,
 } from "../../src/app/lib/oauth";
@@ -93,6 +94,34 @@ describe("oauth helpers", () => {
     it("URL points to GitHub authorize endpoint", () => {
       const url = buildAuthorizeUrl();
       expect(url).toContain("https://github.com/login/oauth/authorize");
+    });
+  });
+
+  describe("sanitizeReturnTo", () => {
+    it("accepts internal paths", () => {
+      expect(sanitizeReturnTo("/settings")).toBe("/settings");
+      expect(sanitizeReturnTo("/dashboard")).toBe("/dashboard");
+      expect(sanitizeReturnTo("/")).toBe("/");
+    });
+
+    it("rejects absolute URLs", () => {
+      expect(sanitizeReturnTo("https://evil.com")).toBe("/");
+    });
+
+    it("rejects protocol-relative URLs", () => {
+      expect(sanitizeReturnTo("//evil.com")).toBe("/");
+    });
+
+    it("rejects javascript: URIs", () => {
+      expect(sanitizeReturnTo("javascript:alert(1)")).toBe("/");
+    });
+
+    it("returns / for null", () => {
+      expect(sanitizeReturnTo(null)).toBe("/");
+    });
+
+    it("returns / for empty string", () => {
+      expect(sanitizeReturnTo("")).toBe("/");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Collapses 2-step onboarding wizard to single-step repo selection with auto-fetched orgs
- Adds re-auth flow in Settings with auto-merge of newly accessible organizations
- Extracts OAuth helpers to shared module with returnTo redirect and open-redirect protection