### PR TITLE
feat(auth): adds optional PAT authentication as alternative to OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Dashboard SPA tracking GitHub issues, PRs, and GHA workflow runs across multiple
 - **Pull Requests Tab** — Open PRs with CI check status indicators (green/yellow/red dots). Draft badges, reviewer names.
 - **Actions Tab** — GHA workflow runs grouped by repo and workflow. Accordion collapse, PR run toggle.
 - **Onboarding Wizard** — Two-step org/repo selection with search filtering and bulk select.
-- **Settings Page** — Refresh interval, notification preferences, theme (light/dark/system), density, GitHub Actions limits.
+- **PAT Authentication** — Optional Personal Access Token login as alternative to OAuth. Client-side format validation, detailed token creation instructions for classic and fine-grained PATs.
+- **Settings Page** — Refresh interval, notification preferences, theme (light/dark/system), density, GitHub Actions limits. Shows current auth method and hides OAuth-specific options for PAT users.
 - **Desktop Notifications** — New item alerts with per-type toggles and batching.
 - **Ignore System** — Hide specific items with an "N ignored" badge and unignore popover.
 - **Dark Mode** — System-aware with flash prevention via inline script + CSP SHA-256 hash.
@@ -57,6 +58,7 @@ src/
       config.ts     # Zod v4-validated config with localStorage persistence
       view.ts       # View state (tabs, sorting, ignored items, filters)
     lib/
+      pat.ts            # PAT format validation and token creation instruction constants
       notifications.ts  # Desktop notification permission, detection, and dispatch
   worker/
     index.ts        # OAuth token exchange endpoint, CORS, security headers
@@ -72,6 +74,7 @@ tests/
 ## Security
 
 - Strict CSP: `script-src 'self'` (SHA-256 exception for dark mode script only)
+- PAT tokens stored in `localStorage` (same key as OAuth tokens) — single-user personal dashboard threat model
 - OAuth CSRF protection via `crypto.getRandomValues` state parameter
 - CORS locked to exact origin (strict equality, no substring matching)
 - Access token stored in `localStorage` under app-specific key; CSP prevents XSS token theft

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Dashboard SPA tracking GitHub issues, PRs, and GHA workflow runs across multiple
 ```sh
 pnpm install
 pnpm run dev        # Start Vite dev server
-pnpm test           # Run browser tests (130 tests)
+pnpm test           # Run unit/component tests
 pnpm run typecheck  # TypeScript check
 pnpm run build      # Production build (~241KB JS, ~31KB CSS)
 ```

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -260,26 +260,28 @@ export default function SettingsPage() {
               </div>
             </Show>
 
-            <div class="border-t border-base-300 pt-3">
-              <div class="flex items-center justify-between">
-                <div>
-                  <p class="text-sm font-medium text-base-content">
-                    Organization Access
-                  </p>
-                  <p class="text-xs text-base-content/60">
-                    Request access for restricted orgs on GitHub — new orgs sync when you return
-                  </p>
+            <Show when={config.authMethod !== "pat"}>
+              <div class="border-t border-base-300 pt-3">
+                <div class="flex items-center justify-between">
+                  <div>
+                    <p class="text-sm font-medium text-base-content">
+                      Organization Access
+                    </p>
+                    <p class="text-xs text-base-content/60">
+                      Request access for restricted orgs on GitHub — new orgs sync when you return
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleGrantOrgs}
+                    disabled={merging()}
+                    class="btn btn-sm btn-outline"
+                  >
+                    {merging() ? "Syncing..." : "Manage org access"}
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={handleGrantOrgs}
-                  disabled={merging()}
-                  class="btn btn-sm btn-outline"
-                >
-                  {merging() ? "Syncing..." : "Manage org access"}
-                </button>
               </div>
-            </div>
+            </Show>
 
             <div class="border-t border-base-300 pt-3">
               <div class="flex items-center justify-between">
