### PR TITLE
chore: removes WAF bypass token (BFM disabled)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,6 @@ jobs:
         run: node scripts/verify-csp-hash.mjs
       - name: WAF smoke tests
         run: pnpm test:waf
-        env:
-          WAF_BYPASS_TOKEN: ${{ secrets.WAF_BYPASS_TOKEN }}
       - run: pnpm run build
         env:
           VITE_GITHUB_CLIENT_ID: ${{ vars.VITE_GITHUB_CLIENT_ID }}

--- a/scripts/waf-smoke-test.sh
+++ b/scripts/waf-smoke-test.sh
@@ -14,14 +14,6 @@ BASE="https://gh.gordoncode.dev"
 PASS=0
 FAIL=0
 
-# When WAF_BYPASS_TOKEN is set (CI), send a header that a Cloudflare WAF rule
-# uses to skip Bot Fight Mode for this request. Without it (local dev), requests
-# pass through normally since residential IPs aren't challenged.
-BYPASS=()
-if [[ -n "${WAF_BYPASS_TOKEN:-}" ]]; then
-  BYPASS=(-H "X-CI-Bypass: ${WAF_BYPASS_TOKEN}")
-fi
-
 assert_status() {
   local expected="$1" actual="$2" label="$3"
   if [[ "$actual" == "$expected" ]]; then
@@ -34,7 +26,7 @@ assert_status() {
 }
 
 fetch() {
-  curl -s -o /dev/null -w "%{http_code}" "${BYPASS[@]}" "$@"
+  curl -s -o /dev/null -w "%{http_code}" "$@"
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Removes WAF_BYPASS_TOKEN env var from deploy workflow (Bot Fight Mode disabled, bypass unnecessary)
- Removes bypass header logic from WAF smoke test script