### PR TITLE
feat: adds expand/collapse persistence and toolbar buttons

### DIFF
--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -1,14 +1,15 @@
-import { createMemo, For, Show } from "solid-js";
+import { createEffect, createMemo, For, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 import type { WorkflowRun } from "../../services/api";
 import { config } from "../../stores/config";
-import { viewState, setViewState, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, type ActionsFilterField } from "../../stores/view";
+import { viewState, setViewState, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, type ActionsFilterField } from "../../stores/view";
 import WorkflowSummaryCard from "./WorkflowSummaryCard";
 import IgnoreBadge from "./IgnoreBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import FilterChips from "../shared/FilterChips";
 import type { FilterChipGroupDef } from "../shared/FilterChips";
 import ChevronIcon from "../shared/ChevronIcon";
+import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 
 interface ActionsTabProps {
   workflowRuns: WorkflowRun[];
@@ -116,16 +117,21 @@ const actionsFilterGroups: FilterChipGroupDef[] = [
 ];
 
 export default function ActionsTab(props: ActionsTabProps) {
-  const [expandedRepos, setExpandedRepos] = createStore<Record<string, boolean>>({});
   const [expandedWorkflows, setExpandedWorkflows] = createStore<Record<string, boolean>>({});
-
-  function toggleRepo(repoFullName: string) {
-    setExpandedRepos(repoFullName, (v) => !v);
-  }
 
   function toggleWorkflow(key: string) {
     setExpandedWorkflows(key, (v) => !v);
   }
+
+  const activeRepoNames = createMemo(() =>
+    [...new Set(props.workflowRuns.map((r) => r.repoFullName))]
+  );
+
+  createEffect(() => {
+    const names = activeRepoNames();
+    if (names.length === 0) return;
+    pruneExpandedRepos("actions", names);
+  });
 
   function handleIgnore(run: WorkflowRun) {
     ignoreItem({
@@ -180,7 +186,7 @@ export default function ActionsTab(props: ActionsTabProps) {
   return (
     <div class="divide-y divide-base-300">
       {/* Toolbar */}
-      <div class="flex flex-wrap items-center gap-3 px-4 py-2 bg-base-100">
+      <div class="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
         <label class="flex items-center gap-1.5 text-sm text-base-content/70 cursor-pointer select-none">
           <input
             type="checkbox"
@@ -198,6 +204,10 @@ export default function ActionsTab(props: ActionsTabProps) {
           onResetAll={() => resetAllTabFilters("actions")}
         />
         <div class="flex-1" />
+        <ExpandCollapseButtons
+          onExpandAll={() => setAllExpanded("actions", repoGroups().map((g) => g.repoFullName), true)}
+          onCollapseAll={() => setAllExpanded("actions", repoGroups().map((g) => g.repoFullName), false)}
+        />
         <IgnoreBadge
           items={viewState.ignoredItems.filter((i) => i.type === "workflowRun")}
           onUnignore={unignoreItem}
@@ -224,7 +234,7 @@ export default function ActionsTab(props: ActionsTabProps) {
       <Show when={repoGroups().length > 0}>
         <For each={repoGroups()}>
           {(repoGroup) => {
-            const isExpanded = () => !!expandedRepos[repoGroup.repoFullName];
+            const isExpanded = () => !!viewState.expandedRepos.actions[repoGroup.repoFullName];
 
             const sortedWorkflows = createMemo(() =>
               sortWorkflowsByStatus(repoGroup.workflows)
@@ -249,7 +259,7 @@ export default function ActionsTab(props: ActionsTabProps) {
               <div class="bg-base-100">
                 {/* Repo header */}
                 <button
-                  onClick={() => toggleRepo(repoGroup.repoFullName)}
+                  onClick={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
                   aria-expanded={isExpanded()}
                   class="w-full flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors"
                 >

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -1,7 +1,6 @@
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
-import { createStore } from "solid-js/store";
 import { config } from "../../stores/config";
-import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, type IssueFilterField } from "../../stores/view";
+import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, type IssueFilterField } from "../../stores/view";
 import type { Issue } from "../../services/api";
 import ItemRow from "./ItemRow";
 import IgnoreBadge from "./IgnoreBadge";
@@ -13,6 +12,7 @@ import type { FilterChipGroupDef } from "../shared/FilterChips";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
+import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import { deriveInvolvementRoles } from "../../lib/format";
 import { groupByRepo, computePageLayout, slicePageGroups } from "../../lib/grouping";
 
@@ -54,11 +54,6 @@ const sortOptions: SortOption[] = [
 
 export default function IssuesTab(props: IssuesTabProps) {
   const [page, setPage] = createSignal(0);
-  const [expandedRepos, setExpandedRepos] = createStore<Record<string, boolean>>({});
-
-  function toggleRepo(repoFullName: string) {
-    setExpandedRepos(repoFullName, (v) => !v);
-  }
 
   const sortPref = createMemo(() => {
     const pref = viewState.sortPreferences["issues"];
@@ -141,14 +136,14 @@ export default function IssuesTab(props: IssuesTabProps) {
     if (page() > max) setPage(max);
   });
 
-  // Auto-expand first group on initial mount
-  let hasAutoExpanded = false;
+  const activeRepoNames = createMemo(() =>
+    [...new Set(props.issues.map((i) => i.repoFullName))]
+  );
+
   createEffect(() => {
-    const groups = pageGroups();
-    if (!hasAutoExpanded && groups.length > 0) {
-      hasAutoExpanded = true;
-      setExpandedRepos(groups[0].repoFullName, true);
-    }
+    const names = activeRepoNames();
+    if (names.length === 0) return;
+    pruneExpandedRepos("issues", names);
   });
 
   function handleSort(field: string, direction: "asc" | "desc") {
@@ -193,6 +188,10 @@ export default function IssuesTab(props: IssuesTabProps) {
           }}
         />
         <div class="flex-1" />
+        <ExpandCollapseButtons
+          onExpandAll={() => setAllExpanded("issues", repoGroups().map((g) => g.repoFullName), true)}
+          onCollapseAll={() => setAllExpanded("issues", repoGroups().map((g) => g.repoFullName), false)}
+        />
         <IgnoreBadge
           items={viewState.ignoredItems.filter((i) => i.type === "issue")}
           onUnignore={unignoreItem}
@@ -234,7 +233,7 @@ export default function IssuesTab(props: IssuesTabProps) {
           <div class="divide-y divide-base-300">
             <For each={pageGroups()}>
               {(repoGroup) => {
-                const isExpanded = () => !!expandedRepos[repoGroup.repoFullName];
+                const isExpanded = () => !!viewState.expandedRepos.issues[repoGroup.repoFullName];
 
                 const roleSummary = createMemo(() => {
                   const counts: Record<string, number> = {};
@@ -252,7 +251,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                 return (
                   <div class="bg-base-100">
                     <button
-                      onClick={() => toggleRepo(repoGroup.repoFullName)}
+                      onClick={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
                       aria-expanded={isExpanded()}
                       class="w-full flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors"
                     >

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -35,7 +35,7 @@ export default function ItemRow(props: ItemRowProps) {
             href={url()}
             target="_blank"
             rel="noopener noreferrer"
-            class="absolute inset-0"
+            class="absolute inset-0 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset rounded"
             aria-label={`${props.repo} #${props.number}: ${props.title}`}
           />
         )}

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -1,5 +1,5 @@
 import { For, JSX, Show } from "solid-js";
-import { openGitHubUrl } from "../../lib/url";
+import { isSafeGitHubUrl } from "../../lib/url";
 import { relativeTime, labelTextColor, formatCount } from "../../lib/format";
 
 export interface ItemRowProps {
@@ -19,27 +19,13 @@ export interface ItemRowProps {
 
 export default function ItemRow(props: ItemRowProps) {
   const isCompact = () => props.density === "compact";
-
-  function handleRowClick(e: MouseEvent) {
-    // Only open if click was not on the ignore button
-    if ((e.target as HTMLElement).closest("[data-ignore-btn]")) return;
-    openGitHubUrl(props.url);
-  }
+  const safeUrl = () => isSafeGitHubUrl(props.url) ? props.url : undefined;
 
   return (
     <div
-      role="row"
-      tabIndex={0}
-      onClick={handleRowClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          openGitHubUrl(props.url);
-        }
-      }}
-      class={`group relative flex items-start gap-3 cursor-pointer
+      class={`group relative flex items-start gap-3
         hover:bg-base-200
-        transition-colors focus:outline-none focus:bg-base-200 focus-visible:ring-2 focus-visible:ring-primary
+        transition-colors
         ${isCompact() ? "px-4 py-2" : "px-4 py-3"}`}
     >
       {/* Repo badge */}
@@ -60,9 +46,14 @@ export default function ItemRow(props: ItemRowProps) {
           <span class="text-base-content/60 shrink-0">
             #{props.number}
           </span>
-          <span class="font-medium text-base-content truncate">
+          <a
+            href={safeUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-medium text-base-content truncate after:absolute after:inset-0"
+          >
             {props.title}
-          </span>
+          </a>
         </div>
 
         {/* Labels row */}
@@ -119,11 +110,8 @@ export default function ItemRow(props: ItemRowProps) {
       {/* Ignore button — visible on hover */}
       <button
         data-ignore-btn
-        onClick={(e) => {
-          e.stopPropagation();
-          props.onIgnore();
-        }}
-        class={`shrink-0 self-center rounded p-1
+        onClick={() => props.onIgnore()}
+        class={`relative z-10 shrink-0 self-center rounded p-1
           text-base-content/30
           hover:text-error
           opacity-0 group-hover:opacity-100 focus:opacity-100

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -28,6 +28,19 @@ export default function ItemRow(props: ItemRowProps) {
         transition-colors
         ${isCompact() ? "px-4 py-2" : "px-4 py-3"}`}
     >
+      {/* Overlay link — covers entire row; interactive children use relative z-10 */}
+      <Show when={safeUrl()}>
+        {(url) => (
+          <a
+            href={url()}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="absolute inset-0"
+            aria-label={`${props.repo} #${props.number}: ${props.title}`}
+          />
+        )}
+      </Show>
+
       {/* Repo badge */}
       <Show when={!props.hideRepo}>
         <span
@@ -46,14 +59,9 @@ export default function ItemRow(props: ItemRowProps) {
           <span class="text-base-content/60 shrink-0">
             #{props.number}
           </span>
-          <a
-            href={safeUrl()}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="font-medium text-base-content truncate after:absolute after:inset-0"
-          >
+          <span class="font-medium text-base-content truncate">
             {props.title}
-          </a>
+          </span>
         </div>
 
         {/* Labels row */}
@@ -77,9 +85,9 @@ export default function ItemRow(props: ItemRowProps) {
           </div>
         </Show>
 
-        {/* Additional children slot */}
+        {/* Additional children slot — z-10 to sit above stretched link */}
         <Show when={props.children !== undefined}>
-          <div class={isCompact() ? "mt-0.5" : "mt-1"}>{props.children}</div>
+          <div class={`relative z-10 ${isCompact() ? "mt-0.5" : "mt-1"}`}>{props.children}</div>
         </Show>
       </div>
 

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -1,9 +1,9 @@
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
-import { createStore } from "solid-js/store";
 import { config } from "../../stores/config";
-import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, type PullRequestFilterField } from "../../stores/view";
+import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, type PullRequestFilterField } from "../../stores/view";
 import type { PullRequest } from "../../services/api";
 import { deriveInvolvementRoles, prSizeCategory } from "../../lib/format";
+import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import ItemRow from "./ItemRow";
 import StatusDot from "../shared/StatusDot";
 import IgnoreBadge from "./IgnoreBadge";
@@ -119,11 +119,6 @@ const sortOptions: SortOption[] = [
 
 export default function PullRequestsTab(props: PullRequestsTabProps) {
   const [page, setPage] = createSignal(0);
-  const [expandedRepos, setExpandedRepos] = createStore<Record<string, boolean>>({});
-
-  function toggleRepo(repoFullName: string) {
-    setExpandedRepos(repoFullName, (v) => !v);
-  }
 
   const sortPref = createMemo(() => {
     const pref = viewState.sortPreferences["pullRequests"];
@@ -230,14 +225,14 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     if (page() > max) setPage(max);
   });
 
-  // Auto-expand first group on initial load
-  let hasAutoExpanded = false;
+  const activeRepoNames = createMemo(() =>
+    [...new Set(props.pullRequests.map((pr) => pr.repoFullName))]
+  );
+
   createEffect(() => {
-    const groups = pageGroups();
-    if (!hasAutoExpanded && groups.length > 0) {
-      hasAutoExpanded = true;
-      setExpandedRepos(groups[0].repoFullName, true);
-    }
+    const names = activeRepoNames();
+    if (names.length === 0) return;
+    pruneExpandedRepos("pullRequests", names);
   });
 
   function handleSort(field: string, direction: "asc" | "desc") {
@@ -282,6 +277,10 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
           }}
         />
         <div class="flex-1" />
+        <ExpandCollapseButtons
+          onExpandAll={() => setAllExpanded("pullRequests", repoGroups().map((g) => g.repoFullName), true)}
+          onCollapseAll={() => setAllExpanded("pullRequests", repoGroups().map((g) => g.repoFullName), false)}
+        />
         <IgnoreBadge
           items={viewState.ignoredItems.filter((i) => i.type === "pullRequest")}
           onUnignore={unignoreItem}
@@ -323,7 +322,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
           <div class="divide-y divide-base-300">
             <For each={pageGroups()}>
               {(repoGroup) => {
-                const isExpanded = () => !!expandedRepos[repoGroup.repoFullName];
+                const isExpanded = () => !!viewState.expandedRepos.pullRequests[repoGroup.repoFullName];
 
                 const summaryMeta = createMemo(() => {
                   const checks = { success: 0, failure: 0, pending: 0, conflict: 0 };
@@ -354,7 +353,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                 return (
                   <div class="bg-base-100">
                     <button
-                      onClick={() => toggleRepo(repoGroup.repoFullName)}
+                      onClick={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
                       aria-expanded={isExpanded()}
                       class="w-full flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors"
                     >

--- a/src/app/components/shared/ExpandCollapseButtons.tsx
+++ b/src/app/components/shared/ExpandCollapseButtons.tsx
@@ -1,0 +1,53 @@
+export interface ExpandCollapseButtonsProps {
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
+}
+
+export default function ExpandCollapseButtons(props: ExpandCollapseButtonsProps) {
+  return (
+    <div class="flex items-center gap-1">
+      <button
+        class="btn btn-ghost btn-xs"
+        title="Expand all"
+        aria-label="Expand all"
+        onClick={() => props.onExpandAll()}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width={1.5}
+          stroke="currentColor"
+          class="h-4 w-4"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m4.5 5.25 7.5 7.5 7.5-7.5m-15 6 7.5 7.5 7.5-7.5"
+          />
+        </svg>
+      </button>
+      <button
+        class="btn btn-ghost btn-xs"
+        title="Collapse all"
+        aria-label="Collapse all"
+        onClick={() => props.onCollapseAll()}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width={1.5}
+          stroke="currentColor"
+          class="h-4 w-4"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m4.5 18.75 7.5-7.5 7.5 7.5m-15-6 7.5-7.5 7.5 7.5"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/app/components/shared/ExpandCollapseButtons.tsx
+++ b/src/app/components/shared/ExpandCollapseButtons.tsx
@@ -10,7 +10,7 @@ export default function ExpandCollapseButtons(props: ExpandCollapseButtonsProps)
         class="btn btn-ghost btn-xs"
         title="Expand all"
         aria-label="Expand all"
-        onClick={() => props.onExpandAll()}
+        onClick={props.onExpandAll}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -31,7 +31,7 @@ export default function ExpandCollapseButtons(props: ExpandCollapseButtonsProps)
         class="btn btn-ghost btn-xs"
         title="Collapse all"
         aria-label="Collapse all"
-        onClick={() => props.onCollapseAll()}
+        onClick={props.onCollapseAll}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createStore, produce } from "solid-js/store";
-import { createEffect, onCleanup } from "solid-js";
+import { createEffect, onCleanup, untrack } from "solid-js";
 
 export const VIEW_STORAGE_KEY = "github-tracker:view";
 
@@ -240,15 +240,15 @@ export function pruneExpandedRepos(
   tab: keyof ViewState["expandedRepos"],
   activeRepoNames: string[]
 ): void {
-  if (Object.keys(viewState.expandedRepos[tab]).length === 0) return;
+  const currentKeys = untrack(() => Object.keys(viewState.expandedRepos[tab]));
+  if (currentKeys.length === 0) return;
   const activeSet = new Set(activeRepoNames);
+  const staleKeys = currentKeys.filter((k) => !activeSet.has(k));
+  if (staleKeys.length === 0) return;
   setViewState(
     produce((draft) => {
-      const keys = Object.keys(draft.expandedRepos[tab]);
-      for (const key of keys) {
-        if (!activeSet.has(key)) {
-          delete draft.expandedRepos[tab][key];
-        }
+      for (const key of staleKeys) {
+        delete draft.expandedRepos[tab][key];
       }
     })
   );

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -102,8 +102,19 @@ export const [viewState, setViewState] = createStore<ViewState>(
 );
 
 export function resetViewState(): void {
-  const defaults = ViewStateSchema.parse({});
-  setViewState(defaults);
+  updateViewState({
+    lastActiveTab: "issues",
+    sortPreferences: {},
+    ignoredItems: [],
+    globalFilter: { org: null, repo: null },
+    tabFilters: {
+      issues: { role: "all", comments: "all" },
+      pullRequests: { role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all" },
+      actions: { conclusion: "all", event: "all" },
+    },
+    showPrRuns: false,
+    expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
+  });
 }
 
 export function updateViewState(partial: Partial<ViewState>): void {

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -69,6 +69,15 @@ export const ViewStateSchema = z.object({
     actions: { conclusion: "all", event: "all" },
   }),
   showPrRuns: z.boolean().default(false),
+  expandedRepos: z.object({
+    issues: z.record(z.string(), z.boolean()).default({}),
+    pullRequests: z.record(z.string(), z.boolean()).default({}),
+    actions: z.record(z.string(), z.boolean()).default({}),
+  }).default({
+    issues: {},
+    pullRequests: {},
+    actions: {},
+  }),
 });
 
 export type ViewState = z.infer<typeof ViewStateSchema>;
@@ -187,6 +196,59 @@ export function resetAllTabFilters(
         draft.tabFilters.pullRequests = PullRequestFiltersSchema.parse({});
       } else {
         draft.tabFilters.actions = ActionsFiltersSchema.parse({});
+      }
+    })
+  );
+}
+
+export function toggleExpandedRepo(
+  tab: keyof ViewState["expandedRepos"],
+  repoFullName: string
+): void {
+  setViewState(
+    produce((draft) => {
+      if (draft.expandedRepos[tab][repoFullName]) {
+        delete draft.expandedRepos[tab][repoFullName];
+      } else {
+        draft.expandedRepos[tab][repoFullName] = true;
+      }
+    })
+  );
+}
+
+export function setAllExpanded(
+  tab: keyof ViewState["expandedRepos"],
+  repoFullNames: string[],
+  expanded: boolean
+): void {
+  setViewState(
+    produce((draft) => {
+      if (expanded) {
+        for (const name of repoFullNames) {
+          draft.expandedRepos[tab][name] = true;
+        }
+      } else {
+        for (const name of repoFullNames) {
+          delete draft.expandedRepos[tab][name];
+        }
+      }
+    })
+  );
+}
+
+export function pruneExpandedRepos(
+  tab: keyof ViewState["expandedRepos"],
+  activeRepoNames: string[]
+): void {
+  if (Object.keys(viewState.expandedRepos[tab]).length === 0) return;
+  const activeSet = new Set(activeRepoNames);
+  setViewState(
+    produce((draft) => {
+      const keys = Object.keys(draft.expandedRepos[tab]);
+      for (const key of keys) {
+        if (!activeSet.has(key)) {
+          delete draft.expandedRepos[tab][key];
+        }
       }
     })
   );

--- a/tests/components/ActionsTab.test.tsx
+++ b/tests/components/ActionsTab.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import ActionsTab from "../../src/app/components/dashboard/ActionsTab";
 import * as viewStore from "../../src/app/stores/view";
+import { viewState } from "../../src/app/stores/view";
 import { makeWorkflowRun, resetViewStore } from "../helpers/index";
 
 beforeEach(() => {
@@ -294,5 +295,111 @@ describe("ActionsTab", () => {
     render(() => <ActionsTab workflowRuns={[]} />);
     screen.getByRole("checkbox");
     screen.getByText("Show PR runs");
+  });
+
+  it("Expand all button expands all repo groups", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo-a", workflowId: 1, name: "CI-A", displayTitle: "run-a" }),
+      makeWorkflowRun({ repoFullName: "owner/repo-b", workflowId: 2, name: "CI-B", displayTitle: "run-b" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+
+    // Both groups collapsed by default
+    expect(screen.queryByText("run-a")).toBeNull();
+    expect(screen.queryByText("run-b")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /Expand all/i }));
+
+    // After expand all, workflow names visible (repos expanded)
+    expect(screen.getAllByText("CI-A").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("CI-B").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Collapse all button collapses all repo groups", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo-a", workflowId: 1, name: "CI-A" }),
+      makeWorkflowRun({ repoFullName: "owner/repo-b", workflowId: 2, name: "CI-B" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+
+    // Expand all first
+    await user.click(screen.getByRole("button", { name: /Expand all/i }));
+    expect(screen.getAllByText("CI-A").length).toBeGreaterThanOrEqual(1);
+
+    // Collapse all
+    await user.click(screen.getByRole("button", { name: /Collapse all/i }));
+
+    // Repo groups collapsed — workflow names hidden
+    expect(screen.queryByText("CI-A")).toBeNull();
+    expect(screen.queryByText("CI-B")).toBeNull();
+  });
+
+  it("workflow card expansion is independent of repo-level expand/collapse all", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "CI", displayTitle: "my-unique-run" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+
+    // Expand repo
+    await user.click(screen.getByRole("button", { name: /Expand all/i }));
+    // Expand workflow card
+    const cards = screen.getAllByText("CI");
+    await user.click(cards[0]);
+    // Run row now visible
+    screen.getByText("my-unique-run");
+
+    // Collapse all repos, then expand again
+    await user.click(screen.getByRole("button", { name: /Collapse all/i }));
+    await user.click(screen.getByRole("button", { name: /Expand all/i }));
+
+    // Workflow card expansion is local state — it resets when repo collapses/re-renders
+    // The key assertion: repo expand/collapse does not affect workflow-level state in viewState
+    // (workflow state is local, not persisted)
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
+  });
+
+  it("expanded repo state persists in viewState", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "CI" }),
+    ];
+    render(() => <ActionsTab workflowRuns={runs} />);
+
+    // Initially not expanded
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBeFalsy();
+
+    // Click repo header to expand
+    await user.click(screen.getByText("owner/repo"));
+
+    // viewState updated
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
+
+    // Click again to collapse
+    await user.click(screen.getByText("owner/repo"));
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBeFalsy();
+  });
+
+  it("expanded state survives component unmount and remount", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "CI", displayTitle: "unique-title" }),
+    ];
+
+    // First render — expand repo
+    const { unmount } = render(() => <ActionsTab workflowRuns={runs} />);
+    await user.click(screen.getByText("owner/repo"));
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
+
+    // Unmount
+    unmount();
+
+    // Re-render — viewState persists so repo should still be expanded
+    render(() => <ActionsTab workflowRuns={runs} />);
+    // Workflow name visible means the repo group is expanded
+    expect(screen.getAllByText("CI").length).toBeGreaterThanOrEqual(1);
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
   });
 });

--- a/tests/components/ActionsTab.test.tsx
+++ b/tests/components/ActionsTab.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
 import ActionsTab from "../../src/app/components/dashboard/ActionsTab";
+import type { WorkflowRun } from "../../src/app/services/api";
 import * as viewStore from "../../src/app/stores/view";
 import { viewState } from "../../src/app/stores/view";
 import { makeWorkflowRun, resetViewStore } from "../helpers/index";
@@ -355,10 +357,41 @@ describe("ActionsTab", () => {
     await user.click(screen.getByRole("button", { name: /Collapse all/i }));
     await user.click(screen.getByRole("button", { name: /Expand all/i }));
 
-    // Workflow card expansion is local state — it resets when repo collapses/re-renders
-    // The key assertion: repo expand/collapse does not affect workflow-level state in viewState
-    // (workflow state is local, not persisted)
+    // Workflow card expansion is local component state (not persisted in viewState)
+    // It survives collapse/expand within the same mount because expandedWorkflows
+    // is at component scope, but would reset on full component remount
     expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
+    // Run row still visible — local store persists within same component instance
+    screen.getByText("my-unique-run");
+  });
+
+  it("prunes stale expanded keys when a repo disappears from data", () => {
+    const [runs, setRuns] = createSignal<WorkflowRun[]>([
+      makeWorkflowRun({ repoFullName: "owner/repo-a", workflowId: 1, name: "CI-A" }),
+      makeWorkflowRun({ repoFullName: "owner/repo-b", workflowId: 2, name: "CI-B" }),
+    ]);
+    viewStore.setAllExpanded("actions", ["owner/repo-a", "owner/repo-b"], true);
+    render(() => <ActionsTab workflowRuns={runs()} />);
+
+    // Remove repo-b from data — pruning effect should fire
+    setRuns([makeWorkflowRun({ repoFullName: "owner/repo-a", workflowId: 1, name: "CI-A" })]);
+    expect(viewState.expandedRepos.actions["owner/repo-a"]).toBe(true);
+    expect("owner/repo-b" in viewState.expandedRepos.actions).toBe(false);
+  });
+
+  it("preserves expanded keys when data becomes empty and restores UI on re-population", () => {
+    const [runs, setRuns] = createSignal<WorkflowRun[]>([
+      makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "CI" }),
+    ]);
+    viewStore.setAllExpanded("actions", ["owner/repo"], true);
+    render(() => <ActionsTab workflowRuns={runs()} />);
+
+    setRuns([]);
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
+
+    // Data returns — UI should use preserved expanded state
+    setRuns([makeWorkflowRun({ repoFullName: "owner/repo", workflowId: 1, name: "CI" })]);
+    expect(screen.getAllByText("CI").length).toBeGreaterThanOrEqual(1);
   });
 
   it("expanded repo state persists in viewState", async () => {

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -134,12 +134,7 @@ beforeEach(async () => {
     errors: [],
   });
   // Reset view store to defaults
-  viewStore.updateViewState({
-    lastActiveTab: "issues",
-    sortPreferences: {},
-    ignoredItems: [],
-    globalFilter: { org: null, repo: null },
-  });
+  viewStore.resetViewState();
 });
 
 describe("DashboardPage — tab switching", () => {

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -198,8 +198,9 @@ describe("DashboardPage — data flow", () => {
 
     render(() => <DashboardPage />);
     await waitFor(() => {
-      screen.getByText("Fetched issue alpha");
-      screen.getByText("Fetched issue beta");
+      // Repo group header visible (groups start collapsed — verify data reached the tab)
+      screen.getByText("owner/repo");
+      screen.getByText("2 issues");
     });
   });
 
@@ -219,8 +220,9 @@ describe("DashboardPage — data flow", () => {
     render(() => <DashboardPage />);
     await user.click(screen.getByText("Pull Requests"));
     await waitFor(() => {
-      screen.getByText("Fetched PR one");
-      screen.getByText("Fetched PR two");
+      // Repo group header visible (groups start collapsed — verify data reached the tab)
+      screen.getByText("owner/repo");
+      screen.getByText("2 PRs");
     });
   });
 
@@ -274,15 +276,17 @@ describe("DashboardPage — data flow", () => {
     vi.mocked(pollService.fetchAllData)
       .mockResolvedValueOnce({ issues, pullRequests: [], workflowRuns: [], errors: [] })
       .mockResolvedValue({ issues: [], pullRequests: [], workflowRuns: [], errors: [], skipped: true });
-
     render(() => <DashboardPage />);
     await waitFor(() => {
-      screen.getByText("Existing issue");
+      // Repo group header visible (collapsed — verify data reached the tab)
+      screen.getByText("owner/repo");
+      screen.getByText("1 issue");
     });
 
     // Trigger a second fetch via the captured callback — skipped result should not erase data
     await capturedFetchAll?.();
-    screen.getByText("Existing issue");
+    // Data still present (collapsed repo group summary persists)
+    screen.getByText("1 issue");
   });
 });
 
@@ -348,7 +352,9 @@ describe("DashboardPage — onAuthCleared integration", () => {
 
     render(() => <DashboardPage />);
     await waitFor(() => {
-      screen.getByText("Should be cleared");
+      // Repo group header visible (collapsed — verify data reached the tab)
+      screen.getByText("owner/repo");
+      screen.getByText("1 issue");
     });
 
     // DashboardPage registered an onAuthCleared callback at module scope.
@@ -359,9 +365,9 @@ describe("DashboardPage — onAuthCleared integration", () => {
     // The coordinator's destroy() should have been called
     expect(mockDestroy).toHaveBeenCalled();
 
-    // Dashboard data should be cleared — no stale items visible
+    // Dashboard data should be cleared — no stale repo groups visible
     await waitFor(() => {
-      expect(screen.queryByText("Should be cleared")).toBeNull();
+      expect(screen.queryByText("1 issue")).toBeNull();
     });
   });
 });

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -386,11 +386,11 @@ describe("DashboardPage — onHotData integration", () => {
       expect(capturedOnHotData).not.toBeNull();
     });
 
-    // Verify initial state shows pending
+    // Verify initial state shows pending (collapsed summary shows "1 PR" with pending count)
     const user = userEvent.setup();
     await user.click(screen.getByText("Pull Requests"));
     await waitFor(() => {
-      expect(screen.getByLabelText("Checks in progress")).toBeTruthy();
+      screen.getByText("1 PR");
     });
 
     // Simulate hot poll returning a status update (generation=0 matches default mock)
@@ -402,7 +402,8 @@ describe("DashboardPage — onHotData integration", () => {
     }]]);
     capturedOnHotData!(prUpdates, new Map(), 0);
 
-    // The StatusDot should update from "Checks in progress" to "All checks passed"
+    // Expand the repo to verify the StatusDot updated
+    await user.click(screen.getByText("owner/repo"));
     await waitFor(() => {
       expect(screen.getByLabelText("All checks passed")).toBeTruthy();
     });
@@ -427,6 +428,12 @@ describe("DashboardPage — onHotData integration", () => {
 
     const user = userEvent.setup();
     await user.click(screen.getByText("Pull Requests"));
+    await waitFor(() => {
+      screen.getByText("1 PR");
+    });
+
+    // Expand repo to see StatusDot
+    await user.click(screen.getByText("owner/repo"));
     await waitFor(() => {
       expect(screen.getByLabelText("Checks in progress")).toBeTruthy();
     });

--- a/tests/components/ExpandCollapseButtons.test.tsx
+++ b/tests/components/ExpandCollapseButtons.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+import ExpandCollapseButtons from "../../src/app/components/shared/ExpandCollapseButtons";
+
+describe("ExpandCollapseButtons", () => {
+  it("renders both buttons with correct aria-labels", () => {
+    render(() => <ExpandCollapseButtons onExpandAll={() => {}} onCollapseAll={() => {}} />);
+    expect(screen.getByRole("button", { name: "Expand all" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Collapse all" })).toBeTruthy();
+  });
+
+  it("calls onExpandAll when expand button is clicked", () => {
+    const onExpandAll = vi.fn();
+    render(() => <ExpandCollapseButtons onExpandAll={onExpandAll} onCollapseAll={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+    expect(onExpandAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCollapseAll when collapse button is clicked", () => {
+    const onCollapseAll = vi.fn();
+    render(() => <ExpandCollapseButtons onExpandAll={() => {}} onCollapseAll={onCollapseAll} />);
+    fireEvent.click(screen.getByRole("button", { name: "Collapse all" }));
+    expect(onCollapseAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/ExpandCollapseButtons.test.tsx
+++ b/tests/components/ExpandCollapseButtons.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
 import ExpandCollapseButtons from "../../src/app/components/shared/ExpandCollapseButtons";
 
 describe("ExpandCollapseButtons", () => {
@@ -9,17 +10,19 @@ describe("ExpandCollapseButtons", () => {
     expect(screen.getByRole("button", { name: "Collapse all" })).toBeTruthy();
   });
 
-  it("calls onExpandAll when expand button is clicked", () => {
+  it("calls onExpandAll when expand button is clicked", async () => {
+    const user = userEvent.setup();
     const onExpandAll = vi.fn();
     render(() => <ExpandCollapseButtons onExpandAll={onExpandAll} onCollapseAll={() => {}} />);
-    fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+    await user.click(screen.getByRole("button", { name: "Expand all" }));
     expect(onExpandAll).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onCollapseAll when collapse button is clicked", () => {
+  it("calls onCollapseAll when collapse button is clicked", async () => {
+    const user = userEvent.setup();
     const onCollapseAll = vi.fn();
     render(() => <ExpandCollapseButtons onExpandAll={() => {}} onCollapseAll={onCollapseAll} />);
-    fireEvent.click(screen.getByRole("button", { name: "Collapse all" }));
+    await user.click(screen.getByRole("button", { name: "Collapse all" }));
     expect(onCollapseAll).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -489,4 +489,30 @@ describe("IssuesTab", () => {
     // State persisted in viewState store — should still be expanded
     screen.getByText("Survives remount");
   });
+
+  it("clicking 'Expand all' expands repos on other pages too", async () => {
+    const user = userEvent.setup();
+    updateConfig({ itemsPerPage: 10 });
+    const issues = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeIssue({ id: 100 + i, title: `Repo A issue ${i}`, repoFullName: "org/repo-a" })
+      ),
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeIssue({ id: 200 + i, title: `Repo B issue ${i}`, repoFullName: "org/repo-b" })
+      ),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    // Page 1 shows repo-a, page 2 shows repo-b
+    screen.getByText(/Page 1 of 2/);
+
+    // Expand all — affects repos on ALL pages
+    await user.click(screen.getByLabelText("Expand all"));
+    // Repo-a items visible on page 1
+    screen.getByText("Repo A issue 0");
+
+    // Navigate to page 2 — repo-b should already be expanded
+    await user.click(screen.getByLabelText("Next page"));
+    screen.getByText("org/repo-b");
+    screen.getByText("Repo B issue 0");
+  });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -6,6 +6,7 @@ import IssuesTab from "../../src/app/components/dashboard/IssuesTab";
 import type { Issue } from "../../src/app/services/api";
 import { makeIssue, resetViewStore } from "../helpers/index";
 import * as viewStore from "../../src/app/stores/view";
+import { setAllExpanded, viewState } from "../../src/app/stores/view";
 import { updateConfig, resetConfig } from "../../src/app/stores/config";
 
 beforeEach(() => {
@@ -19,6 +20,7 @@ describe("IssuesTab", () => {
       makeIssue({ number: 1, title: "First issue" }),
       makeIssue({ number: 2, title: "Second issue" }),
     ];
+    setAllExpanded("issues", ["owner/repo"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     screen.getByText("First issue");
     screen.getByText("Second issue");
@@ -57,6 +59,7 @@ describe("IssuesTab", () => {
       makeIssue({ number: 2, title: "In other repo", repoFullName: "owner/other" }),
     ];
     viewStore.setGlobalFilter(null, "owner/target");
+    setAllExpanded("issues", ["owner/target"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     screen.getByText("In target repo");
     expect(screen.queryByText("In other repo")).toBeNull();
@@ -68,6 +71,7 @@ describe("IssuesTab", () => {
       makeIssue({ number: 2, title: "Outside org", repoFullName: "otherorg/repo-b" }),
     ];
     viewStore.setGlobalFilter("myorg", null);
+    setAllExpanded("issues", ["myorg/repo-a"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     screen.getByText("In org");
     expect(screen.queryByText("Outside org")).toBeNull();
@@ -78,6 +82,7 @@ describe("IssuesTab", () => {
       makeIssue({ id: 1, title: "Older issue", updatedAt: "2024-01-10T00:00:00Z" }),
       makeIssue({ id: 2, title: "Newer issue", updatedAt: "2024-01-20T00:00:00Z" }),
     ];
+    setAllExpanded("issues", ["owner/repo"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     const allText = screen.getAllByRole("listitem");
     const texts = allText.map((el) => el.textContent ?? "");
@@ -127,15 +132,16 @@ describe("IssuesTab", () => {
     expect(screen.queryByLabelText("Next page")).toBeNull();
   });
 
-  it("first repo group auto-expands on initial mount", () => {
+  it("all repo groups start collapsed by default", () => {
     const issues = [
       makeIssue({ id: 1, title: "Issue in first repo", repoFullName: "org/repo-a" }),
       makeIssue({ id: 2, title: "Issue in second repo", repoFullName: "org/repo-b" }),
     ];
     render(() => <IssuesTab issues={issues} userLogin="" />);
-    // First group should be expanded — items visible
-    screen.getByText("Issue in first repo");
-    // Second group starts collapsed — items hidden
+    // Both groups start collapsed — headers visible, items hidden
+    screen.getByText("org/repo-a");
+    screen.getByText("org/repo-b");
+    expect(screen.queryByText("Issue in first repo")).toBeNull();
     expect(screen.queryByText("Issue in second repo")).toBeNull();
   });
 
@@ -145,6 +151,7 @@ describe("IssuesTab", () => {
       makeIssue({ id: 2, title: "Other Issue", userLogin: "bob", assigneeLogins: [] }),
     ];
     viewStore.setTabFilter("issues", "role", "author");
+    setAllExpanded("issues", ["owner/repo"], true);
     render(() => <IssuesTab issues={issues} userLogin="alice" />);
     screen.getByText("My Issue");
     expect(screen.queryByText("Other Issue")).toBeNull();
@@ -156,6 +163,7 @@ describe("IssuesTab", () => {
       makeIssue({ id: 2, title: "Silent Issue", comments: 0 }),
     ];
     viewStore.setTabFilter("issues", "comments", "has");
+    setAllExpanded("issues", ["owner/repo"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     screen.getByText("Discussed Issue");
     expect(screen.queryByText("Silent Issue")).toBeNull();
@@ -167,6 +175,7 @@ describe("IssuesTab", () => {
       makeIssue({ id: 2, title: "Silent Issue", comments: 0 }),
     ];
     viewStore.setTabFilter("issues", "comments", "none");
+    setAllExpanded("issues", ["owner/repo"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     screen.getByText("Silent Issue");
     expect(screen.queryByText("Discussed Issue")).toBeNull();
@@ -178,29 +187,34 @@ describe("IssuesTab", () => {
       makeIssue({ id: 2, title: "Issue in repo B", repoFullName: "org/repo-b" }),
       makeIssue({ id: 3, title: "Another in repo A", repoFullName: "org/repo-a" }),
     ];
+    setAllExpanded("issues", ["org/repo-a"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     // Both repo headers visible
     screen.getByText("org/repo-a");
     screen.getByText("org/repo-b");
-    // First group (repo-a) is auto-expanded — items visible
+    // repo-a is expanded — items visible
     screen.getByText("Issue in repo A");
     screen.getByText("Another in repo A");
-    // Second group (repo-b) starts collapsed — items hidden
+    // repo-b starts collapsed — items hidden
     expect(screen.queryByText("Issue in repo B")).toBeNull();
   });
 
-  it("collapses the first auto-expanded repo group when header is clicked", async () => {
+  it("expands and collapses a repo group when header is clicked", async () => {
     const user = userEvent.setup();
     const issues = [
       makeIssue({ id: 1, title: "Visible issue", repoFullName: "org/repo-a" }),
     ];
     render(() => <IssuesTab issues={issues} userLogin="" />);
-    // First group is auto-expanded
-    screen.getByText("Visible issue");
+    // Starts collapsed
+    expect(screen.queryByText("Visible issue")).toBeNull();
 
+    // Click to expand
     const repoHeader = screen.getByText("org/repo-a").closest("button")!;
     await user.click(repoHeader);
+    screen.getByText("Visible issue");
 
+    // Click to collapse
+    await user.click(repoHeader);
     expect(screen.queryByText("Visible issue")).toBeNull();
   });
 
@@ -220,13 +234,13 @@ describe("IssuesTab", () => {
     screen.getByText("Second repo issue");
   });
 
-  it("sets aria-expanded=true on the first (auto-expanded) repo group header", () => {
+  it("sets aria-expanded=false on all repo group headers by default", () => {
     const issues = [
       makeIssue({ id: 1, title: "Test issue", repoFullName: "org/repo-a" }),
     ];
     render(() => <IssuesTab issues={issues} userLogin="" />);
     const header = screen.getByText("org/repo-a").closest("button")!;
-    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(header.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("sets aria-expanded=false on subsequent (collapsed) repo group headers", () => {
@@ -247,59 +261,46 @@ describe("IssuesTab", () => {
     render(() => <IssuesTab issues={issues} userLogin="" />);
     const header = screen.getByText("org/repo-a").closest("button")!;
 
-    // Initially auto-expanded
-    expect(header.getAttribute("aria-expanded")).toBe("true");
-    await user.click(header);
+    // Initially collapsed
     expect(header.getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByText("Toggle issue")).toBeNull();
 
     await user.click(header);
     expect(header.getAttribute("aria-expanded")).toBe("true");
     screen.getByText("Toggle issue");
+
+    await user.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Toggle issue")).toBeNull();
   });
 
-  it("shows item count in collapsed repo group header", async () => {
-    const user = userEvent.setup();
+  it("shows item count in collapsed repo group header", () => {
     const issues = [
       makeIssue({ id: 1, title: "Issue 1", repoFullName: "org/repo-a" }),
       makeIssue({ id: 2, title: "Issue 2", repoFullName: "org/repo-a" }),
       makeIssue({ id: 3, title: "Issue 3", repoFullName: "org/repo-a" }),
     ];
     render(() => <IssuesTab issues={issues} userLogin="" />);
-
-    // Collapse the auto-expanded group
-    const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
-
+    // Groups start collapsed — summary visible
     screen.getByText("3 issues");
   });
 
-  it("shows singular 'issue' for a group with one item when collapsed", async () => {
-    const user = userEvent.setup();
+  it("shows singular 'issue' for a group with one item when collapsed", () => {
     const issues = [
       makeIssue({ id: 1, title: "Only issue", repoFullName: "org/repo-a" }),
     ];
     render(() => <IssuesTab issues={issues} userLogin="" />);
-
-    const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
-
+    // Group starts collapsed
     screen.getByText("1 issue");
   });
 
-  it("shows role summary badges in collapsed repo group header", async () => {
-    const user = userEvent.setup();
+  it("shows role summary badges in collapsed repo group header", () => {
     const issues = [
       makeIssue({ id: 1, title: "My issue", repoFullName: "org/repo-a", userLogin: "alice", assigneeLogins: [] }),
       makeIssue({ id: 2, title: "My second issue", repoFullName: "org/repo-a", userLogin: "alice", assigneeLogins: [] }),
     ];
     render(() => <IssuesTab issues={issues} userLogin="alice" />);
-
-    // Collapse the auto-expanded group
-    const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
-
-    // Should show author role badge with count
+    // Group starts collapsed — summary badges visible
     screen.getByText("author ×2");
   });
 
@@ -310,17 +311,17 @@ describe("IssuesTab", () => {
     ];
     render(() => <IssuesTab issues={issues} userLogin="alice" />);
 
-    // Group starts expanded — no summary count visible
-    expect(screen.queryByText("1 issue")).toBeNull();
-
-    // Collapse — summary appears
-    const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
+    // Group starts collapsed — summary count visible
     screen.getByText("1 issue");
 
-    // Expand again — summary disappears
+    // Expand — summary disappears
+    const header = screen.getByText("org/repo-a").closest("button")!;
     await user.click(header);
     expect(screen.queryByText("1 issue")).toBeNull();
+
+    // Collapse again — summary reappears
+    await user.click(header);
+    screen.getByText("1 issue");
   });
 
   it("IgnoreBadge renders in the toolbar", () => {
@@ -368,27 +369,24 @@ describe("IssuesTab", () => {
     ];
     render(() => <IssuesTab issues={issues} userLogin="alice" />);
 
-    // First group (repo-a) is auto-expanded, collapse it
+    // Expand repo-a
     const repoHeader = screen.getByText("org/repo-a").closest("button")!;
     await user.click(repoHeader);
-    expect(screen.queryByText("Alice issue")).toBeNull();
-    expect(repoHeader.getAttribute("aria-expanded")).toBe("false");
+    screen.getByText("Alice issue");
 
     // Apply role filter that keeps only alice's issue (repo-a)
     viewStore.setTabFilter("issues", "role", "author");
-    // repo-a still visible (collapsed), repo-b filtered out
+    // repo-a still visible (expanded), repo-b filtered out
     screen.getByText("org/repo-a");
+    screen.getByText("Alice issue");
     expect(screen.queryByText("org/repo-b")).toBeNull();
-    // Items still hidden because collapse state persists
-    expect(screen.queryByText("Alice issue")).toBeNull();
 
-    // Clear filter — repo-b reappears, repo-a stays collapsed
+    // Clear filter — repo-b reappears, repo-a stays expanded
     viewStore.resetTabFilter("issues", "role");
     screen.getByText("org/repo-a");
     screen.getByText("org/repo-b");
-    // repo-a stays collapsed (was collapsed before filter applied)
-    expect(screen.queryByText("Alice issue")).toBeNull();
-    // repo-b is collapsed (never expanded), so Bob issue is also hidden
+    screen.getByText("Alice issue");
+    // repo-b is collapsed (never expanded), so Bob issue is hidden
     expect(screen.queryByText("Bob issue")).toBeNull();
   });
 
@@ -401,6 +399,7 @@ describe("IssuesTab", () => {
     const repoBIssues = Array.from({ length: 6 }, (_, i) =>
       makeIssue({ id: 200 + i, title: `Repo B issue ${i}`, repoFullName: "org/repo-b" })
     );
+    setAllExpanded("issues", ["org/repo-a", "org/repo-b"], true);
     const [issues, setIssues] = createSignal<Issue[]>([...repoAIssues, ...repoBIssues]);
     render(() => <IssuesTab issues={issues()} userLogin="" />);
 
@@ -422,6 +421,7 @@ describe("IssuesTab", () => {
     const issues = Array.from({ length: 15 }, (_, i) =>
       makeIssue({ id: 300 + i, title: `Big repo issue ${i}`, repoFullName: "org/big-repo" })
     );
+    setAllExpanded("issues", ["org/big-repo"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     // All 15 items in one group — whole-groups-only pagination keeps them together
     screen.getByText("org/big-repo");
@@ -429,5 +429,64 @@ describe("IssuesTab", () => {
     screen.getByText("Big repo issue 14");
     // No pagination controls (single page with oversized group)
     expect(screen.queryByLabelText("Next page")).toBeNull();
+  });
+
+  it("clicking 'Expand all' expands all repo groups", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Issue A", repoFullName: "org/repo-a" }),
+      makeIssue({ id: 2, title: "Issue B", repoFullName: "org/repo-b" }),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    // Both start collapsed
+    expect(screen.queryByText("Issue A")).toBeNull();
+    expect(screen.queryByText("Issue B")).toBeNull();
+
+    await user.click(screen.getByLabelText("Expand all"));
+    screen.getByText("Issue A");
+    screen.getByText("Issue B");
+  });
+
+  it("clicking 'Collapse all' collapses all repo groups", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Issue A", repoFullName: "org/repo-a" }),
+      makeIssue({ id: 2, title: "Issue B", repoFullName: "org/repo-b" }),
+    ];
+    setAllExpanded("issues", ["org/repo-a", "org/repo-b"], true);
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    screen.getByText("Issue A");
+    screen.getByText("Issue B");
+
+    await user.click(screen.getByLabelText("Collapse all"));
+    expect(screen.queryByText("Issue A")).toBeNull();
+    expect(screen.queryByText("Issue B")).toBeNull();
+  });
+
+  it("expanded state persists in viewState after toggle", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Persisted issue", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    const header = screen.getByText("org/repo-a").closest("button")!;
+    await user.click(header);
+    expect(viewState.expandedRepos.issues["org/repo-a"]).toBe(true);
+  });
+
+  it("expanded state survives component unmount/remount", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Survives remount", repoFullName: "org/repo-a" }),
+    ];
+    const { unmount } = render(() => <IssuesTab issues={issues} userLogin="" />);
+    const header = screen.getByText("org/repo-a").closest("button")!;
+    await user.click(header);
+    screen.getByText("Survives remount");
+
+    unmount();
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    // State persisted in viewState store — should still be expanded
+    screen.getByText("Survives remount");
   });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -390,6 +390,33 @@ describe("IssuesTab", () => {
     expect(screen.queryByText("Bob issue")).toBeNull();
   });
 
+  it("collapse all with active filter preserves hidden repos' expanded state", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Alice issue", repoFullName: "org/repo-a", userLogin: "alice" }),
+      makeIssue({ id: 2, title: "Bob issue", repoFullName: "org/repo-b", userLogin: "bob" }),
+    ];
+    setAllExpanded("issues", ["org/repo-a", "org/repo-b"], true);
+    render(() => <IssuesTab issues={issues} userLogin="alice" />);
+    screen.getByText("Alice issue");
+    screen.getByText("Bob issue");
+
+    // Apply filter hiding repo-b (only alice's issues visible)
+    viewStore.setTabFilter("issues", "role", "author");
+    screen.getByText("Alice issue");
+    expect(screen.queryByText("org/repo-b")).toBeNull();
+
+    // Collapse all — only affects visible (filtered) repos
+    await user.click(screen.getByLabelText("Collapse all"));
+    expect(screen.queryByText("Alice issue")).toBeNull();
+
+    // Remove filter — repo-b should still be expanded (was hidden during collapse-all)
+    viewStore.resetTabFilter("issues", "role");
+    screen.getByText("Bob issue");
+    // repo-a was collapsed by collapse-all
+    expect(screen.queryByText("Alice issue")).toBeNull();
+  });
+
   it("resets page when data shrinks below current page", async () => {
     const user = userEvent.setup();
     updateConfig({ itemsPerPage: 10 });
@@ -488,6 +515,54 @@ describe("IssuesTab", () => {
     render(() => <IssuesTab issues={issues} userLogin="" />);
     // State persisted in viewState store — should still be expanded
     screen.getByText("Survives remount");
+  });
+
+  it("prunes stale expanded keys when a repo disappears from data", () => {
+    const [issues, setIssues] = createSignal<Issue[]>([
+      makeIssue({ id: 1, title: "Repo A issue", repoFullName: "org/repo-a" }),
+      makeIssue({ id: 2, title: "Repo B issue", repoFullName: "org/repo-b" }),
+    ]);
+    setAllExpanded("issues", ["org/repo-a", "org/repo-b"], true);
+    render(() => <IssuesTab issues={issues()} userLogin="" />);
+    // Both repos expanded
+    screen.getByText("Repo A issue");
+    screen.getByText("Repo B issue");
+
+    // Remove repo-b from data — pruning effect should fire
+    setIssues([makeIssue({ id: 1, title: "Repo A issue", repoFullName: "org/repo-a" })]);
+    expect(viewState.expandedRepos.issues["org/repo-a"]).toBe(true);
+    expect("org/repo-b" in viewState.expandedRepos.issues).toBe(false);
+  });
+
+  it("prunes the first repo key when it disappears (name-based, not positional)", () => {
+    const [issues, setIssues] = createSignal<Issue[]>([
+      makeIssue({ id: 1, title: "Repo A issue", repoFullName: "org/repo-a" }),
+      makeIssue({ id: 2, title: "Repo B issue", repoFullName: "org/repo-b" }),
+    ]);
+    setAllExpanded("issues", ["org/repo-a", "org/repo-b"], true);
+    render(() => <IssuesTab issues={issues()} userLogin="" />);
+
+    // Remove repo-a (first), keep repo-b (second)
+    setIssues([makeIssue({ id: 2, title: "Repo B issue", repoFullName: "org/repo-b" })]);
+    expect("org/repo-a" in viewState.expandedRepos.issues).toBe(false);
+    expect(viewState.expandedRepos.issues["org/repo-b"]).toBe(true);
+  });
+
+  it("preserves expanded keys when data becomes empty and restores UI on re-population", () => {
+    const [issues, setIssues] = createSignal<Issue[]>([
+      makeIssue({ id: 1, title: "Issue A", repoFullName: "org/repo-a" }),
+    ]);
+    setAllExpanded("issues", ["org/repo-a"], true);
+    render(() => <IssuesTab issues={issues()} userLogin="" />);
+    screen.getByText("Issue A");
+
+    // Data becomes empty (e.g. loading state) — expanded state should be preserved
+    setIssues([]);
+    expect(viewState.expandedRepos.issues["org/repo-a"]).toBe(true);
+
+    // Data returns — UI should use preserved expanded state
+    setIssues([makeIssue({ id: 1, title: "Issue A", repoFullName: "org/repo-a" })]);
+    screen.getByText("Issue A");
   });
 
   it("clicking 'Expand all' expands repos on other pages too", async () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -59,21 +59,18 @@ describe("ItemRow", () => {
     expect(screen.queryByTestId("child-slot")).toBeNull();
   });
 
-  it("opens url in new tab when row is clicked", async () => {
-    const user = userEvent.setup();
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+  it("title is a real link with correct href and target", () => {
     render(() => <ItemRow {...defaultProps} />);
+    const link = screen.getByText("Fix a bug").closest("a")!;
+    expect(link.getAttribute("href")).toBe(defaultProps.url);
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
 
-    // Click on the title text to trigger row click
-    const titleEl = screen.getByText("Fix a bug");
-    await user.click(titleEl);
-
-    expect(openSpy).toHaveBeenCalledWith(
-      defaultProps.url,
-      "_blank",
-      "noopener,noreferrer"
-    );
-    openSpy.mockRestore();
+  it("title link has no href for non-GitHub URLs", () => {
+    render(() => <ItemRow {...defaultProps} url="https://evil.com/bad" />);
+    const link = screen.getByText("Fix a bug").closest("a")!;
+    expect(link.getAttribute("href")).toBeNull();
   });
 
   it("calls onIgnore when ignore button is clicked", async () => {
@@ -87,33 +84,31 @@ describe("ItemRow", () => {
     expect(onIgnore).toHaveBeenCalledOnce();
   });
 
-  it("does not open URL when ignore button is clicked", async () => {
+  it("ignore button does not navigate (sits above stretched link)", async () => {
     const user = userEvent.setup();
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
     const onIgnore = vi.fn();
     render(() => <ItemRow {...defaultProps} onIgnore={onIgnore} />);
 
     const ignoreBtn = screen.getByLabelText(/Ignore #42/i);
     await user.click(ignoreBtn);
 
-    expect(openSpy).not.toHaveBeenCalled();
-    openSpy.mockRestore();
+    expect(onIgnore).toHaveBeenCalledOnce();
   });
 
   it("applies compact padding in compact density", () => {
     const { container } = render(() => (
       <ItemRow {...defaultProps} density="compact" />
     ));
-    const row = container.querySelector("[role='row']");
-    expect(row?.className).toContain("py-2");
+    const row = container.querySelector(".group")!;
+    expect(row.className).toContain("py-2");
   });
 
   it("applies comfortable padding in comfortable density", () => {
     const { container } = render(() => (
       <ItemRow {...defaultProps} density="comfortable" />
     ));
-    const row = container.querySelector("[role='row']");
-    expect(row?.className).toContain("py-3");
+    const row = container.querySelector(".group")!;
+    expect(row.className).toContain("py-3");
   });
 
   it("renders no labels section when labels array is empty", () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -54,23 +54,33 @@ describe("ItemRow", () => {
     screen.getByTestId("child-slot");
   });
 
+  it("children slot sits above overlay link (relative z-10)", () => {
+    const { container } = render(() => (
+      <ItemRow {...defaultProps}>
+        <span data-testid="child-slot">extra content</span>
+      </ItemRow>
+    ));
+    const childWrapper = container.querySelector("[data-testid='child-slot']")!.parentElement!;
+    expect(childWrapper.className).toContain("relative");
+    expect(childWrapper.className).toContain("z-10");
+  });
+
   it("does not render children slot when not provided", () => {
     render(() => <ItemRow {...defaultProps} />);
     expect(screen.queryByTestId("child-slot")).toBeNull();
   });
 
-  it("title is a real link with correct href and target", () => {
+  it("renders overlay link with correct href, target, rel, and aria-label", () => {
     render(() => <ItemRow {...defaultProps} />);
-    const link = screen.getByText("Fix a bug").closest("a")!;
+    const link = screen.getByRole("link", { name: /octocat\/Hello-World #42: Fix a bug/ });
     expect(link.getAttribute("href")).toBe(defaultProps.url);
     expect(link.getAttribute("target")).toBe("_blank");
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
-  it("title link has no href for non-GitHub URLs", () => {
+  it("does not render overlay link for non-GitHub URLs", () => {
     render(() => <ItemRow {...defaultProps} url="https://evil.com/bad" />);
-    const link = screen.getByText("Fix a bug").closest("a")!;
-    expect(link.getAttribute("href")).toBeNull();
+    expect(screen.queryByRole("link")).toBeNull();
   });
 
   it("calls onIgnore when ignore button is clicked", async () => {
@@ -84,15 +94,11 @@ describe("ItemRow", () => {
     expect(onIgnore).toHaveBeenCalledOnce();
   });
 
-  it("ignore button does not navigate (sits above stretched link)", async () => {
-    const user = userEvent.setup();
-    const onIgnore = vi.fn();
-    render(() => <ItemRow {...defaultProps} onIgnore={onIgnore} />);
-
+  it("ignore button has relative z-10 to sit above overlay link", () => {
+    render(() => <ItemRow {...defaultProps} />);
     const ignoreBtn = screen.getByLabelText(/Ignore #42/i);
-    await user.click(ignoreBtn);
-
-    expect(onIgnore).toHaveBeenCalledOnce();
+    expect(ignoreBtn.className).toContain("relative");
+    expect(ignoreBtn.className).toContain("z-10");
   });
 
   it("applies compact padding in compact density", () => {

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -570,6 +570,38 @@ describe("PullRequestsTab", () => {
     screen.getByText("Persistent PR");
   });
 
+  it("prunes stale expanded keys when a repo disappears from data", () => {
+    const [prs, setPrs] = createSignal<PullRequest[]>([
+      makePullRequest({ id: 1, title: "Repo A PR", repoFullName: "org/repo-a" }),
+      makePullRequest({ id: 2, title: "Repo B PR", repoFullName: "org/repo-b" }),
+    ]);
+    setAllExpanded("pullRequests", ["org/repo-a", "org/repo-b"], true);
+    render(() => <PullRequestsTab pullRequests={prs()} userLogin="" />);
+    screen.getByText("Repo A PR");
+    screen.getByText("Repo B PR");
+
+    // Remove repo-b from data — pruning effect should fire
+    setPrs([makePullRequest({ id: 1, title: "Repo A PR", repoFullName: "org/repo-a" })]);
+    expect(viewStore.viewState.expandedRepos.pullRequests["org/repo-a"]).toBe(true);
+    expect("org/repo-b" in viewStore.viewState.expandedRepos.pullRequests).toBe(false);
+  });
+
+  it("preserves expanded keys when data becomes empty and restores UI on re-population", () => {
+    const [prs, setPrs] = createSignal<PullRequest[]>([
+      makePullRequest({ id: 1, title: "PR A", repoFullName: "org/repo-a" }),
+    ]);
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
+    render(() => <PullRequestsTab pullRequests={prs()} userLogin="" />);
+    screen.getByText("PR A");
+
+    setPrs([]);
+    expect(viewStore.viewState.expandedRepos.pullRequests["org/repo-a"]).toBe(true);
+
+    // Data returns — UI should use preserved expanded state
+    setPrs([makePullRequest({ id: 1, title: "PR A", repoFullName: "org/repo-a" })]);
+    screen.getByText("PR A");
+  });
+
   it("clicking 'Expand all' expands repos on other pages too", async () => {
     const user = userEvent.setup();
     updateConfig({ itemsPerPage: 10 });

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -569,4 +569,30 @@ describe("PullRequestsTab", () => {
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("Persistent PR");
   });
+
+  it("clicking 'Expand all' expands repos on other pages too", async () => {
+    const user = userEvent.setup();
+    updateConfig({ itemsPerPage: 10 });
+    const prs = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        makePullRequest({ id: 100 + i, title: `Repo A PR ${i}`, repoFullName: "org/repo-a" })
+      ),
+      ...Array.from({ length: 6 }, (_, i) =>
+        makePullRequest({ id: 200 + i, title: `Repo B PR ${i}`, repoFullName: "org/repo-b" })
+      ),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    // Page 1 shows repo-a, page 2 shows repo-b
+    screen.getByText(/Page 1 of 2/);
+
+    // Expand all — affects repos on ALL pages
+    await user.click(screen.getByLabelText("Expand all"));
+    // Repo-a items visible on page 1
+    screen.getByText("Repo A PR 0");
+
+    // Navigate to page 2 — repo-b should already be expanded
+    await user.click(screen.getByLabelText("Next page"));
+    screen.getByText("org/repo-b");
+    screen.getByText("Repo B PR 0");
+  });
 });

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -5,6 +5,7 @@ import { createSignal } from "solid-js";
 import PullRequestsTab from "../../src/app/components/dashboard/PullRequestsTab";
 import type { PullRequest } from "../../src/app/services/api";
 import * as viewStore from "../../src/app/stores/view";
+import { setAllExpanded } from "../../src/app/stores/view";
 import { makePullRequest, resetViewStore } from "../helpers/index";
 import { updateConfig, resetConfig } from "../../src/app/stores/config";
 
@@ -19,8 +20,8 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 1, number: 1, title: "First PR", repoFullName: "org/repo-a" }),
       makePullRequest({ id: 2, number: 2, title: "Second PR", repoFullName: "org/repo-a" }),
     ];
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // First group auto-expands, so items are visible
     screen.getByText("First PR");
     screen.getByText("Second PR");
   });
@@ -57,6 +58,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, number: 2, title: "In other repo", repoFullName: "owner/other" }),
     ];
     viewStore.setGlobalFilter(null, "owner/target");
+    setAllExpanded("pullRequests", ["owner/target"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("In target repo");
     expect(screen.queryByText("In other repo")).toBeNull();
@@ -68,6 +70,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, number: 2, title: "Outside org", repoFullName: "otherorg/repo-b" }),
     ];
     viewStore.setGlobalFilter("myorg", null);
+    setAllExpanded("pullRequests", ["myorg/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("In org");
     expect(screen.queryByText("Outside org")).toBeNull();
@@ -78,6 +81,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 1, title: "Older PR", updatedAt: "2024-01-10T00:00:00Z", repoFullName: "org/repo-a" }),
       makePullRequest({ id: 2, title: "Newer PR", updatedAt: "2024-01-20T00:00:00Z", repoFullName: "org/repo-a" }),
     ];
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     const items = screen.getAllByRole("listitem");
     const texts = items.map((el) => el.textContent ?? "");
@@ -129,15 +133,16 @@ describe("PullRequestsTab", () => {
     const prs = [
       makePullRequest({ id: 1, title: "PR with status", checkStatus: "success", repoFullName: "org/repo-a" }),
     ];
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // First group auto-expands, so StatusDot is visible
     screen.getByLabelText("All checks passed");
   });
 
   it("shows Draft badge for draft PRs when expanded", () => {
     const pr = makePullRequest({ id: 1, title: "Draft PR", draft: true, repoFullName: "org/repo-a" });
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={[pr]} userLogin="" />);
-    // "Draft" appears in both the filter chip button and the PR badge (first group auto-expands)
+    // "Draft" appears in both the filter chip button and the PR badge
     const draftEls = screen.getAllByText("Draft");
     // At least one is a span (the badge), not a button (the chip)
     const badgeEl = draftEls.find((el) => el.tagName.toLowerCase() === "span");
@@ -155,8 +160,9 @@ describe("PullRequestsTab", () => {
 
   it("shows Author role badge when userLogin matches PR author", () => {
     const pr = makePullRequest({ id: 1, title: "My PR", userLogin: "alice", reviewerLogins: [], assigneeLogins: [], repoFullName: "org/repo-a" });
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={[pr]} userLogin="alice" />);
-    // "Author" appears in both the filter chip button and the role badge (first group auto-expands)
+    // "Author" appears in both the filter chip button and the role badge
     const authorEls = screen.getAllByText("Author");
     const badgeEl = authorEls.find((el) => el.tagName.toLowerCase() === "span");
     expect(badgeEl).toBeDefined();
@@ -164,8 +170,9 @@ describe("PullRequestsTab", () => {
 
   it("shows Reviewer role badge when userLogin is a reviewer", () => {
     const pr = makePullRequest({ id: 1, title: "Review PR", userLogin: "bob", reviewerLogins: ["alice"], assigneeLogins: [], repoFullName: "org/repo-a" });
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={[pr]} userLogin="alice" />);
-    // "Reviewer" appears in both the filter chip button and the role badge (first group auto-expands)
+    // "Reviewer" appears in both the filter chip button and the role badge
     const reviewerEls = screen.getAllByText("Reviewer");
     const badgeEl = reviewerEls.find((el) => el.tagName.toLowerCase() === "span");
     expect(badgeEl).toBeDefined();
@@ -173,8 +180,9 @@ describe("PullRequestsTab", () => {
 
   it("shows ReviewBadge for approved PRs when expanded", () => {
     const pr = makePullRequest({ id: 1, title: "Approved PR", reviewDecision: "APPROVED", repoFullName: "org/repo-a" });
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={[pr]} userLogin="" />);
-    // "Approved" appears in both the filter chip button and the review badge (first group auto-expands)
+    // "Approved" appears in both the filter chip button and the review badge
     const approvedEls = screen.getAllByText("Approved");
     const badgeEl = approvedEls.find((el) => el.tagName.toLowerCase() === "span");
     expect(badgeEl).toBeDefined();
@@ -182,8 +190,9 @@ describe("PullRequestsTab", () => {
 
   it("shows SizeBadge for each PR when expanded", () => {
     const pr = makePullRequest({ id: 1, title: "Big PR", additions: 300, deletions: 100, repoFullName: "org/repo-a" });
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={[pr]} userLogin="" />);
-    // prSizeCategory(300, 100) = 400 total -> M (first group auto-expands)
+    // prSizeCategory(300, 100) = 400 total -> M
     // "M" appears in both the filter chip button and the size badge
     const mEls = screen.getAllByText("M");
     const badgeEl = mEls.find((el) => el.tagName.toLowerCase() === "span");
@@ -196,6 +205,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "Other PR", userLogin: "bob", reviewerLogins: [], assigneeLogins: [], repoFullName: "org/repo-a" }),
     ];
     viewStore.setTabFilter("pullRequests", "role", "author");
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="alice" />);
     screen.getByText("My PR");
     expect(screen.queryByText("Other PR")).toBeNull();
@@ -207,6 +217,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "Pending PR", reviewDecision: null, repoFullName: "org/repo-a" }),
     ];
     viewStore.setTabFilter("pullRequests", "reviewDecision", "APPROVED");
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("Approved PR");
     expect(screen.queryByText("Pending PR")).toBeNull();
@@ -218,6 +229,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "Ready PR", draft: false, repoFullName: "org/repo-a" }),
     ];
     viewStore.setTabFilter("pullRequests", "draft", "draft");
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("Draft PR");
     expect(screen.queryByText("Ready PR")).toBeNull();
@@ -229,6 +241,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "Failing PR", checkStatus: "failure", repoFullName: "org/repo-a" }),
     ];
     viewStore.setTabFilter("pullRequests", "checkStatus", "success");
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("Passing PR");
     expect(screen.queryByText("Failing PR")).toBeNull();
@@ -240,6 +253,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "Has CI PR", checkStatus: "success", repoFullName: "org/repo-a" }),
     ];
     viewStore.setTabFilter("pullRequests", "checkStatus", "none");
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("No CI PR");
     expect(screen.queryByText("Has CI PR")).toBeNull();
@@ -251,6 +265,7 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "Large PR", additions: 600, deletions: 200, repoFullName: "org/repo-a" }),
     ];
     viewStore.setTabFilter("pullRequests", "sizeCategory", "XS");
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("Small PR");
     expect(screen.queryByText("Large PR")).toBeNull();
@@ -262,43 +277,48 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "PR in repo B", repoFullName: "org/repo-b" }),
       makePullRequest({ id: 3, title: "Another in repo A", repoFullName: "org/repo-a" }),
     ];
+    setAllExpanded("pullRequests", ["org/repo-a"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("org/repo-a");
     screen.getByText("org/repo-b");
-    // First group (repo-a) is auto-expanded
+    // repo-a is expanded
     screen.getByText("PR in repo A");
     screen.getByText("Another in repo A");
     // repo-b is collapsed, so its PR is not visible
     expect(screen.queryByText("PR in repo B")).toBeNull();
   });
 
-  it("auto-expands first repo group on initial mount", () => {
+  it("all repo groups start collapsed on initial mount", () => {
     const prs = [
       makePullRequest({ id: 1, title: "First Repo PR", repoFullName: "org/repo-a" }),
       makePullRequest({ id: 2, title: "Second Repo PR", repoFullName: "org/repo-b" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // First group is auto-expanded
-    screen.getByText("First Repo PR");
-    // Second group is collapsed
+    // Both groups should start collapsed
+    expect(screen.queryByText("First Repo PR")).toBeNull();
     expect(screen.queryByText("Second Repo PR")).toBeNull();
-    // First group header has aria-expanded=true
+    // Repo headers are still visible
+    screen.getByText("org/repo-a");
+    screen.getByText("org/repo-b");
+    // Both headers have aria-expanded=false
     const firstHeader = screen.getByText("org/repo-a").closest("button")!;
-    expect(firstHeader.getAttribute("aria-expanded")).toBe("true");
+    expect(firstHeader.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("collapses a repo group when header is clicked", async () => {
+  it("collapses a repo group when header is clicked after expanding", async () => {
     const user = userEvent.setup();
     const prs = [
       makePullRequest({ id: 1, title: "Visible PR", repoFullName: "org/repo-a" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // First group auto-expands
+    const repoHeader = screen.getByText("org/repo-a").closest("button")!;
+
+    // Click to expand first
+    await user.click(repoHeader);
     screen.getByText("Visible PR");
 
-    const repoHeader = screen.getByText("org/repo-a");
+    // Click again to collapse
     await user.click(repoHeader);
-
     expect(screen.queryByText("Visible PR")).toBeNull();
   });
 
@@ -309,25 +329,25 @@ describe("PullRequestsTab", () => {
       makePullRequest({ id: 2, title: "Second Repo PR", repoFullName: "org/repo-b" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // Second group starts collapsed
+    // Both groups start collapsed
     expect(screen.queryByText("Second Repo PR")).toBeNull();
 
-    const repoHeader = screen.getByText("org/repo-b");
+    const repoHeader = screen.getByText("org/repo-b").closest("button")!;
     await user.click(repoHeader);
 
     screen.getByText("Second Repo PR");
   });
 
-  it("sets aria-expanded=true on first repo group header by default", () => {
+  it("starts with aria-expanded=false on all repo group headers", () => {
     const prs = [
       makePullRequest({ id: 1, title: "Test PR", repoFullName: "org/repo-a" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     const header = screen.getByText("org/repo-a").closest("button")!;
-    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(header.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("toggles aria-expanded to false on collapse and back to true on re-expand", async () => {
+  it("toggles aria-expanded false→true→false on header clicks", async () => {
     const user = userEvent.setup();
     const prs = [
       makePullRequest({ id: 1, title: "Toggle PR", repoFullName: "org/repo-a" }),
@@ -335,81 +355,73 @@ describe("PullRequestsTab", () => {
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     const header = screen.getByText("org/repo-a").closest("button")!;
 
-    expect(header.getAttribute("aria-expanded")).toBe("true");
-    await user.click(header);
+    // Starts collapsed
     expect(header.getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByText("Toggle PR")).toBeNull();
 
+    // Expand
     await user.click(header);
     expect(header.getAttribute("aria-expanded")).toBe("true");
     screen.getByText("Toggle PR");
+
+    // Collapse again
+    await user.click(header);
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Toggle PR")).toBeNull();
   });
 
-  it("shows collapsed summary with PR count when group is collapsed", async () => {
-    const user = userEvent.setup();
+  it("shows collapsed summary with PR count when group is collapsed", () => {
     const prs = [
       makePullRequest({ id: 1, title: "PR One", repoFullName: "org/repo-a" }),
       makePullRequest({ id: 2, title: "PR Two", repoFullName: "org/repo-a" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // Collapse the first group
-    const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
-
-    // Summary should show count
+    // Group starts collapsed — summary should show count
     screen.getByText("2 PRs");
   });
 
-  it("shows check status dots in collapsed summary", async () => {
-    const user = userEvent.setup();
+  it("shows check status dots in collapsed summary", () => {
     const prs = [
       makePullRequest({ id: 1, title: "PR One", checkStatus: "success", repoFullName: "org/repo-a" }),
       makePullRequest({ id: 2, title: "PR Two", checkStatus: "failure", repoFullName: "org/repo-a" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // Collapse the first group
+    // Group starts collapsed — check success count (1) and failure count (1) shown as text
     const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
-
-    // Check success count (1) and failure count (1) shown as text
     const summarySpan = header.querySelector(".ml-auto")!;
     expect(summarySpan.textContent).toContain("1");
   });
 
-  it("shows review state badges in collapsed summary", async () => {
-    const user = userEvent.setup();
+  it("shows review state badges in collapsed summary", () => {
     const prs = [
       makePullRequest({ id: 1, title: "PR One", reviewDecision: "APPROVED", repoFullName: "org/repo-a" }),
       makePullRequest({ id: 2, title: "PR Two", reviewDecision: "CHANGES_REQUESTED", repoFullName: "org/repo-a" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // Collapse the first group
-    const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
-
+    // Group starts collapsed — review badges visible in summary
     screen.getByText("Approved ×1");
     screen.getByText("Changes ×1");
   });
 
-  it("shows role badges in collapsed summary", async () => {
-    const user = userEvent.setup();
+  it("shows role badges in collapsed summary", () => {
     const prs = [
       makePullRequest({ id: 1, title: "My PR", userLogin: "alice", reviewerLogins: [], assigneeLogins: [], repoFullName: "org/repo-a" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="alice" />);
-    // Collapse the first group
-    const header = screen.getByText("org/repo-a").closest("button")!;
-    await user.click(header);
-
+    // Group starts collapsed — role badges visible in summary
     screen.getByText("author ×1");
   });
 
-  it("hides summary metadata when group is expanded", () => {
+  it("hides summary metadata when group is expanded", async () => {
+    const user = userEvent.setup();
     const prs = [
       makePullRequest({ id: 1, title: "PR One", repoFullName: "org/repo-a" }),
     ];
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
-    // First group is auto-expanded — no summary count shown
+    const header = screen.getByText("org/repo-a").closest("button")!;
+    // Expand the group
+    await user.click(header);
+    // Summary count should not be shown when expanded
     expect(screen.queryByText("1 PR")).toBeNull();
   });
 
@@ -454,6 +466,7 @@ describe("PullRequestsTab", () => {
     const prs = Array.from({ length: 15 }, (_, i) =>
       makePullRequest({ id: 300 + i, title: `Big repo PR ${i}`, repoFullName: "org/big-repo" })
     );
+    setAllExpanded("pullRequests", ["org/big-repo"], true);
     render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
     screen.getByText("org/big-repo");
     screen.getByText("Big repo PR 0");
@@ -483,6 +496,77 @@ describe("PullRequestsTab", () => {
     setPrs(repoAPrs);
     expect(screen.queryByLabelText("Next page")).toBeNull();
     screen.getByText("org/repo-a");
-    screen.getByText("Repo A PR 0");
+  });
+
+  it("clicking Expand all expands all repo groups", async () => {
+    const user = userEvent.setup();
+    const prs = [
+      makePullRequest({ id: 1, title: "PR in repo A", repoFullName: "org/repo-a" }),
+      makePullRequest({ id: 2, title: "PR in repo B", repoFullName: "org/repo-b" }),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    // Both start collapsed
+    expect(screen.queryByText("PR in repo A")).toBeNull();
+    expect(screen.queryByText("PR in repo B")).toBeNull();
+
+    await user.click(screen.getByLabelText("Expand all"));
+
+    screen.getByText("PR in repo A");
+    screen.getByText("PR in repo B");
+  });
+
+  it("clicking Collapse all collapses all repo groups", async () => {
+    const user = userEvent.setup();
+    const prs = [
+      makePullRequest({ id: 1, title: "PR in repo A", repoFullName: "org/repo-a" }),
+      makePullRequest({ id: 2, title: "PR in repo B", repoFullName: "org/repo-b" }),
+    ];
+    setAllExpanded("pullRequests", ["org/repo-a", "org/repo-b"], true);
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    // Both start expanded
+    screen.getByText("PR in repo A");
+    screen.getByText("PR in repo B");
+
+    await user.click(screen.getByLabelText("Collapse all"));
+
+    expect(screen.queryByText("PR in repo A")).toBeNull();
+    expect(screen.queryByText("PR in repo B")).toBeNull();
+  });
+
+  it("expanded state persists in viewState after toggle", async () => {
+    const user = userEvent.setup();
+    const prs = [
+      makePullRequest({ id: 1, title: "PR in repo A", repoFullName: "org/repo-a" }),
+    ];
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+
+    // Initially collapsed
+    expect(viewStore.viewState.expandedRepos.pullRequests["org/repo-a"]).toBeFalsy();
+
+    const header = screen.getByText("org/repo-a").closest("button")!;
+    await user.click(header);
+
+    // Now expanded in viewState
+    expect(viewStore.viewState.expandedRepos.pullRequests["org/repo-a"]).toBe(true);
+  });
+
+  it("expanded state survives component unmount and remount", async () => {
+    const user = userEvent.setup();
+    const prs = [
+      makePullRequest({ id: 1, title: "Persistent PR", repoFullName: "org/repo-a" }),
+    ];
+
+    const { unmount } = render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    const header = screen.getByText("org/repo-a").closest("button")!;
+    await user.click(header);
+    // Confirm expanded
+    screen.getByText("Persistent PR");
+
+    // Unmount
+    unmount();
+
+    // Remount — state in viewState should persist
+    render(() => <PullRequestsTab pullRequests={prs} userLogin="" />);
+    screen.getByText("Persistent PR");
   });
 });

--- a/tests/helpers/index.tsx
+++ b/tests/helpers/index.tsx
@@ -1,6 +1,6 @@
 import { render } from "@solidjs/testing-library";
 import { MemoryRouter, createMemoryHistory } from "@solidjs/router";
-import { updateViewState } from "../../src/app/stores/view";
+import { resetViewState } from "../../src/app/stores/view";
 import type { Issue, PullRequest, WorkflowRun, ApiError } from "../../src/app/services/api";
 import type { JSX } from "solid-js";
 
@@ -103,17 +103,5 @@ export function renderWithRouter(
 }
 
 export function resetViewStore(): void {
-  updateViewState({
-    lastActiveTab: "issues",
-    sortPreferences: {},
-    ignoredItems: [],
-    globalFilter: { org: null, repo: null },
-    tabFilters: {
-      issues: { role: "all", comments: "all" },
-      pullRequests: { role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all" },
-      actions: { conclusion: "all", event: "all" },
-    },
-    showPrRuns: false,
-    expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
-  });
+  resetViewState();
 }

--- a/tests/helpers/index.tsx
+++ b/tests/helpers/index.tsx
@@ -114,5 +114,6 @@ export function resetViewStore(): void {
       actions: { conclusion: "all", event: "all" },
     },
     showPrRuns: false,
+    expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
   });
 }

--- a/tests/services/api-optimization.test.ts
+++ b/tests/services/api-optimization.test.ts
@@ -591,7 +591,7 @@ describe("workflow run concurrency", () => {
 
   it("processes repos faster with pooled concurrency than sequential chunks", async () => {
     const repos = makeRepos(30);
-    const DELAY_MS = 5;
+    const DELAY_MS = 20;
 
     const makeTimedOctokit = () => ({
       request: vi.fn(async () => {

--- a/tests/stores/view.test.ts
+++ b/tests/stores/view.test.ts
@@ -3,6 +3,7 @@ import { createRoot } from "solid-js";
 import {
   viewState,
   updateViewState,
+  resetViewState,
   ignoreItem,
   unignoreItem,
   setSortPreference,
@@ -44,20 +45,12 @@ Object.defineProperty(globalThis, "localStorage", {
   configurable: true,
 });
 
-const defaultState = ViewStateSchema.parse({});
-
-function resetViewState() {
-  updateViewState({
-    lastActiveTab: defaultState.lastActiveTab,
-    sortPreferences: {},
-    ignoredItems: [],
-    globalFilter: { org: null, repo: null },
-    expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
-  });
+function resetForTest() {
+  resetViewState();
 }
 
 beforeEach(() => {
-  resetViewState();
+  resetForTest();
   localStorageMock.clear();
 });
 
@@ -243,6 +236,14 @@ describe("expandedRepos helpers", () => {
     expect(viewState.expandedRepos.issues["owner/c"]).toBe(true);
   });
 
+  it("setAllExpanded with empty array is a no-op", () => {
+    setAllExpanded("issues", ["owner/existing"], true);
+    setAllExpanded("issues", [], true);
+    expect(viewState.expandedRepos.issues["owner/existing"]).toBe(true);
+    setAllExpanded("issues", [], false);
+    expect(viewState.expandedRepos.issues["owner/existing"]).toBe(true);
+  });
+
   it("setAllExpanded with expanded=false deletes all keys (sparse record)", () => {
     setAllExpanded("issues", ["owner/a", "owner/b"], true);
     setAllExpanded("issues", ["owner/a", "owner/b"], false);
@@ -287,5 +288,21 @@ describe("expandedRepos helpers", () => {
     expect(restored.expandedRepos.pullRequests).toEqual({});
     dispose();
     vi.useRealTimers();
+  });
+});
+
+describe("resetViewState", () => {
+  it("clears dynamically-added expandedRepos keys", () => {
+    setAllExpanded("issues", ["org/repo-a", "org/repo-b"], true);
+    setAllExpanded("pullRequests", ["org/repo-c"], true);
+    toggleExpandedRepo("actions", "org/repo-d");
+    expect(viewState.expandedRepos.issues["org/repo-a"]).toBe(true);
+
+    resetViewState();
+
+    expect("org/repo-a" in viewState.expandedRepos.issues).toBe(false);
+    expect("org/repo-b" in viewState.expandedRepos.issues).toBe(false);
+    expect("org/repo-c" in viewState.expandedRepos.pullRequests).toBe(false);
+    expect("org/repo-d" in viewState.expandedRepos.actions).toBe(false);
   });
 });

--- a/tests/stores/view.test.ts
+++ b/tests/stores/view.test.ts
@@ -9,6 +9,9 @@ import {
   setGlobalFilter,
   initViewPersistence,
   ViewStateSchema,
+  toggleExpandedRepo,
+  setAllExpanded,
+  pruneExpandedRepos,
 } from "../../src/app/stores/view";
 import type { IgnoredItem } from "../../src/app/stores/view";
 
@@ -49,6 +52,7 @@ function resetViewState() {
     sortPreferences: {},
     ignoredItems: [],
     globalFilter: { org: null, repo: null },
+    expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
   });
 }
 
@@ -203,5 +207,85 @@ describe("ViewStateSchema", () => {
   it("safeParse returns success=false for invalid data", () => {
     const result = ViewStateSchema.safeParse({ lastActiveTab: "invalid-tab-name" });
     expect(result.success).toBe(false);
+  });
+
+  it("missing expandedRepos field parses to defaults", () => {
+    const result = ViewStateSchema.parse({ lastActiveTab: "actions" });
+    expect(result.expandedRepos).toEqual({ issues: {}, pullRequests: {}, actions: {} });
+  });
+});
+
+describe("expandedRepos helpers", () => {
+  it("toggleExpandedRepo sets key to true when absent", () => {
+    toggleExpandedRepo("issues", "owner/repo");
+    expect(viewState.expandedRepos.issues["owner/repo"]).toBe(true);
+  });
+
+  it("toggleExpandedRepo deletes key when already true (sparse record)", () => {
+    toggleExpandedRepo("issues", "owner/repo");
+    expect(viewState.expandedRepos.issues["owner/repo"]).toBe(true);
+    toggleExpandedRepo("issues", "owner/repo");
+    expect("owner/repo" in viewState.expandedRepos.issues).toBe(false);
+  });
+
+  it("toggleExpandedRepo works independently per tab", () => {
+    toggleExpandedRepo("issues", "owner/repo");
+    toggleExpandedRepo("pullRequests", "owner/repo");
+    expect(viewState.expandedRepos.issues["owner/repo"]).toBe(true);
+    expect(viewState.expandedRepos.pullRequests["owner/repo"]).toBe(true);
+    expect("owner/repo" in viewState.expandedRepos.actions).toBe(false);
+  });
+
+  it("setAllExpanded sets multiple repos to true", () => {
+    setAllExpanded("issues", ["owner/a", "owner/b", "owner/c"], true);
+    expect(viewState.expandedRepos.issues["owner/a"]).toBe(true);
+    expect(viewState.expandedRepos.issues["owner/b"]).toBe(true);
+    expect(viewState.expandedRepos.issues["owner/c"]).toBe(true);
+  });
+
+  it("setAllExpanded with expanded=false deletes all keys (sparse record)", () => {
+    setAllExpanded("issues", ["owner/a", "owner/b"], true);
+    setAllExpanded("issues", ["owner/a", "owner/b"], false);
+    expect("owner/a" in viewState.expandedRepos.issues).toBe(false);
+    expect("owner/b" in viewState.expandedRepos.issues).toBe(false);
+  });
+
+  it("pruneExpandedRepos removes stale keys and keeps active ones", () => {
+    setAllExpanded("actions", ["owner/active", "owner/stale"], true);
+    pruneExpandedRepos("actions", ["owner/active"]);
+    expect(viewState.expandedRepos.actions["owner/active"]).toBe(true);
+    expect("owner/stale" in viewState.expandedRepos.actions).toBe(false);
+  });
+
+  it("pruneExpandedRepos short-circuits when no stale keys exist", () => {
+    setAllExpanded("pullRequests", ["owner/a"], true);
+    // Spy on setViewState indirectly: verify state is unchanged and no error thrown
+    const before = JSON.stringify(viewState.expandedRepos.pullRequests);
+    pruneExpandedRepos("pullRequests", ["owner/a"]);
+    expect(JSON.stringify(viewState.expandedRepos.pullRequests)).toBe(before);
+    expect(viewState.expandedRepos.pullRequests["owner/a"]).toBe(true);
+  });
+
+  it("localStorage round-trip: expandedRepos persists and restores via schema", async () => {
+    vi.useFakeTimers();
+    let dispose!: () => void;
+    createRoot((d) => {
+      dispose = d;
+      initViewPersistence();
+      toggleExpandedRepo("issues", "myorg/myrepo");
+      setAllExpanded("actions", ["myorg/ci"], true);
+    });
+
+    await Promise.resolve();
+    vi.advanceTimersByTime(200);
+
+    const raw = localStorageMock.getItem(VIEW_KEY);
+    expect(raw).not.toBeNull();
+    const restored = ViewStateSchema.parse(JSON.parse(raw!));
+    expect(restored.expandedRepos.issues["myorg/myrepo"]).toBe(true);
+    expect(restored.expandedRepos.actions["myorg/ci"]).toBe(true);
+    expect(restored.expandedRepos.pullRequests).toEqual({});
+    dispose();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Adds per-tab `expandedRepos` to viewState store with toggle, setAll, and prune helpers persisted via localStorage
- Creates ExpandCollapseButtons shared component (expand all / collapse all) added to all three dashboard tab toolbars
- Removes auto-expand-first-group behavior; all repos start collapsed by default with state persisting across tab switches and page reloads