@@ -561,6 +563,14 @@ export default function SettingsPage() {
 
         {/* Section 7: Data */}
         <Section title="Data">
+          {/* Authentication method */}
+          <SettingRow
+            label="Authentication"
+            description="Current sign-in method"
+          >
+            <span class="text-sm">{config.authMethod === "pat" ? "Personal Access Token" : "OAuth"}</span>
+          </SettingRow>
+
           {/* Clear cache */}
           <SettingRow
             label="Clear cache"

--- a/src/app/lib/pat.ts
+++ b/src/app/lib/pat.ts
@@ -1,0 +1,45 @@
+export function isValidPatFormat(token: string): { valid: boolean; error?: string } {
+  const trimmed = token.trim();
+  if (trimmed.length === 0) {
+    return { valid: false, error: "Please enter a token" };
+  }
+
+  const isClassic = trimmed.startsWith("ghp_");
+  const isFineGrained = trimmed.startsWith("github_pat_");
+
+  if (!isClassic && !isFineGrained) {
+    return { valid: false, error: "Token should start with ghp_ (classic) or github_pat_ (fine-grained)" };
+  }
+
+  const prefix = isClassic ? "ghp_" : "github_pat_";
+  const payload = trimmed.slice(prefix.length);
+
+  if (!/^[A-Za-z0-9_]*$/.test(payload)) {
+    return { valid: false, error: "Token contains invalid characters — check that you copied it correctly" };
+  }
+
+  const minLength = isClassic ? 40 : 47;
+  if (trimmed.length < minLength) {
+    return { valid: false, error: "Token appears truncated — check that you copied the full value" };
+  }
+
+  return { valid: true };
+}
+
+export const PAT_FINE_GRAINED_PERMISSIONS = {
+  repository: [
+    "Actions: Read-only",
+    "Contents: Read-only",
+    "Issues: Read-only",
+    "Metadata: Read-only",
+    "Pull requests: Read-only",
+  ],
+} as const;
+
+// Fine-grained PATs cannot access the Notifications API (GET /notifications returns 403).
+// The app gracefully handles this — the notifications gate auto-disables on 403.
+export const PAT_FINE_GRAINED_NOTIFICATIONS_CAVEAT =
+  "Fine-grained tokens cannot access notifications — the app will skip notification-based polling optimization and still function correctly.";
+
+export const GITHUB_PAT_URL = "https://github.com/settings/tokens/new";
+export const GITHUB_FINE_GRAINED_PAT_URL = "https://github.com/settings/personal-access-tokens/new";

--- a/src/app/lib/pat.ts
+++ b/src/app/lib/pat.ts
@@ -1,4 +1,8 @@
-export function isValidPatFormat(token: string): { valid: boolean; error?: string } {
+export type PatValidationResult =
+  | { valid: true }
+  | { valid: false; error: string };
+
+export function isValidPatFormat(token: string): PatValidationResult {
   const trimmed = token.trim();
   if (trimmed.length === 0) {
     return { valid: false, error: "Please enter a token" };
@@ -18,28 +22,15 @@ export function isValidPatFormat(token: string): { valid: boolean; error?: strin
     return { valid: false, error: "Token contains invalid characters — check that you copied it correctly" };
   }
 
-  const minLength = isClassic ? 40 : 47;
+  // Classic PATs are exactly 40 chars. Fine-grained PATs are ~93 chars;
+  // use 80 as a safe lower bound to catch clearly truncated tokens.
+  const minLength = isClassic ? 40 : 80;
   if (trimmed.length < minLength) {
     return { valid: false, error: "Token appears truncated — check that you copied the full value" };
   }
 
   return { valid: true };
 }
-
-export const PAT_FINE_GRAINED_PERMISSIONS = {
-  repository: [
-    "Actions: Read-only",
-    "Contents: Read-only",
-    "Issues: Read-only",
-    "Metadata: Read-only",
-    "Pull requests: Read-only",
-  ],
-} as const;
-
-// Fine-grained PATs cannot access the Notifications API (GET /notifications returns 403).
-// The app gracefully handles this — the notifications gate auto-disables on 403.
-export const PAT_FINE_GRAINED_NOTIFICATIONS_CAVEAT =
-  "Fine-grained tokens cannot access notifications — the app will skip notification-based polling optimization and still function correctly.";
 
 export const GITHUB_PAT_URL = "https://github.com/settings/tokens/new";
 export const GITHUB_FINE_GRAINED_PAT_URL = "https://github.com/settings/personal-access-tokens/new";

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -1,12 +1,10 @@
 import { createSignal, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
-import { setAuthFromPat, validateToken } from "../stores/auth";
+import { setAuthFromPat, type GitHubUser } from "../stores/auth";
 import {
   isValidPatFormat,
-  PAT_FINE_GRAINED_PERMISSIONS,
   GITHUB_PAT_URL,
   GITHUB_FINE_GRAINED_PAT_URL,
-  PAT_FINE_GRAINED_NOTIFICATIONS_CAVEAT,
 } from "../lib/pat";
 import { buildAuthorizeUrl } from "../lib/oauth";
 
@@ -27,15 +25,13 @@ export default function LoginPage() {
     if (submitting()) return;
     const validation = isValidPatFormat(patInput());
     if (!validation.valid) {
-      setPatError(validation.error!);
+      setPatError(validation.error);
       return;
     }
     setSubmitting(true);
     setPatError(null);
     const trimmedToken = patInput().trim();
     try {
-      // Validate token BEFORE storing to prevent half-set state and
-      // distinguish network errors from invalid tokens
       const resp = await fetch("https://api.github.com/user", {
         headers: {
           Authorization: `Bearer ${trimmedToken}`,
@@ -49,21 +45,16 @@ export default function LoginPage() {
             ? "Token is invalid — check that you entered it correctly"
             : `GitHub returned ${resp.status} — try again later`
         );
-        setSubmitting(false);
         return;
       }
-      if (!showPatForm()) {
-        setSubmitting(false);
-        return;
-      }
-      // Token is valid — store it and populate user data
-      setAuthFromPat(trimmedToken);
-      await validateToken();
+      if (!showPatForm()) return;
+      const userData = (await resp.json()) as GitHubUser;
+      setAuthFromPat(trimmedToken, userData);
       setPatInput("");
-      setSubmitting(false);
       navigate("/", { replace: true });
     } catch {
       setPatError("Network error — please try again");
+    } finally {
       setSubmitting(false);
     }
   }
@@ -120,36 +111,25 @@ export default function LoginPage() {
                       >
                         Classic token
                       </a>
-                      {" "}(fine for personal use) — select these scopes:
+                      {" "}(recommended) — works across all orgs. Select these scopes:
                     </p>
                     <ul class="list-disc list-inside space-y-0.5 text-base-content/70">
-                      <li><code>repo</code> — access repository data (issues, PRs, actions)</li>
-                      <li><code>read:org</code> — read organization membership</li>
-                      <li><code>notifications</code> — access notification status</li>
+                      <li><code>repo</code></li>
+                      <li><code>read:org</code> <span class="text-base-content/40">(under admin:org)</span></li>
+                      <li><code>notifications</code></li>
                     </ul>
                   </div>
 
-                  <div>
-                    <p class="font-medium mb-1">
-                      <a
-                        href={GITHUB_FINE_GRAINED_PAT_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="link link-primary"
-                      >
-                        Fine-grained token
-                      </a>
-                      {" "}(recommended by GitHub) — set repository access to "All repositories", then enable:
-                    </p>
-                    <ul class="list-disc list-inside space-y-0.5 text-base-content/70">
-                      {PAT_FINE_GRAINED_PERMISSIONS.repository.map((perm) => (
-                        <li>{perm}</li>
-                      ))}
-                    </ul>
-                  </div>
-
-                  <p class="text-warning text-xs">
-                    {PAT_FINE_GRAINED_NOTIFICATIONS_CAVEAT}
+                  <p class="text-base-content/50">
+                    <a
+                      href={GITHUB_FINE_GRAINED_PAT_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="link"
+                    >
+                      Fine-grained tokens
+                    </a>
+                    {" "}also work, but only access one org at a time and do not support notifications. Add read-only permissions for Actions, Contents, Issues, and Pull requests.
                   </p>
                 </div>
 

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -1,39 +1,204 @@
+import { createSignal, Show } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import { setAuthFromPat, validateToken } from "../stores/auth";
+import {
+  isValidPatFormat,
+  PAT_FINE_GRAINED_PERMISSIONS,
+  GITHUB_PAT_URL,
+  GITHUB_FINE_GRAINED_PAT_URL,
+  PAT_FINE_GRAINED_NOTIFICATIONS_CAVEAT,
+} from "../lib/pat";
 import { buildAuthorizeUrl } from "../lib/oauth";
 
 export default function LoginPage() {
+  const navigate = useNavigate();
+
+  const [showPatForm, setShowPatForm] = createSignal(false);
+  const [patInput, setPatInput] = createSignal("");
+  const [patError, setPatError] = createSignal<string | null>(null);
+  const [submitting, setSubmitting] = createSignal(false);
+
   function handleLogin() {
     window.location.href = buildAuthorizeUrl();
+  }
+
+  async function handlePatSubmit(e: Event) {
+    e.preventDefault();
+    if (submitting()) return;
+    const validation = isValidPatFormat(patInput());
+    if (!validation.valid) {
+      setPatError(validation.error!);
+      return;
+    }
+    setSubmitting(true);
+    setPatError(null);
+    const trimmedToken = patInput().trim();
+    try {
+      // Validate token BEFORE storing to prevent half-set state and
+      // distinguish network errors from invalid tokens
+      const resp = await fetch("https://api.github.com/user", {
+        headers: {
+          Authorization: `Bearer ${trimmedToken}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      });
+      if (!resp.ok) {
+        setPatError(
+          resp.status === 401
+            ? "Token is invalid — check that you entered it correctly"
+            : `GitHub returned ${resp.status} — try again later`
+        );
+        setSubmitting(false);
+        return;
+      }
+      if (!showPatForm()) {
+        setSubmitting(false);
+        return;
+      }
+      // Token is valid — store it and populate user data
+      setAuthFromPat(trimmedToken);
+      await validateToken();
+      setPatInput("");
+      setSubmitting(false);
+      navigate("/", { replace: true });
+    } catch {
+      setPatError("Network error — please try again");
+      setSubmitting(false);
+    }
   }
 
   return (
     <div class="bg-base-200 min-h-screen flex items-center justify-center">
       <div class="card bg-base-100 shadow-xl max-w-sm w-full mx-4">
         <div class="card-body items-center text-center gap-6">
-          <div class="flex flex-col items-center gap-2">
-            <h1 class="card-title text-2xl">
-              GitHub Tracker
-            </h1>
-            <p class="text-sm text-base-content/60 text-center">
-              Track issues, pull requests, and workflow runs across your GitHub
-              repositories.
-            </p>
-          </div>
 
-          <button
-            type="button"
-            onClick={handleLogin}
-            class="btn btn-neutral w-full"
+          <Show
+            when={!showPatForm()}
+            fallback={
+              <form onSubmit={(e) => void handlePatSubmit(e)} class="w-full flex flex-col gap-4">
+                <h2 class="card-title">Sign in with Token</h2>
+
+                <div class="text-left w-full">
+                  <label for="pat-input" class="label">
+                    <span class="label-text">Personal access token</span>
+                  </label>
+                  <input
+                    id="pat-input"
+                    type="password"
+                    autocomplete="new-password"
+                    placeholder="ghp_... or github_pat_..."
+                    class={`input input-bordered w-full${patError() !== null ? " input-error" : ""}`}
+                    aria-invalid={patError() !== null}
+                    aria-describedby={patError() !== null ? "pat-error" : undefined}
+                    value={patInput()}
+                    onInput={(e) => setPatInput(e.currentTarget.value)}
+                  />
+                  <Show when={patError() !== null}>
+                    <p id="pat-error" role="alert" class="text-error text-xs mt-1">
+                      {patError()}
+                    </p>
+                  </Show>
+                </div>
+
+                <button
+                  type="submit"
+                  class="btn btn-neutral w-full"
+                  disabled={submitting()}
+                >
+                  {submitting() ? "Verifying..." : "Sign in"}
+                </button>
+
+                <div class="text-left text-xs space-y-3 mt-4">
+                  <div>
+                    <p class="font-medium mb-1">
+                      <a
+                        href={GITHUB_PAT_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="link link-primary"
+                      >
+                        Classic token
+                      </a>
+                      {" "}(fine for personal use) — select these scopes:
+                    </p>
+                    <ul class="list-disc list-inside space-y-0.5 text-base-content/70">
+                      <li><code>repo</code> — access repository data (issues, PRs, actions)</li>
+                      <li><code>read:org</code> — read organization membership</li>
+                      <li><code>notifications</code> — access notification status</li>
+                    </ul>
+                  </div>
+
+                  <div>
+                    <p class="font-medium mb-1">
+                      <a
+                        href={GITHUB_FINE_GRAINED_PAT_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="link link-primary"
+                      >
+                        Fine-grained token
+                      </a>
+                      {" "}(recommended by GitHub) — set repository access to "All repositories", then enable:
+                    </p>
+                    <ul class="list-disc list-inside space-y-0.5 text-base-content/70">
+                      {PAT_FINE_GRAINED_PERMISSIONS.repository.map((perm) => (
+                        <li>{perm}</li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <p class="text-warning text-xs">
+                    {PAT_FINE_GRAINED_NOTIFICATIONS_CAVEAT}
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => { setShowPatForm(false); setPatError(null); setPatInput(""); }}
+                  class="link link-primary text-sm mt-2"
+                >
+                  Use OAuth instead
+                </button>
+              </form>
+            }
           >
-            <svg
-              viewBox="0 0 16 16"
-              class="w-5 h-5"
-              aria-hidden="true"
-              fill="currentColor"
+            <div class="flex flex-col items-center gap-2">
+              <h1 class="card-title text-2xl">
+                GitHub Tracker
+              </h1>
+              <p class="text-sm text-base-content/60 text-center">
+                Track issues, pull requests, and workflow runs across your GitHub
+                repositories.
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleLogin}
+              class="btn btn-neutral w-full"
             >
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-            </svg>
-            Sign in with GitHub
-          </button>
+              <svg
+                viewBox="0 0 16 16"
+                class="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+              >
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+              </svg>
+              Sign in with GitHub
+            </button>
+
+            <div class="divider text-xs text-base-content/40">or</div>
+            <button
+              type="button"
+              onClick={() => setShowPatForm(true)}
+              class="link link-primary text-sm"
+            >
+              Use a Personal Access Token
+            </button>
+          </Show>
+
         </div>
       </div>
     </div>

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -135,7 +135,9 @@ async function hasNotificationChanges(): Promise<boolean> {
       (err as { status?: number }).status === 403
     ) {
       console.warn("[poll] Notifications API returned 403 — disabling gate");
-      pushNotification("notifications", "Notifications API returned 403 — check that the notifications scope is granted", "warning");
+      pushNotification("notifications", config.authMethod === "pat"
+        ? "Notifications API returned 403 — fine-grained tokens may not support notifications"
+        : "Notifications API returned 403 — check that the notifications scope is granted", "warning");
       _notifGateDisabled = true;
     }
     return true;

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -136,7 +136,7 @@ async function hasNotificationChanges(): Promise<boolean> {
     ) {
       console.warn("[poll] Notifications API returned 403 — disabling gate");
       pushNotification("notifications", config.authMethod === "pat"
-        ? "Notifications API returned 403 — fine-grained tokens may not support notifications"
+        ? "Notifications API returned 403 — fine-grained tokens do not support notifications; classic tokens need the notifications scope"
         : "Notifications API returned 403 — check that the notifications scope is granted", "warning");
       _notifGateDisabled = true;
     }

--- a/src/app/stores/auth.ts
+++ b/src/app/stores/auth.ts
@@ -1,6 +1,6 @@
 import { createSignal } from "solid-js";
 import { clearCache } from "./cache";
-import { CONFIG_STORAGE_KEY, resetConfig } from "./config";
+import { CONFIG_STORAGE_KEY, resetConfig, updateConfig, config } from "./config";
 import { VIEW_STORAGE_KEY, resetViewState } from "./view";
 
 export const AUTH_STORAGE_KEY = "github-tracker:auth-token";
@@ -43,6 +43,11 @@ export function setAuth(response: TokenExchangeResponse): void {
   localStorage.setItem(AUTH_STORAGE_KEY, response.access_token);
   _setToken(response.access_token);
   console.info("[auth] access token set (localStorage)");
+}
+
+export function setAuthFromPat(token: string): void {
+  setAuth({ access_token: token });
+  updateConfig({ authMethod: "pat" });
 }
 
 const _onClearCallbacks: (() => void)[] = [];
@@ -107,8 +112,12 @@ export async function validateToken(): Promise<boolean> {
     }
 
     if (resp.status === 401) {
-      // Permanent token is revoked — clear auth and redirect to login
-      console.info("[auth] access token invalid — clearing auth");
+      const method = config.authMethod;
+      console.info(
+        method === "pat"
+          ? "[auth] PAT invalid or expired — clearing auth"
+          : "[auth] access token invalid — clearing auth"
+      );
       clearAuth();
       return false;
     }

--- a/src/app/stores/auth.ts
+++ b/src/app/stores/auth.ts
@@ -45,8 +45,9 @@ export function setAuth(response: TokenExchangeResponse): void {
   console.info("[auth] access token set (localStorage)");
 }
 
-export function setAuthFromPat(token: string): void {
+export function setAuthFromPat(token: string, userData: GitHubUser): void {
   setAuth({ access_token: token });
+  setUser({ login: userData.login, avatar_url: userData.avatar_url, name: userData.name });
   updateConfig({ authMethod: "pat" });
 }
 

--- a/src/app/stores/config.ts
+++ b/src/app/stores/config.ts
@@ -46,6 +46,7 @@ export const ConfigSchema = z.object({
   defaultTab: z.enum(["issues", "pullRequests", "actions"]).default("issues"),
   rememberLastTab: z.boolean().default(true),
   onboardingComplete: z.boolean().default(false),
+  authMethod: z.enum(["oauth", "pat"]).default("oauth"),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -6,7 +6,6 @@ import userEvent from "@testing-library/user-event";
 
 vi.mock("../../src/app/stores/auth", () => ({
   setAuthFromPat: vi.fn(),
-  validateToken: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("../../src/app/lib/pat", async (importOriginal) => {
@@ -66,7 +65,6 @@ function mockFetchNetworkError() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(authStore.validateToken).mockResolvedValue(true);
   mockFetchOk();
   Object.defineProperty(window, "location", {
     configurable: true,
@@ -119,13 +117,27 @@ describe("LoginPage — PAT form navigation", () => {
     screen.getByLabelText("Personal access token");
   });
 
-  it("PAT form shows submit button and instructions", async () => {
+  it("PAT form shows submit button and token creation links", async () => {
     const user = userEvent.setup();
     render(() => <LoginPage />);
     await user.click(screen.getByText("Use a Personal Access Token"));
     screen.getByRole("button", { name: "Sign in" });
     screen.getByRole("link", { name: /Classic token/i });
-    screen.getByRole("link", { name: /Fine-grained token/i });
+    screen.getByRole("link", { name: /Fine-grained tokens/i });
+  });
+
+  it("shows classic token as recommended", async () => {
+    const user = userEvent.setup();
+    render(() => <LoginPage />);
+    await user.click(screen.getByText("Use a Personal Access Token"));
+    screen.getByText(/recommended/i);
+  });
+
+  it("shows fine-grained limitations inline", async () => {
+    const user = userEvent.setup();
+    render(() => <LoginPage />);
+    await user.click(screen.getByText("Use a Personal Access Token"));
+    screen.getByText(/only access one org at a time/i);
   });
 
   it("clicking 'Use OAuth instead' returns to OAuth view and clears state", async () => {
@@ -185,7 +197,7 @@ describe("LoginPage — PAT form validation", () => {
     expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
   });
 
-  it("calls navigate('/') on successful validation", async () => {
+  it("calls setAuthFromPat with token and user data, then navigates", async () => {
     vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
     mockFetchOk();
     const user = await openPatForm();
@@ -194,7 +206,10 @@ describe("LoginPage — PAT form validation", () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
     });
-    expect(authStore.setAuthFromPat).toHaveBeenCalled();
+    expect(authStore.setAuthFromPat).toHaveBeenCalledWith(
+      "ghp_" + "a".repeat(36),
+      githubUser,
+    );
   });
 
   it("shows 'Verifying...' and disables button while submitting", async () => {
@@ -213,6 +228,20 @@ describe("LoginPage — PAT form validation", () => {
     resolveFetch({ ok: true, status: 200, json: () => Promise.resolve(githubUser) } as Response);
   });
 
+  it("re-enables button after successful submission", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    mockFetchOk();
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
+    // finally block should have run — button no longer disabled
+    const btn = screen.getByRole("button", { name: "Sign in" });
+    expect(btn.hasAttribute("disabled")).toBe(false);
+  });
+
   it("shows 'Network error' on fetch failure", async () => {
     vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
     mockFetchNetworkError();
@@ -223,6 +252,19 @@ describe("LoginPage — PAT form validation", () => {
       expect(screen.getByRole("alert").textContent).toContain("Network error");
     });
     expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
+  });
+
+  it("re-enables button after network error", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    mockFetchNetworkError();
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      screen.getByRole("alert");
+    });
+    const btn = screen.getByRole("button", { name: "Sign in" });
+    expect(btn.hasAttribute("disabled")).toBe(false);
   });
 
   it("does not navigate when user switches to OAuth during validation", async () => {
@@ -241,10 +283,10 @@ describe("LoginPage — PAT form validation", () => {
     await user.click(screen.getByText("Use OAuth instead"));
     // Resolve fetch as successful — but user already left
     resolveFetch({ ok: true, status: 200, json: () => Promise.resolve(githubUser) } as Response);
-    // Wait a tick for the async handler to complete
-    await new Promise((r) => setTimeout(r, 50));
-    // Token was never stored and navigation never happened
-    expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
+    // Wait for async handler to settle
+    await waitFor(() => {
+      expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
+    });
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -1,123 +1,250 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, waitFor } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("../../src/app/stores/auth", () => ({
+  setAuthFromPat: vi.fn(),
+  validateToken: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../src/app/lib/pat", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/app/lib/pat")>();
+  return {
+    ...actual,
+    isValidPatFormat: vi.fn(actual.isValidPatFormat),
+  };
+});
+
+// Full router mock — per project convention (SolidJS useNavigate requires Route context;
+// partial mocks of @solidjs/router render empty divs)
+const mockNavigate = vi.fn();
+vi.mock("@solidjs/router", () => ({
+  useNavigate: () => mockNavigate,
+  MemoryRouter: (props: { children: unknown }) => props.children,
+  Route: (props: { component: () => unknown }) => props.component(),
+}));
+
+// ── Imports after mocks ───────────────────────────────────────────────────────
+
 import LoginPage from "../../src/app/pages/LoginPage";
-import { OAUTH_STATE_KEY } from "../../src/app/lib/oauth";
+import * as authStore from "../../src/app/stores/auth";
+import * as patLib from "../../src/app/lib/pat";
 
-describe("LoginPage", () => {
-  beforeEach(() => {
-    // Allow setting window.location.href
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      writable: true,
-      value: { href: "", origin: "http://localhost" },
-    });
-    sessionStorage.clear();
-    // Stub the env var used by the component
-    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const githubUser = { login: "testuser", avatar_url: "https://avatars.githubusercontent.com/u/1", name: "Test User" };
+
+function mockFetchOk() {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(githubUser),
+  }));
+}
+
+function mockFetch401() {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: false,
+    status: 401,
+  }));
+}
+
+function mockFetch503() {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: false,
+    status: 503,
+  }));
+}
+
+function mockFetchNetworkError() {
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authStore.validateToken).mockResolvedValue(true);
+  mockFetchOk();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: { href: "", origin: "http://localhost" },
   });
+  sessionStorage.clear();
+  vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+});
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
-  it("renders the app title", () => {
-    render(() => <LoginPage />);
-    screen.getByText("GitHub Tracker");
-  });
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
-  it("renders the sign in button", () => {
+describe("LoginPage — OAuth view (default)", () => {
+  it("shows 'Sign in with GitHub' button", () => {
     render(() => <LoginPage />);
     screen.getByText("Sign in with GitHub");
   });
 
-  it("shows app branding description", () => {
+  it("shows 'Use a Personal Access Token' link", () => {
     render(() => <LoginPage />);
+    screen.getByText("Use a Personal Access Token");
+  });
+
+  it("shows app title and description", () => {
+    render(() => <LoginPage />);
+    screen.getByText("GitHub Tracker");
     screen.getByText(/Track issues, pull requests/i);
   });
 
-  it("clicking login sets window.location.href to GitHub OAuth URL", async () => {
+  it("clicking 'Sign in with GitHub' navigates to OAuth URL", async () => {
     const user = userEvent.setup();
     render(() => <LoginPage />);
-    const button = screen.getByText("Sign in with GitHub");
-    await user.click(button);
+    await user.click(screen.getByText("Sign in with GitHub"));
     expect(window.location.href).toContain("https://github.com/login/oauth/authorize");
   });
+});
 
-  it("OAuth URL includes correct client_id", async () => {
+describe("LoginPage — PAT form navigation", () => {
+  it("clicking 'Use a Personal Access Token' shows PAT form", async () => {
     const user = userEvent.setup();
     render(() => <LoginPage />);
-    const button = screen.getByText("Sign in with GitHub");
-    await user.click(button);
-    const url = new URL(window.location.href);
-    // The component reads import.meta.env.VITE_GITHUB_CLIENT_ID at click-time
-    // It falls back to whatever is in the env — we verify it is present
-    expect(url.searchParams.get("client_id")).toBeTruthy();
+    await user.click(screen.getByText("Use a Personal Access Token"));
+    screen.getByText("Sign in with Token");
+    screen.getByLabelText("Personal access token");
   });
 
-  it("OAuth URL includes state param", async () => {
+  it("PAT form shows submit button and instructions", async () => {
     const user = userEvent.setup();
     render(() => <LoginPage />);
-    const button = screen.getByText("Sign in with GitHub");
-    await user.click(button);
-    const url = new URL(window.location.href);
-    const state = url.searchParams.get("state");
-    expect(state).toBeTruthy();
-    expect(state!.length).toBeGreaterThan(0);
+    await user.click(screen.getByText("Use a Personal Access Token"));
+    screen.getByRole("button", { name: "Sign in" });
+    screen.getByRole("link", { name: /Classic token/i });
+    screen.getByRole("link", { name: /Fine-grained token/i });
   });
 
-  it("stores state in sessionStorage for CSRF protection", async () => {
+  it("clicking 'Use OAuth instead' returns to OAuth view and clears state", async () => {
     const user = userEvent.setup();
     render(() => <LoginPage />);
-    const button = screen.getByText("Sign in with GitHub");
-    await user.click(button);
-    const stored = sessionStorage.getItem(OAUTH_STATE_KEY);
-    expect(stored).toBeTruthy();
+    await user.click(screen.getByText("Use a Personal Access Token"));
+    screen.getByText("Sign in with Token");
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_test");
+    await user.click(screen.getByText("Use OAuth instead"));
+    screen.getByText("Sign in with GitHub");
+    expect(screen.queryByText("Sign in with Token")).toBeNull();
   });
+});
 
-  it("state in URL matches state in sessionStorage", async () => {
+describe("LoginPage — PAT form validation", () => {
+  async function openPatForm() {
     const user = userEvent.setup();
     render(() => <LoginPage />);
-    const button = screen.getByText("Sign in with GitHub");
-    await user.click(button);
-    const url = new URL(window.location.href);
-    const urlState = url.searchParams.get("state");
-    const storedState = sessionStorage.getItem(OAUTH_STATE_KEY);
-    expect(urlState).toBe(storedState);
+    await user.click(screen.getByText("Use a Personal Access Token"));
+    return user;
+  }
+
+  it("shows validation error for invalid token format", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({
+      valid: false,
+      error: "Token should start with ghp_ (classic) or github_pat_ (fine-grained)",
+    });
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "bad-token");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    screen.getByRole("alert");
+    expect(screen.getByRole("alert").textContent).toContain("should start with ghp_");
   });
 
-  it("OAuth URL includes redirect_uri with /oauth/callback", async () => {
-    const user = userEvent.setup();
-    render(() => <LoginPage />);
-    const button = screen.getByText("Sign in with GitHub");
-    await user.click(button);
-    const url = new URL(window.location.href);
-    expect(url.searchParams.get("redirect_uri")).toContain("/oauth/callback");
+  it("shows 'Token is invalid' error on 401 from GitHub", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    mockFetch401();
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("Token is invalid");
+    });
+    // Token was never stored — setAuthFromPat should NOT have been called
+    expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
   });
 
-  it("OAuth URL includes scope parameter with required scopes", async () => {
-    const user = userEvent.setup();
-    render(() => <LoginPage />);
-    const button = screen.getByText("Sign in with GitHub");
-    await user.click(button);
-    const url = new URL(window.location.href);
-    expect(url.searchParams.get("scope")).toBe("repo read:org notifications");
+  it("shows status-specific error on non-401 HTTP failure", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    mockFetch503();
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("503");
+    });
+    expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
   });
 
-  it("each login click generates a unique state", async () => {
-    // Render two separate instances to simulate two clicks
-    const { unmount } = render(() => <LoginPage />);
-    const user1 = userEvent.setup();
-    await user1.click(screen.getByText("Sign in with GitHub"));
-    const state1 = new URL(window.location.href).searchParams.get("state");
-    unmount();
+  it("calls navigate('/') on successful validation", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    mockFetchOk();
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    });
+    expect(authStore.setAuthFromPat).toHaveBeenCalled();
+  });
 
-    render(() => <LoginPage />);
-    const user2 = userEvent.setup();
-    await user2.click(screen.getByText("Sign in with GitHub"));
-    const state2 = new URL(window.location.href).searchParams.get("state");
+  it("shows 'Verifying...' and disables button while submitting", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    let resolveFetch!: (v: Response) => void;
+    vi.stubGlobal("fetch", vi.fn().mockReturnValueOnce(
+      new Promise<Response>((r) => { resolveFetch = r; })
+    ));
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      const btn = screen.getByRole("button", { name: "Verifying..." });
+      expect(btn.hasAttribute("disabled")).toBe(true);
+    });
+    resolveFetch({ ok: true, status: 200, json: () => Promise.resolve(githubUser) } as Response);
+  });
 
-    // States should be random — extremely unlikely to collide
-    expect(state1).not.toBe(state2);
+  it("shows 'Network error' on fetch failure", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    mockFetchNetworkError();
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("Network error");
+    });
+    expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when user switches to OAuth during validation", async () => {
+    vi.mocked(patLib.isValidPatFormat).mockReturnValueOnce({ valid: true });
+    let resolveFetch!: (v: Response) => void;
+    vi.stubGlobal("fetch", vi.fn().mockReturnValueOnce(
+      new Promise<Response>((r) => { resolveFetch = r; })
+    ));
+    const user = await openPatForm();
+    await user.type(screen.getByLabelText("Personal access token"), "ghp_" + "a".repeat(36));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      screen.getByRole("button", { name: "Verifying..." });
+    });
+    // User switches back to OAuth view while fetch is in-flight
+    await user.click(screen.getByText("Use OAuth instead"));
+    // Resolve fetch as successful — but user already left
+    resolveFetch({ ok: true, status: 200, json: () => Promise.resolve(githubUser) } as Response);
+    // Wait a tick for the async handler to complete
+    await new Promise((r) => setTimeout(r, 50));
+    // Token was never stored and navigation never happened
+    expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -115,6 +115,7 @@ beforeEach(() => {
     notifications: { enabled: false, issues: true, pullRequests: true, workflowRuns: true },
     selectedOrgs: [],
     selectedRepos: [],
+    authMethod: "oauth" as const,
   });
 
   sessionStorage.clear();
@@ -512,6 +513,30 @@ describe("SettingsPage — Data: Sign out", () => {
 });
 
 // Theme application tests removed — theme is now handled by createEffect in App.tsx, not SettingsPage
+
+describe("SettingsPage — Auth method display", () => {
+  it("shows 'OAuth' when authMethod is 'oauth'", () => {
+    renderSettings();
+    screen.getByText("OAuth");
+  });
+
+  it("shows 'Personal Access Token' when authMethod is 'pat'", () => {
+    updateConfig({ authMethod: "pat" });
+    renderSettings();
+    screen.getByText("Personal Access Token");
+  });
+
+  it("shows 'Manage org access' when authMethod is 'oauth'", () => {
+    renderSettings();
+    screen.getByRole("button", { name: "Manage org access" });
+  });
+
+  it("hides 'Manage org access' when authMethod is 'pat'", () => {
+    updateConfig({ authMethod: "pat" });
+    renderSettings();
+    expect(screen.queryByRole("button", { name: "Manage org access" })).toBeNull();
+  });
+});
 
 describe("SettingsPage — Manage org access button", () => {
   beforeEach(() => {

--- a/tests/lib/pat.test.ts
+++ b/tests/lib/pat.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { isValidPatFormat } from "../../src/app/lib/pat";
+
+describe("isValidPatFormat", () => {
+  it("rejects empty string", () => {
+    const result = isValidPatFormat("");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Please enter a token");
+  });
+
+  it("rejects whitespace-only string", () => {
+    const result = isValidPatFormat("   ");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Please enter a token");
+  });
+
+  it("rejects random string without valid prefix", () => {
+    const result = isValidPatFormat("some_random_token_value");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("should start with ghp_");
+  });
+
+  it("rejects ghp without underscore (not a truncation)", () => {
+    const result = isValidPatFormat("ghp" + "a".repeat(37));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("should start with ghp_");
+  });
+
+  it("rejects github_pat without trailing underscore", () => {
+    const result = isValidPatFormat("github_pat" + "a".repeat(37));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("should start with ghp_");
+  });
+
+  it("accepts valid classic PAT (ghp_ + 36 chars = 40 total)", () => {
+    const token = "ghp_" + "a".repeat(36);
+    expect(token.length).toBe(40);
+    const result = isValidPatFormat(token);
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("rejects classic PAT one char too short (39 total)", () => {
+    const token = "ghp_" + "a".repeat(35);
+    expect(token.length).toBe(39);
+    const result = isValidPatFormat(token);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("truncated");
+  });
+
+  it("rejects very short classic PAT", () => {
+    const result = isValidPatFormat("ghp_abc");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("truncated");
+  });
+
+  it("accepts valid fine-grained PAT (github_pat_ + 36 chars = 47 total)", () => {
+    const token = "github_pat_" + "a".repeat(36);
+    expect(token.length).toBe(47);
+    const result = isValidPatFormat(token);
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("rejects fine-grained PAT one char too short (46 total)", () => {
+    const token = "github_pat_" + "a".repeat(35);
+    expect(token.length).toBe(46);
+    const result = isValidPatFormat(token);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("truncated");
+  });
+
+  it("rejects very short fine-grained PAT", () => {
+    const result = isValidPatFormat("github_pat_short");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("truncated");
+  });
+
+  it("trims whitespace and validates underlying token", () => {
+    const token = "  ghp_" + "a".repeat(36) + "  ";
+    const result = isValidPatFormat(token);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects bare prefix ghp_ as truncated (not invalid characters)", () => {
+    const result = isValidPatFormat("ghp_");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("truncated");
+  });
+
+  it("rejects token with invalid characters", () => {
+    const token = "ghp_" + "abc!def" + "a".repeat(29);
+    const result = isValidPatFormat(token);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("invalid characters");
+  });
+});

--- a/tests/lib/pat.test.ts
+++ b/tests/lib/pat.test.ts
@@ -1,97 +1,109 @@
 import { describe, it, expect } from "vitest";
 import { isValidPatFormat } from "../../src/app/lib/pat";
 
+/** Type-safe helper: asserts result is invalid and returns the error string */
+function expectInvalid(result: ReturnType<typeof isValidPatFormat>): string {
+  expect(result.valid).toBe(false);
+  if (!result.valid) return result.error;
+  throw new Error("unreachable");
+}
+
 describe("isValidPatFormat", () => {
   it("rejects empty string", () => {
-    const result = isValidPatFormat("");
-    expect(result.valid).toBe(false);
-    expect(result.error).toBe("Please enter a token");
+    expect(expectInvalid(isValidPatFormat(""))).toBe("Please enter a token");
   });
 
   it("rejects whitespace-only string", () => {
-    const result = isValidPatFormat("   ");
-    expect(result.valid).toBe(false);
-    expect(result.error).toBe("Please enter a token");
+    expect(expectInvalid(isValidPatFormat("   "))).toBe("Please enter a token");
   });
 
   it("rejects random string without valid prefix", () => {
-    const result = isValidPatFormat("some_random_token_value");
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("should start with ghp_");
+    expect(expectInvalid(isValidPatFormat("some_random_token_value"))).toContain("should start with ghp_");
   });
 
   it("rejects ghp without underscore (not a truncation)", () => {
-    const result = isValidPatFormat("ghp" + "a".repeat(37));
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("should start with ghp_");
+    expect(expectInvalid(isValidPatFormat("ghp" + "a".repeat(37)))).toContain("should start with ghp_");
   });
 
   it("rejects github_pat without trailing underscore", () => {
-    const result = isValidPatFormat("github_pat" + "a".repeat(37));
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("should start with ghp_");
+    expect(expectInvalid(isValidPatFormat("github_pat" + "a".repeat(37)))).toContain("should start with ghp_");
   });
 
   it("accepts valid classic PAT (ghp_ + 36 chars = 40 total)", () => {
     const token = "ghp_" + "a".repeat(36);
     expect(token.length).toBe(40);
-    const result = isValidPatFormat(token);
-    expect(result.valid).toBe(true);
-    expect(result.error).toBeUndefined();
+    expect(isValidPatFormat(token).valid).toBe(true);
   });
 
   it("rejects classic PAT one char too short (39 total)", () => {
     const token = "ghp_" + "a".repeat(35);
     expect(token.length).toBe(39);
-    const result = isValidPatFormat(token);
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("truncated");
+    expect(expectInvalid(isValidPatFormat(token))).toContain("truncated");
   });
 
   it("rejects very short classic PAT", () => {
-    const result = isValidPatFormat("ghp_abc");
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("truncated");
+    expect(expectInvalid(isValidPatFormat("ghp_abc"))).toContain("truncated");
   });
 
-  it("accepts valid fine-grained PAT (github_pat_ + 36 chars = 47 total)", () => {
-    const token = "github_pat_" + "a".repeat(36);
-    expect(token.length).toBe(47);
-    const result = isValidPatFormat(token);
-    expect(result.valid).toBe(true);
-    expect(result.error).toBeUndefined();
+  it("accepts valid fine-grained PAT (github_pat_ + 69 chars = 80 total)", () => {
+    const token = "github_pat_" + "a".repeat(69);
+    expect(token.length).toBe(80);
+    expect(isValidPatFormat(token).valid).toBe(true);
   });
 
-  it("rejects fine-grained PAT one char too short (46 total)", () => {
-    const token = "github_pat_" + "a".repeat(35);
-    expect(token.length).toBe(46);
-    const result = isValidPatFormat(token);
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("truncated");
+  it("accepts realistic fine-grained PAT (~93 chars)", () => {
+    const token = "github_pat_" + "a1b2c3d4e5".repeat(8) + "ab";
+    expect(token.length).toBe(93);
+    expect(isValidPatFormat(token).valid).toBe(true);
+  });
+
+  it("rejects fine-grained PAT one char too short (79 total)", () => {
+    const token = "github_pat_" + "a".repeat(68);
+    expect(token.length).toBe(79);
+    expect(expectInvalid(isValidPatFormat(token))).toContain("truncated");
   });
 
   it("rejects very short fine-grained PAT", () => {
-    const result = isValidPatFormat("github_pat_short");
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("truncated");
+    expect(expectInvalid(isValidPatFormat("github_pat_short"))).toContain("truncated");
+  });
+
+  it("rejects truncated fine-grained PAT that would pass old minimum (47 chars)", () => {
+    const token = "github_pat_" + "a".repeat(36);
+    expect(token.length).toBe(47);
+    expect(expectInvalid(isValidPatFormat(token))).toContain("truncated");
   });
 
   it("trims whitespace and validates underlying token", () => {
     const token = "  ghp_" + "a".repeat(36) + "  ";
-    const result = isValidPatFormat(token);
-    expect(result.valid).toBe(true);
+    expect(isValidPatFormat(token).valid).toBe(true);
   });
 
   it("rejects bare prefix ghp_ as truncated (not invalid characters)", () => {
-    const result = isValidPatFormat("ghp_");
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain("truncated");
+    expect(expectInvalid(isValidPatFormat("ghp_"))).toContain("truncated");
   });
 
   it("rejects token with invalid characters", () => {
     const token = "ghp_" + "abc!def" + "a".repeat(29);
-    const result = isValidPatFormat(token);
+    expect(expectInvalid(isValidPatFormat(token))).toContain("invalid characters");
+  });
+
+  it("accepts fine-grained PAT with underscores in payload", () => {
+    const token = "github_pat_" + "abc_def_ghi_".repeat(6) + "abcdef";
+    expect(token.length).toBeGreaterThanOrEqual(80);
+    expect(isValidPatFormat(token).valid).toBe(true);
+  });
+
+  it("returns discriminated union — no error key when valid", () => {
+    const result = isValidPatFormat("ghp_" + "a".repeat(36));
+    expect(result.valid).toBe(true);
+    expect("error" in result).toBe(false);
+  });
+
+  it("returns discriminated union — error present when invalid", () => {
+    const result = isValidPatFormat("bad");
     expect(result.valid).toBe(false);
-    expect(result.error).toContain("invalid characters");
+    if (!result.valid) {
+      expect(result.error).toBeTruthy();
+    }
   });
 });

--- a/tests/services/poll-fetchAllData.test.ts
+++ b/tests/services/poll-fetchAllData.test.ts
@@ -547,6 +547,44 @@ describe("fetchAllData — notification gate 403 auto-disable", () => {
     expect(fetchIssuesAndPullRequests).toHaveBeenCalled();
     expect(fetchWorkflowRuns).toHaveBeenCalled();
   });
+
+  it("shows PAT-specific 403 notification when authMethod is 'pat'", async () => {
+    vi.resetModules();
+
+    // Override config mock to include authMethod: "pat" for this test
+    vi.doMock("../../src/app/stores/config", () => ({
+      config: {
+        selectedRepos: [{ owner: "octocat", name: "Hello-World", fullName: "octocat/Hello-World" }],
+        maxWorkflowsPerRepo: 5,
+        maxRunsPerWorkflow: 3,
+        authMethod: "pat",
+      },
+    }));
+
+    const { getClient } = await import("../../src/app/services/github");
+    const { fetchIssuesAndPullRequests, fetchWorkflowRuns } = await import("../../src/app/services/api");
+    const { pushNotification } = await import("../../src/app/lib/errors");
+    const mockOctokit = makeMockOctokit();
+    vi.mocked(getClient).mockReturnValue(mockOctokit as unknown as ReturnType<typeof getClient>);
+    vi.mocked(fetchIssuesAndPullRequests).mockResolvedValue(emptyIssuesAndPrsResult);
+    vi.mocked(fetchWorkflowRuns).mockResolvedValue(emptyRunResult);
+
+    const { fetchAllData } = await import("../../src/app/services/poll");
+
+    // First call — sets _lastSuccessfulFetch
+    await fetchAllData();
+
+    // Second call — gate fires a 403
+    mockOctokit.request.mockRejectedValueOnce({ status: 403 });
+    await fetchAllData();
+
+    // PAT-specific message should mention fine-grained tokens
+    expect(pushNotification).toHaveBeenCalledWith(
+      "notifications",
+      expect.stringContaining("fine-grained tokens do not support notifications"),
+      "warning"
+    );
+  });
 });
 
 // ── qa-4: Concurrency verification ────────────────────────────────────────────

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -290,6 +290,8 @@ describe("setAuthFromPat", () => {
   let mod: typeof import("../../src/app/stores/auth");
   let configMod: typeof import("../../src/app/stores/config");
 
+  const testUser = { login: "testuser", avatar_url: "https://avatars.githubusercontent.com/u/1", name: "Test User" };
+
   beforeEach(async () => {
     localStorageMock.clear();
     vi.resetModules();
@@ -302,22 +304,32 @@ describe("setAuthFromPat", () => {
   });
 
   it("stores token in localStorage", () => {
-    mod.setAuthFromPat("ghp_testtoken123");
+    mod.setAuthFromPat("ghp_testtoken123", testUser);
     expect(localStorageMock.getItem("github-tracker:auth-token")).toBe("ghp_testtoken123");
   });
 
   it("sets token signal", () => {
-    mod.setAuthFromPat("ghp_testtoken123");
+    mod.setAuthFromPat("ghp_testtoken123", testUser);
     expect(mod.token()).toBe("ghp_testtoken123");
   });
 
+  it("populates user signal", () => {
+    mod.setAuthFromPat("ghp_testtoken123", testUser);
+    expect(mod.user()).toEqual(testUser);
+  });
+
+  it("sets isAuthenticated to true", () => {
+    mod.setAuthFromPat("ghp_testtoken123", testUser);
+    expect(mod.isAuthenticated()).toBe(true);
+  });
+
   it("sets config.authMethod to 'pat'", () => {
-    mod.setAuthFromPat("ghp_testtoken123");
+    mod.setAuthFromPat("ghp_testtoken123", testUser);
     expect(configMod.config.authMethod).toBe("pat");
   });
 
   it("clearAuth resets authMethod to 'oauth'", () => {
-    mod.setAuthFromPat("ghp_testtoken123");
+    mod.setAuthFromPat("ghp_testtoken123", testUser);
     expect(configMod.config.authMethod).toBe("pat");
     mod.clearAuth();
     expect(configMod.config.authMethod).toBe("oauth");

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -285,3 +285,41 @@ describe("validateToken", () => {
     expect(localStorageMock.getItem("github-tracker:auth-token")).toBe("ghs_permanent");
   });
 });
+
+describe("setAuthFromPat", () => {
+  let mod: typeof import("../../src/app/stores/auth");
+  let configMod: typeof import("../../src/app/stores/config");
+
+  beforeEach(async () => {
+    localStorageMock.clear();
+    vi.resetModules();
+    mod = await import("../../src/app/stores/auth");
+    configMod = await import("../../src/app/stores/config");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stores token in localStorage", () => {
+    mod.setAuthFromPat("ghp_testtoken123");
+    expect(localStorageMock.getItem("github-tracker:auth-token")).toBe("ghp_testtoken123");
+  });
+
+  it("sets token signal", () => {
+    mod.setAuthFromPat("ghp_testtoken123");
+    expect(mod.token()).toBe("ghp_testtoken123");
+  });
+
+  it("sets config.authMethod to 'pat'", () => {
+    mod.setAuthFromPat("ghp_testtoken123");
+    expect(configMod.config.authMethod).toBe("pat");
+  });
+
+  it("clearAuth resets authMethod to 'oauth'", () => {
+    mod.setAuthFromPat("ghp_testtoken123");
+    expect(configMod.config.authMethod).toBe("pat");
+    mod.clearAuth();
+    expect(configMod.config.authMethod).toBe("oauth");
+  });
+});

--- a/tests/stores/config.test.ts
+++ b/tests/stores/config.test.ts
@@ -45,6 +45,7 @@ describe("ConfigSchema", () => {
     expect(result.defaultTab).toBe("issues");
     expect(result.rememberLastTab).toBe(true);
     expect(result.onboardingComplete).toBe(false);
+    expect(result.authMethod).toBe("oauth");
   });
 
   it("fills missing fields from defaults when partial input given", () => {


### PR DESCRIPTION
## Summary
- Adds PAT login as an alternative to OAuth with validate-before-store pattern, client-side format validation, and detailed token creation instructions for classic and fine-grained PATs
- Settings page shows current auth method and hides OAuth-specific org access UI for PAT users
- Auth-method-aware notification messaging for fine-grained PAT users encountering expected 403s