### PR TITLE
feat(dashboard): adds state visibility and repo locking

### DIFF
--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -1,8 +1,8 @@
-import { createEffect, createMemo, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show, onCleanup } from "solid-js";
 import { createStore } from "solid-js/store";
 import type { WorkflowRun } from "../../services/api";
 import { config } from "../../stores/config";
-import { viewState, setViewState, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, type ActionsFilterField } from "../../stores/view";
+import { viewState, setViewState, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type ActionsFilterField } from "../../stores/view";
 import WorkflowSummaryCard from "./WorkflowSummaryCard";
 import IgnoreBadge from "./IgnoreBadge";
 import SkeletonRows from "../shared/SkeletonRows";
@@ -10,11 +10,14 @@ import FilterChips from "../shared/FilterChips";
 import type { FilterChipGroupDef } from "../shared/FilterChips";
 import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
+import RepoLockControls from "../shared/RepoLockControls";
+import { orderRepoGroups, detectReorderedRepos } from "../../lib/grouping";
 
 interface ActionsTabProps {
   workflowRuns: WorkflowRun[];
   loading?: boolean;
   hasUpstreamRepos?: boolean;
+  hotPollingRunIds?: ReadonlySet<number>;
 }
 
 interface WorkflowGroup {
@@ -134,6 +137,105 @@ export default function ActionsTab(props: ActionsTabProps) {
     pruneExpandedRepos("actions", names);
   });
 
+  createEffect(() => {
+    const names = repoGroups().map(g => g.repoFullName);
+    pruneLockedRepos("actions", names);
+  });
+
+  interface PeekUpdate {
+    itemLabel: string;
+    newStatus: string;
+  }
+  const [peekUpdates, setPeekUpdates] = createSignal<ReadonlyMap<string, PeekUpdate>>(new Map());
+  let peekTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  let prevRunValues = new Map<number, { status: string; conclusion: string | null }>();
+  let flashRunTimeout: ReturnType<typeof setTimeout> | undefined;
+  const [flashingRunIds, setFlashingRunIds] = createSignal<ReadonlySet<number>>(new Set());
+
+  createEffect(() => {
+    const runs = props.workflowRuns;
+    const hotIds = props.hotPollingRunIds;
+
+    if (prevRunValues.size === 0) {
+      prevRunValues = new Map(runs.map(r => [r.id, { status: r.status, conclusion: r.conclusion }]));
+      return;
+    }
+
+    // Only detect changes for hot-polled items — full refresh replaces all data
+    // and would cause mass flashing if not gated.
+    if (!hotIds || hotIds.size === 0) {
+      prevRunValues = new Map(runs.map(r => [r.id, { status: r.status, conclusion: r.conclusion }]));
+      return;
+    }
+
+    const changed = new Set<number>();
+    for (const run of runs) {
+      if (!hotIds.has(run.id)) continue;
+      const prev = prevRunValues.get(run.id);
+      if (prev && (prev.status !== run.status || prev.conclusion !== run.conclusion)) {
+        changed.add(run.id);
+      }
+    }
+
+    prevRunValues = new Map(runs.map(r => [r.id, { status: r.status, conclusion: r.conclusion }]));
+
+    if (changed.size > 0) {
+      setFlashingRunIds(prev => new Set([...prev, ...changed]));
+      clearTimeout(flashRunTimeout);
+      flashRunTimeout = setTimeout(() => setFlashingRunIds(new Set<number>()), 1000);
+
+      // Peek: surface changed runs in collapsed repos
+      const peeks = new Map<string, PeekUpdate>();
+      for (const run of runs) {
+        if (changed.has(run.id)) {
+          const isCollapsed = !viewState.expandedRepos.actions[run.repoFullName];
+          if (isCollapsed) {
+            peeks.set(run.repoFullName, {
+              itemLabel: run.name,
+              newStatus: run.conclusion ?? run.status,
+            });
+          }
+        }
+      }
+      if (peeks.size > 0) {
+        setPeekUpdates(peeks);
+        clearTimeout(peekTimeout);
+        peekTimeout = setTimeout(() => setPeekUpdates(new Map()), 3000);
+      }
+    }
+  });
+
+  let prevRepoOrderActions: string[] = [];
+  let prevLockedOrderActions: string[] = [];
+  let highlightTimeoutActions: ReturnType<typeof setTimeout> | undefined;
+  const [highlightedReposActions, setHighlightedReposActions] = createSignal<ReadonlySet<string>>(new Set());
+
+  createEffect(() => {
+    const currentOrder = repoGroups().map(g => g.repoFullName);
+    const currentLocked = viewState.lockedRepos.actions;
+
+    const lockedChanged = currentLocked.length !== prevLockedOrderActions.length
+      || currentLocked.some((r, i) => r !== prevLockedOrderActions[i]);
+
+    if (prevRepoOrderActions.length > 0 && !lockedChanged) {
+      const moved = detectReorderedRepos(prevRepoOrderActions, currentOrder);
+      if (moved.size > 0) {
+        setHighlightedReposActions(moved);
+        clearTimeout(highlightTimeoutActions);
+        highlightTimeoutActions = setTimeout(() => setHighlightedReposActions(new Set<string>()), 1500);
+      }
+    }
+
+    prevRepoOrderActions = currentOrder;
+    prevLockedOrderActions = [...currentLocked];
+  });
+  onCleanup(() => {
+    clearTimeout(flashRunTimeout);
+    clearTimeout(peekTimeout);
+    clearTimeout(highlightTimeoutActions);
+  });
+
   function handleIgnore(run: WorkflowRun) {
     ignoreItem({
       id: String(run.id),
@@ -182,7 +284,9 @@ export default function ActionsTab(props: ActionsTabProps) {
     });
   });
 
-  const repoGroups = createMemo(() => groupRuns(filteredRuns()));
+  const repoGroups = createMemo(() =>
+    orderRepoGroups(groupRuns(filteredRuns()), viewState.lockedRepos.actions)
+  );
 
   return (
     <div class="divide-y divide-base-300">
@@ -259,37 +363,51 @@ export default function ActionsTab(props: ActionsTabProps) {
             return (
               <div class="bg-base-100">
                 {/* Repo header */}
-                <button
-                  onClick={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
-                  aria-expanded={isExpanded()}
-                  class="w-full flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors"
-                >
-                  <ChevronIcon size="md" rotated={!isExpanded()} />
-                  {repoGroup.repoFullName}
-                  <Show when={!isExpanded()}>
-                    <span class="ml-auto text-xs font-normal text-base-content/60">
-                      {collapsedSummary().total} workflow{collapsedSummary().total !== 1 ? "s" : ""}
-                      <Show when={collapsedSummary().passed > 0 || collapsedSummary().failed > 0 || collapsedSummary().running > 0}>
-                        {": "}
-                        <Show when={collapsedSummary().passed > 0}>
-                          <span>{collapsedSummary().passed} passed</span>
+                <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposActions().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
+                  <button
+                    onClick={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
+                    aria-expanded={isExpanded()}
+                    class="flex-1 flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content"
+                  >
+                    <ChevronIcon size="md" rotated={!isExpanded()} />
+                    {repoGroup.repoFullName}
+                    <Show when={!isExpanded()}>
+                      <span class="ml-auto text-xs font-normal text-base-content/60">
+                        {collapsedSummary().total} workflow{collapsedSummary().total !== 1 ? "s" : ""}
+                        <Show when={collapsedSummary().passed > 0 || collapsedSummary().failed > 0 || collapsedSummary().running > 0}>
+                          {": "}
+                          <Show when={collapsedSummary().passed > 0}>
+                            <span>{collapsedSummary().passed} passed</span>
+                          </Show>
+                          <Show when={collapsedSummary().passed > 0 && (collapsedSummary().failed > 0 || collapsedSummary().running > 0)}>
+                            {", "}
+                          </Show>
+                          <Show when={collapsedSummary().failed > 0}>
+                            <span class="text-error font-medium">{collapsedSummary().failed} failed</span>
+                          </Show>
+                          <Show when={collapsedSummary().failed > 0 && collapsedSummary().running > 0}>
+                            {", "}
+                          </Show>
+                          <Show when={collapsedSummary().running > 0}>
+                            <span>{collapsedSummary().running} running</span>
+                          </Show>
                         </Show>
-                        <Show when={collapsedSummary().passed > 0 && (collapsedSummary().failed > 0 || collapsedSummary().running > 0)}>
-                          {", "}
-                        </Show>
-                        <Show when={collapsedSummary().failed > 0}>
-                          <span class="text-error font-medium">{collapsedSummary().failed} failed</span>
-                        </Show>
-                        <Show when={collapsedSummary().failed > 0 && collapsedSummary().running > 0}>
-                          {", "}
-                        </Show>
-                        <Show when={collapsedSummary().running > 0}>
-                          <span>{collapsedSummary().running} running</span>
-                        </Show>
-                      </Show>
+                      </span>
+                    </Show>
+                  </button>
+                  <RepoLockControls tab="actions" repoFullName={repoGroup.repoFullName} />
+                </div>
+                <Show when={!isExpanded() && peekUpdates().has(repoGroup.repoFullName)}>
+                  <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
+                    <span class="loading loading-spinner loading-xs text-primary/60" />
+                    <span class="truncate flex-1">
+                      {peekUpdates().get(repoGroup.repoFullName)!.itemLabel}
                     </span>
-                  </Show>
-                </button>
+                    <span class="badge badge-xs badge-primary">
+                      {peekUpdates().get(repoGroup.repoFullName)!.newStatus}
+                    </span>
+                  </div>
+                </Show>
 
                 {/* Workflow cards grid */}
                 <Show when={isExpanded()}>
@@ -308,6 +426,8 @@ export default function ActionsTab(props: ActionsTabProps) {
                               onToggle={() => toggleWorkflow(wfKey)}
                               onIgnoreRun={handleIgnore}
                               density={config.viewDensity}
+                              hotPollingRunIds={props.hotPollingRunIds}
+                              flashingRunIds={flashingRunIds()}
                             />
                           </div>
                         );

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -397,16 +397,14 @@ export default function ActionsTab(props: ActionsTabProps) {
                   </button>
                   <RepoLockControls tab="actions" repoFullName={repoGroup.repoFullName} />
                 </div>
-                <Show when={!isExpanded() && peekUpdates().has(repoGroup.repoFullName)}>
-                  <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
-                    <span class="loading loading-spinner loading-xs text-primary/60" />
-                    <span class="truncate flex-1">
-                      {peekUpdates().get(repoGroup.repoFullName)!.itemLabel}
-                    </span>
-                    <span class="badge badge-xs badge-primary">
-                      {peekUpdates().get(repoGroup.repoFullName)!.newStatus}
-                    </span>
-                  </div>
+                <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
+                  {(peek) => (
+                    <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
+                      <span class="loading loading-spinner loading-xs text-primary/60" />
+                      <span class="truncate flex-1">{peek().itemLabel}</span>
+                      <span class="badge badge-xs badge-primary">{peek().newStatus}</span>
+                    </div>
+                  )}
                 </Show>
 
                 {/* Workflow cards grid */}

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -254,7 +254,8 @@ export default function ActionsTab(props: ActionsTabProps) {
   );
 
   createEffect(() => {
-    const names = repoGroups().map(g => g.repoFullName);
+    const names = activeRepoNames();
+    if (names.length === 0) return;
     pruneLockedRepos("actions", names);
   });
 

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -137,11 +137,6 @@ export default function ActionsTab(props: ActionsTabProps) {
     pruneExpandedRepos("actions", names);
   });
 
-  createEffect(() => {
-    const names = repoGroups().map(g => g.repoFullName);
-    pruneLockedRepos("actions", names);
-  });
-
   interface PeekUpdate {
     itemLabel: string;
     newStatus: string;
@@ -206,36 +201,6 @@ export default function ActionsTab(props: ActionsTabProps) {
     }
   });
 
-  let prevRepoOrderActions: string[] = [];
-  let prevLockedOrderActions: string[] = [];
-  let highlightTimeoutActions: ReturnType<typeof setTimeout> | undefined;
-  const [highlightedReposActions, setHighlightedReposActions] = createSignal<ReadonlySet<string>>(new Set());
-
-  createEffect(() => {
-    const currentOrder = repoGroups().map(g => g.repoFullName);
-    const currentLocked = viewState.lockedRepos.actions;
-
-    const lockedChanged = currentLocked.length !== prevLockedOrderActions.length
-      || currentLocked.some((r, i) => r !== prevLockedOrderActions[i]);
-
-    if (prevRepoOrderActions.length > 0 && !lockedChanged) {
-      const moved = detectReorderedRepos(prevRepoOrderActions, currentOrder);
-      if (moved.size > 0) {
-        setHighlightedReposActions(moved);
-        clearTimeout(highlightTimeoutActions);
-        highlightTimeoutActions = setTimeout(() => setHighlightedReposActions(new Set<string>()), 1500);
-      }
-    }
-
-    prevRepoOrderActions = currentOrder;
-    prevLockedOrderActions = [...currentLocked];
-  });
-  onCleanup(() => {
-    clearTimeout(flashRunTimeout);
-    clearTimeout(peekTimeout);
-    clearTimeout(highlightTimeoutActions);
-  });
-
   function handleIgnore(run: WorkflowRun) {
     ignoreItem({
       id: String(run.id),
@@ -287,6 +252,41 @@ export default function ActionsTab(props: ActionsTabProps) {
   const repoGroups = createMemo(() =>
     orderRepoGroups(groupRuns(filteredRuns()), viewState.lockedRepos.actions)
   );
+
+  createEffect(() => {
+    const names = repoGroups().map(g => g.repoFullName);
+    pruneLockedRepos("actions", names);
+  });
+
+  let prevRepoOrderActions: string[] = [];
+  let prevLockedOrderActions: string[] = [];
+  let highlightTimeoutActions: ReturnType<typeof setTimeout> | undefined;
+  const [highlightedReposActions, setHighlightedReposActions] = createSignal<ReadonlySet<string>>(new Set());
+
+  createEffect(() => {
+    const currentOrder = repoGroups().map(g => g.repoFullName);
+    const currentLocked = viewState.lockedRepos.actions;
+
+    const lockedChanged = currentLocked.length !== prevLockedOrderActions.length
+      || currentLocked.some((r, i) => r !== prevLockedOrderActions[i]);
+
+    if (prevRepoOrderActions.length > 0 && !lockedChanged) {
+      const moved = detectReorderedRepos(prevRepoOrderActions, currentOrder);
+      if (moved.size > 0) {
+        setHighlightedReposActions(moved);
+        clearTimeout(highlightTimeoutActions);
+        highlightTimeoutActions = setTimeout(() => setHighlightedReposActions(new Set<string>()), 1500);
+      }
+    }
+
+    prevRepoOrderActions = currentOrder;
+    prevLockedOrderActions = [...currentLocked];
+  });
+  onCleanup(() => {
+    clearTimeout(flashRunTimeout);
+    clearTimeout(peekTimeout);
+    clearTimeout(highlightTimeoutActions);
+  });
 
   return (
     <div class="divide-y divide-base-300">

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -11,7 +11,8 @@ import type { FilterChipGroupDef } from "../shared/FilterChips";
 import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import RepoLockControls from "../shared/RepoLockControls";
-import { orderRepoGroups, detectReorderedRepos } from "../../lib/grouping";
+import { orderRepoGroups, type PeekUpdate } from "../../lib/grouping";
+import { createReorderHighlight } from "../../lib/reorderHighlight";
 
 interface ActionsTabProps {
   workflowRuns: WorkflowRun[];
@@ -137,14 +138,11 @@ export default function ActionsTab(props: ActionsTabProps) {
     pruneExpandedRepos("actions", names);
   });
 
-  interface PeekUpdate {
-    itemLabel: string;
-    newStatus: string;
-  }
   const [peekUpdates, setPeekUpdates] = createSignal<ReadonlyMap<string, PeekUpdate>>(new Map());
   let peekTimeout: ReturnType<typeof setTimeout> | undefined;
 
   let prevRunValues = new Map<number, { status: string; conclusion: string | null }>();
+  let prevRunValuesInitialized = false;
   let flashRunTimeout: ReturnType<typeof setTimeout> | undefined;
   const [flashingRunIds, setFlashingRunIds] = createSignal<ReadonlySet<number>>(new Set());
 
@@ -152,7 +150,8 @@ export default function ActionsTab(props: ActionsTabProps) {
     const runs = props.workflowRuns;
     const hotIds = props.hotPollingRunIds;
 
-    if (prevRunValues.size === 0) {
+    if (!prevRunValuesInitialized) {
+      prevRunValuesInitialized = true;
       prevRunValues = new Map(runs.map(r => [r.id, { status: r.status, conclusion: r.conclusion }]));
       return;
     }
@@ -160,7 +159,9 @@ export default function ActionsTab(props: ActionsTabProps) {
     // Only detect changes for hot-polled items — full refresh replaces all data
     // and would cause mass flashing if not gated.
     if (!hotIds || hotIds.size === 0) {
-      prevRunValues = new Map(runs.map(r => [r.id, { status: r.status, conclusion: r.conclusion }]));
+      for (const run of runs) {
+        prevRunValues.set(run.id, { status: run.status, conclusion: run.conclusion });
+      }
       return;
     }
 
@@ -173,7 +174,9 @@ export default function ActionsTab(props: ActionsTabProps) {
       }
     }
 
-    prevRunValues = new Map(runs.map(r => [r.id, { status: r.status, conclusion: r.conclusion }]));
+    for (const run of runs) {
+      prevRunValues.set(run.id, { status: run.status, conclusion: run.conclusion });
+    }
 
     if (changed.size > 0) {
       setFlashingRunIds(prev => new Set([...prev, ...changed]));
@@ -182,14 +185,25 @@ export default function ActionsTab(props: ActionsTabProps) {
 
       // Peek: surface changed runs in collapsed repos
       const peeks = new Map<string, PeekUpdate>();
+      const peekCounts = new Map<string, number>();
       for (const run of runs) {
         if (changed.has(run.id)) {
           const isCollapsed = !viewState.expandedRepos.actions[run.repoFullName];
           if (isCollapsed) {
-            peeks.set(run.repoFullName, {
-              itemLabel: run.name,
-              newStatus: run.conclusion ?? run.status,
-            });
+            const count = (peekCounts.get(run.repoFullName) ?? 0) + 1;
+            peekCounts.set(run.repoFullName, count);
+            if (count === 1) {
+              peeks.set(run.repoFullName, {
+                itemLabel: run.name,
+                newStatus: run.conclusion ?? run.status,
+              });
+            } else {
+              const existing = peeks.get(run.repoFullName)!;
+              peeks.set(run.repoFullName, {
+                itemLabel: `${existing.itemLabel.split(" + ")[0]} + ${count - 1} more`,
+                newStatus: existing.newStatus,
+              });
+            }
           }
         }
       }
@@ -259,34 +273,13 @@ export default function ActionsTab(props: ActionsTabProps) {
     pruneLockedRepos("actions", names);
   });
 
-  let prevRepoOrderActions: string[] = [];
-  let prevLockedOrderActions: string[] = [];
-  let highlightTimeoutActions: ReturnType<typeof setTimeout> | undefined;
-  const [highlightedReposActions, setHighlightedReposActions] = createSignal<ReadonlySet<string>>(new Set());
-
-  createEffect(() => {
-    const currentOrder = repoGroups().map(g => g.repoFullName);
-    const currentLocked = viewState.lockedRepos.actions;
-
-    const lockedChanged = currentLocked.length !== prevLockedOrderActions.length
-      || currentLocked.some((r, i) => r !== prevLockedOrderActions[i]);
-
-    if (prevRepoOrderActions.length > 0 && !lockedChanged) {
-      const moved = detectReorderedRepos(prevRepoOrderActions, currentOrder);
-      if (moved.size > 0) {
-        setHighlightedReposActions(moved);
-        clearTimeout(highlightTimeoutActions);
-        highlightTimeoutActions = setTimeout(() => setHighlightedReposActions(new Set<string>()), 1500);
-      }
-    }
-
-    prevRepoOrderActions = currentOrder;
-    prevLockedOrderActions = [...currentLocked];
-  });
+  const highlightedReposActions = createReorderHighlight(
+    () => repoGroups().map(g => g.repoFullName),
+    () => viewState.lockedRepos.actions,
+  );
   onCleanup(() => {
     clearTimeout(flashRunTimeout);
     clearTimeout(peekTimeout);
-    clearTimeout(highlightTimeoutActions);
   });
 
   return (

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -186,6 +186,7 @@ export default function ActionsTab(props: ActionsTabProps) {
       // Peek: surface changed runs in collapsed repos
       const peeks = new Map<string, PeekUpdate>();
       const peekCounts = new Map<string, number>();
+      const peekFirstLabels = new Map<string, string>();
       for (const run of runs) {
         if (changed.has(run.id)) {
           const isCollapsed = !viewState.expandedRepos.actions[run.repoFullName];
@@ -193,15 +194,15 @@ export default function ActionsTab(props: ActionsTabProps) {
             const count = (peekCounts.get(run.repoFullName) ?? 0) + 1;
             peekCounts.set(run.repoFullName, count);
             if (count === 1) {
+              peekFirstLabels.set(run.repoFullName, run.name);
               peeks.set(run.repoFullName, {
                 itemLabel: run.name,
                 newStatus: run.conclusion ?? run.status,
               });
             } else {
-              const existing = peeks.get(run.repoFullName)!;
               peeks.set(run.repoFullName, {
-                itemLabel: `${existing.itemLabel.split(" + ")[0]} + ${count - 1} more`,
-                newStatus: existing.newStatus,
+                itemLabel: `${peekFirstLabels.get(run.repoFullName)} + ${count - 1} more`,
+                newStatus: peeks.get(run.repoFullName)!.newStatus,
               });
             }
           }

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, For, Show, onCleanup } from "solid-js";
+import { createEffect, createMemo, For, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 import type { WorkflowRun } from "../../services/api";
 import { config } from "../../stores/config";
@@ -11,8 +11,9 @@ import type { FilterChipGroupDef } from "../shared/FilterChips";
 import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import RepoLockControls from "../shared/RepoLockControls";
-import { orderRepoGroups, type PeekUpdate } from "../../lib/grouping";
+import { orderRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
+import { createFlashDetection } from "../../lib/flashDetection";
 
 interface ActionsTabProps {
   workflowRuns: WorkflowRun[];
@@ -138,82 +139,13 @@ export default function ActionsTab(props: ActionsTabProps) {
     pruneExpandedRepos("actions", names);
   });
 
-  const [peekUpdates, setPeekUpdates] = createSignal<ReadonlyMap<string, PeekUpdate>>(new Map());
-  let peekTimeout: ReturnType<typeof setTimeout> | undefined;
-
-  let prevRunValues = new Map<number, { status: string; conclusion: string | null }>();
-  let prevRunValuesInitialized = false;
-  let flashRunTimeout: ReturnType<typeof setTimeout> | undefined;
-  const [flashingRunIds, setFlashingRunIds] = createSignal<ReadonlySet<number>>(new Set());
-
-  createEffect(() => {
-    const runs = props.workflowRuns;
-    const hotIds = props.hotPollingRunIds;
-
-    if (!prevRunValuesInitialized) {
-      prevRunValuesInitialized = true;
-      prevRunValues = new Map(runs.map(r => [r.id, { status: r.status, conclusion: r.conclusion }]));
-      return;
-    }
-
-    // Only detect changes for hot-polled items — full refresh replaces all data
-    // and would cause mass flashing if not gated.
-    if (!hotIds || hotIds.size === 0) {
-      for (const run of runs) {
-        prevRunValues.set(run.id, { status: run.status, conclusion: run.conclusion });
-      }
-      return;
-    }
-
-    const changed = new Set<number>();
-    for (const run of runs) {
-      if (!hotIds.has(run.id)) continue;
-      const prev = prevRunValues.get(run.id);
-      if (prev && (prev.status !== run.status || prev.conclusion !== run.conclusion)) {
-        changed.add(run.id);
-      }
-    }
-
-    for (const run of runs) {
-      prevRunValues.set(run.id, { status: run.status, conclusion: run.conclusion });
-    }
-
-    if (changed.size > 0) {
-      setFlashingRunIds(prev => new Set([...prev, ...changed]));
-      clearTimeout(flashRunTimeout);
-      flashRunTimeout = setTimeout(() => setFlashingRunIds(new Set<number>()), 1000);
-
-      // Peek: surface changed runs in collapsed repos
-      const peeks = new Map<string, PeekUpdate>();
-      const peekCounts = new Map<string, number>();
-      const peekFirstLabels = new Map<string, string>();
-      for (const run of runs) {
-        if (changed.has(run.id)) {
-          const isCollapsed = !viewState.expandedRepos.actions[run.repoFullName];
-          if (isCollapsed) {
-            const count = (peekCounts.get(run.repoFullName) ?? 0) + 1;
-            peekCounts.set(run.repoFullName, count);
-            if (count === 1) {
-              peekFirstLabels.set(run.repoFullName, run.name);
-              peeks.set(run.repoFullName, {
-                itemLabel: run.name,
-                newStatus: run.conclusion ?? run.status,
-              });
-            } else {
-              peeks.set(run.repoFullName, {
-                itemLabel: `${peekFirstLabels.get(run.repoFullName)} + ${count - 1} more`,
-                newStatus: peeks.get(run.repoFullName)!.newStatus,
-              });
-            }
-          }
-        }
-      }
-      if (peeks.size > 0) {
-        setPeekUpdates(peeks);
-        clearTimeout(peekTimeout);
-        peekTimeout = setTimeout(() => setPeekUpdates(new Map()), 3000);
-      }
-    }
+  const { flashingIds: flashingRunIds, peekUpdates } = createFlashDetection({
+    getItems: () => props.workflowRuns,
+    getHotIds: () => props.hotPollingRunIds,
+    getExpandedRepos: () => viewState.expandedRepos.actions,
+    trackKey: (run) => `${run.status}|${run.conclusion}`,
+    itemLabel: (run) => run.name,
+    itemStatus: (run) => run.conclusion ?? run.status,
   });
 
   function handleIgnore(run: WorkflowRun) {
@@ -278,10 +210,6 @@ export default function ActionsTab(props: ActionsTabProps) {
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.actions,
   );
-  onCleanup(() => {
-    clearTimeout(flashRunTimeout);
-    clearTimeout(peekTimeout);
-  });
 
   return (
     <div class="divide-y divide-base-300">

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -220,7 +220,17 @@ async function pollFetch(): Promise<DashboardData> {
 const [_coordinator, _setCoordinator] = createSignal<ReturnType<typeof createPollCoordinator> | null>(null);
 const [_hotCoordinator, _setHotCoordinator] = createSignal<{ destroy: () => void } | null>(null);
 
+function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+}
+
 export default function DashboardPage() {
+  const [hotPollingPRIds, setHotPollingPRIds] = createSignal<ReadonlySet<number>>(new Set());
+  const [hotPollingRunIds, setHotPollingRunIds] = createSignal<ReadonlySet<number>>(new Set());
 
   const initialTab = createMemo<TabId>(() => {
     if (config.rememberLastTab) {
@@ -269,6 +279,16 @@ export default function DashboardPage() {
               run.completedAt = update.completedAt;
             }
           }));
+        },
+        {
+          onStart: (prDbIds, runIds) => {
+            if (!setsEqual(hotPollingPRIds(), prDbIds)) setHotPollingPRIds(prDbIds);
+            if (!setsEqual(hotPollingRunIds(), runIds)) setHotPollingRunIds(runIds);
+          },
+          onEnd: () => {
+            if (hotPollingPRIds().size > 0) setHotPollingPRIds(new Set<number>());
+            if (hotPollingRunIds().size > 0) setHotPollingRunIds(new Set<number>());
+          },
         }
       ));
     }
@@ -355,6 +375,7 @@ export default function DashboardPage() {
                   userLogin={userLogin()}
                   allUsers={allUsers()}
                   trackedUsers={config.trackedUsers}
+                  hotPollingPRIds={hotPollingPRIds()}
                 />
               </Match>
               <Match when={activeTab() === "actions"}>
@@ -362,6 +383,7 @@ export default function DashboardPage() {
                   workflowRuns={dashboardData.workflowRuns}
                   loading={dashboardData.loading}
                   hasUpstreamRepos={config.upstreamRepos.length > 0}
+                  hotPollingRunIds={hotPollingRunIds()}
                 />
               </Match>
             </Switch>

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -22,6 +22,7 @@ import {
 import { clearAuth, user, onAuthCleared, DASHBOARD_STORAGE_KEY } from "../../stores/auth";
 import { getClient, getGraphqlRateLimit } from "../../services/github";
 import { formatCount } from "../../lib/format";
+import { setsEqual } from "../../lib/collections";
 
 // ── Shared dashboard store (module-level to survive navigation) ─────────────
 
@@ -219,14 +220,6 @@ async function pollFetch(): Promise<DashboardData> {
 
 const [_coordinator, _setCoordinator] = createSignal<ReturnType<typeof createPollCoordinator> | null>(null);
 const [_hotCoordinator, _setHotCoordinator] = createSignal<{ destroy: () => void } | null>(null);
-
-function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
-  if (a.size !== b.size) return false;
-  for (const item of a) {
-    if (!b.has(item)) return false;
-  }
-  return true;
-}
 
 export default function DashboardPage() {
   const [hotPollingPRIds, setHotPollingPRIds] = createSignal<ReadonlySet<number>>(new Set());

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, For, Show, onCleanup } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
 import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type IssueFilterField } from "../../stores/view";
 import type { Issue } from "../../services/api";
@@ -15,7 +15,8 @@ import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import { deriveInvolvementRoles } from "../../lib/format";
-import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, detectReorderedRepos } from "../../lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups } from "../../lib/grouping";
+import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
 
 export interface IssuesTabProps {
@@ -187,31 +188,10 @@ export default function IssuesTab(props: IssuesTabProps) {
     pruneLockedRepos("issues", names);
   });
 
-  let prevRepoOrderIssues: string[] = [];
-  let prevLockedOrderIssues: string[] = [];
-  let highlightTimeoutIssues: ReturnType<typeof setTimeout> | undefined;
-  const [highlightedReposIssues, setHighlightedReposIssues] = createSignal<ReadonlySet<string>>(new Set());
-
-  createEffect(() => {
-    const currentOrder = repoGroups().map(g => g.repoFullName);
-    const currentLocked = viewState.lockedRepos.issues;
-
-    const lockedChanged = currentLocked.length !== prevLockedOrderIssues.length
-      || currentLocked.some((r, i) => r !== prevLockedOrderIssues[i]);
-
-    if (prevRepoOrderIssues.length > 0 && !lockedChanged) {
-      const moved = detectReorderedRepos(prevRepoOrderIssues, currentOrder);
-      if (moved.size > 0) {
-        setHighlightedReposIssues(moved);
-        clearTimeout(highlightTimeoutIssues);
-        highlightTimeoutIssues = setTimeout(() => setHighlightedReposIssues(new Set<string>()), 1500);
-      }
-    }
-
-    prevRepoOrderIssues = currentOrder;
-    prevLockedOrderIssues = [...currentLocked];
-  });
-  onCleanup(() => clearTimeout(highlightTimeoutIssues));
+  const highlightedReposIssues = createReorderHighlight(
+    () => repoGroups().map(g => g.repoFullName),
+    () => viewState.lockedRepos.issues,
+  );
 
   function handleSort(field: string, direction: "asc" | "desc") {
     setSortPreference("issues", field, direction);

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -1,6 +1,6 @@
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show, onCleanup } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
-import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, type IssueFilterField } from "../../stores/view";
+import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type IssueFilterField } from "../../stores/view";
 import type { Issue } from "../../services/api";
 import ItemRow from "./ItemRow";
 import UserAvatarBadge, { buildSurfacedByUsers } from "../shared/UserAvatarBadge";
@@ -15,7 +15,8 @@ import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import { deriveInvolvementRoles } from "../../lib/format";
-import { groupByRepo, computePageLayout, slicePageGroups } from "../../lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, detectReorderedRepos } from "../../lib/grouping";
+import RepoLockControls from "../shared/RepoLockControls";
 
 export interface IssuesTabProps {
   issues: Issue[];
@@ -156,7 +157,9 @@ export default function IssuesTab(props: IssuesTabProps) {
   const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
   const issueMeta = createMemo(() => filteredSortedWithMeta().meta);
 
-  const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
+  const repoGroups = createMemo(() =>
+    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos.issues)
+  );
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
@@ -177,6 +180,37 @@ export default function IssuesTab(props: IssuesTabProps) {
     if (names.length === 0) return;
     pruneExpandedRepos("issues", names);
   });
+
+  createEffect(() => {
+    const names = repoGroups().map(g => g.repoFullName);
+    pruneLockedRepos("issues", names);
+  });
+
+  let prevRepoOrderIssues: string[] = [];
+  let prevLockedOrderIssues: string[] = [];
+  let highlightTimeoutIssues: ReturnType<typeof setTimeout> | undefined;
+  const [highlightedReposIssues, setHighlightedReposIssues] = createSignal<ReadonlySet<string>>(new Set());
+
+  createEffect(() => {
+    const currentOrder = repoGroups().map(g => g.repoFullName);
+    const currentLocked = viewState.lockedRepos.issues;
+
+    const lockedChanged = currentLocked.length !== prevLockedOrderIssues.length
+      || currentLocked.some((r, i) => r !== prevLockedOrderIssues[i]);
+
+    if (prevRepoOrderIssues.length > 0 && !lockedChanged) {
+      const moved = detectReorderedRepos(prevRepoOrderIssues, currentOrder);
+      if (moved.size > 0) {
+        setHighlightedReposIssues(moved);
+        clearTimeout(highlightTimeoutIssues);
+        highlightTimeoutIssues = setTimeout(() => setHighlightedReposIssues(new Set<string>()), 1500);
+      }
+    }
+
+    prevRepoOrderIssues = currentOrder;
+    prevLockedOrderIssues = [...currentLocked];
+  });
+  onCleanup(() => clearTimeout(highlightTimeoutIssues));
 
   function handleSort(field: string, direction: "asc" | "desc") {
     setSortPreference("issues", field, direction);
@@ -282,30 +316,33 @@ export default function IssuesTab(props: IssuesTabProps) {
 
                 return (
                   <div class="bg-base-100">
-                    <button
-                      onClick={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
-                      aria-expanded={isExpanded()}
-                      class="w-full flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors"
-                    >
-                      <ChevronIcon size="md" rotated={!isExpanded()} />
-                      {repoGroup.repoFullName}
-                      <Show when={!isExpanded()}>
-                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
-                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
-                          <For each={roleSummary()}>
-                            {([role, count]) => (
-                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                role === "author" ? "bg-primary/10 text-primary" :
-                                role === "assignee" ? "bg-secondary/10 text-secondary" :
-                                "bg-base-300 text-base-content/70"
-                              }`}>
-                                {role} ×{count}
-                              </span>
-                            )}
-                          </For>
-                        </span>
-                      </Show>
-                    </button>
+                    <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposIssues().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
+                      <button
+                        onClick={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
+                        aria-expanded={isExpanded()}
+                        class="flex-1 flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content"
+                      >
+                        <ChevronIcon size="md" rotated={!isExpanded()} />
+                        {repoGroup.repoFullName}
+                        <Show when={!isExpanded()}>
+                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
+                            <For each={roleSummary()}>
+                              {([role, count]) => (
+                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                  role === "author" ? "bg-primary/10 text-primary" :
+                                  role === "assignee" ? "bg-secondary/10 text-secondary" :
+                                  "bg-base-300 text-base-content/70"
+                                }`}>
+                                  {role} ×{count}
+                                </span>
+                              )}
+                            </For>
+                          </span>
+                        </Show>
+                      </button>
+                      <RepoLockControls tab="issues" repoFullName={repoGroup.repoFullName} />
+                    </div>
                     <Show when={isExpanded()}>
                       <div role="list" class="divide-y divide-base-300">
                         <For each={repoGroup.items}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -182,7 +182,8 @@ export default function IssuesTab(props: IssuesTabProps) {
   });
 
   createEffect(() => {
-    const names = repoGroups().map(g => g.repoFullName);
+    const names = activeRepoNames();
+    if (names.length === 0) return;
     pruneLockedRepos("issues", names);
   });
 

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -17,6 +17,8 @@ export interface ItemRowProps {
   commentCount?: number;
   hideRepo?: boolean;
   surfacedByBadge?: JSX.Element;
+  isPolling?: boolean;
+  isFlashing?: boolean;
 }
 
 export default function ItemRow(props: ItemRowProps) {
@@ -28,7 +30,8 @@ export default function ItemRow(props: ItemRowProps) {
       class={`group relative flex items-start gap-3
         hover:bg-base-200
         transition-colors
-        ${isCompact() ? "px-4 py-2" : "px-4 py-3"}`}
+        ${isCompact() ? "px-4 py-2" : "px-4 py-3"}
+        ${props.isFlashing ? "animate-flash" : props.isPolling ? "animate-shimmer" : ""}`}
     >
       {/* Overlay link — covers entire row; interactive children use relative z-10 */}
       <Show when={safeUrl()}>
@@ -57,7 +60,7 @@ export default function ItemRow(props: ItemRowProps) {
 
       {/* Main content */}
       <div class="flex-1 min-w-0">
-        <div class={`flex flex-wrap items-baseline gap-x-2 gap-y-0.5 ${isCompact() ? "text-sm" : "text-sm"}`}>
+        <div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-sm">
           <span class="text-base-content/60 shrink-0">
             #{props.number}
           </span>
@@ -100,6 +103,9 @@ export default function ItemRow(props: ItemRowProps) {
           <div class="relative z-10">{props.surfacedByBadge}</div>
         </Show>
         <span title={props.createdAt}>{relativeTime(props.createdAt)}</span>
+        <Show when={props.isPolling}>
+          <span class="loading loading-spinner loading-xs text-base-content/40" />
+        </Show>
         <Show when={(props.commentCount ?? 0) > 0}>
           <span class="flex items-center gap-0.5">
             <svg

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -18,7 +18,8 @@ import SizeBadge from "../shared/SizeBadge";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
-import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, detectReorderedRepos } from "../../lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, type PeekUpdate } from "../../lib/grouping";
+import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
 
 export interface PullRequestsTabProps {
@@ -277,14 +278,11 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     pruneLockedRepos("pullRequests", names);
   });
 
-  interface PeekUpdate {
-    itemLabel: string;
-    newStatus: string;
-  }
   const [peekUpdates, setPeekUpdates] = createSignal<ReadonlyMap<string, PeekUpdate>>(new Map());
   let peekTimeout: ReturnType<typeof setTimeout> | undefined;
 
   let prevPRValues = new Map<number, { checkStatus: string | null; reviewDecision: string | null }>();
+  let prevPRValuesInitialized = false;
   let flashTimeout: ReturnType<typeof setTimeout> | undefined;
   const [flashingPRIds, setFlashingPRIds] = createSignal<ReadonlySet<number>>(new Set());
 
@@ -292,7 +290,8 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     const prs = props.pullRequests;
     const hotIds = props.hotPollingPRIds;
 
-    if (prevPRValues.size === 0) {
+    if (!prevPRValuesInitialized) {
+      prevPRValuesInitialized = true;
       prevPRValues = new Map(prs.map(pr => [pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision }]));
       return;
     }
@@ -300,7 +299,9 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     // Only detect changes for hot-polled items — full refresh replaces all data
     // and would cause mass flashing if not gated.
     if (!hotIds || hotIds.size === 0) {
-      prevPRValues = new Map(prs.map(pr => [pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision }]));
+      for (const pr of prs) {
+        prevPRValues.set(pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision });
+      }
       return;
     }
 
@@ -313,7 +314,9 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
       }
     }
 
-    prevPRValues = new Map(prs.map(pr => [pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision }]));
+    for (const pr of prs) {
+      prevPRValues.set(pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision });
+    }
 
     if (changed.size > 0) {
       setFlashingPRIds(prev => new Set([...prev, ...changed]));
@@ -322,14 +325,25 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
 
       // Peek: surface changed items in collapsed repos
       const peeks = new Map<string, PeekUpdate>();
+      const peekCounts = new Map<string, number>();
       for (const pr of prs) {
         if (changed.has(pr.id)) {
           const isCollapsed = !viewState.expandedRepos.pullRequests[pr.repoFullName];
           if (isCollapsed) {
-            peeks.set(pr.repoFullName, {
-              itemLabel: `#${pr.number} ${pr.title}`,
-              newStatus: pr.checkStatus ?? pr.reviewDecision ?? "updated",
-            });
+            const count = (peekCounts.get(pr.repoFullName) ?? 0) + 1;
+            peekCounts.set(pr.repoFullName, count);
+            if (count === 1) {
+              peeks.set(pr.repoFullName, {
+                itemLabel: `#${pr.number} ${pr.title}`,
+                newStatus: pr.checkStatus ?? pr.reviewDecision ?? "updated",
+              });
+            } else {
+              const existing = peeks.get(pr.repoFullName)!;
+              peeks.set(pr.repoFullName, {
+                itemLabel: `${existing.itemLabel.split(" + ")[0]} + ${count - 1} more`,
+                newStatus: existing.newStatus,
+              });
+            }
           }
         }
       }
@@ -341,34 +355,13 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     }
   });
 
-  let prevRepoOrderPRs: string[] = [];
-  let prevLockedOrderPRs: string[] = [];
-  let highlightTimeoutPRs: ReturnType<typeof setTimeout> | undefined;
-  const [highlightedReposPRs, setHighlightedReposPRs] = createSignal<ReadonlySet<string>>(new Set());
-
-  createEffect(() => {
-    const currentOrder = repoGroups().map(g => g.repoFullName);
-    const currentLocked = viewState.lockedRepos.pullRequests;
-
-    const lockedChanged = currentLocked.length !== prevLockedOrderPRs.length
-      || currentLocked.some((r, i) => r !== prevLockedOrderPRs[i]);
-
-    if (prevRepoOrderPRs.length > 0 && !lockedChanged) {
-      const moved = detectReorderedRepos(prevRepoOrderPRs, currentOrder);
-      if (moved.size > 0) {
-        setHighlightedReposPRs(moved);
-        clearTimeout(highlightTimeoutPRs);
-        highlightTimeoutPRs = setTimeout(() => setHighlightedReposPRs(new Set<string>()), 1500);
-      }
-    }
-
-    prevRepoOrderPRs = currentOrder;
-    prevLockedOrderPRs = [...currentLocked];
-  });
+  const highlightedReposPRs = createReorderHighlight(
+    () => repoGroups().map(g => g.repoFullName),
+    () => viewState.lockedRepos.pullRequests,
+  );
   onCleanup(() => {
     clearTimeout(flashTimeout);
     clearTimeout(peekTimeout);
-    clearTimeout(highlightTimeoutPRs);
   });
 
   function handleSort(field: string, direction: "asc" | "desc") {
@@ -498,62 +491,62 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         {repoGroup.repoFullName}
                         <Show when={!isExpanded()}>
                           <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
-                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
-                          <Show when={summaryMeta().checks.success > 0}>
-                            <span class="flex items-center gap-0.5">
-                              <span class="inline-block w-2 h-2 rounded-full bg-success" />
-                              <span>{summaryMeta().checks.success}</span>
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().checks.failure > 0}>
-                            <span class="flex items-center gap-0.5">
-                              <span class="inline-block w-2 h-2 rounded-full bg-error" />
-                              <span>{summaryMeta().checks.failure}</span>
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().checks.pending > 0}>
-                            <span class="flex items-center gap-0.5">
-                              <span class="inline-block w-2 h-2 rounded-full bg-warning" />
-                              <span>{summaryMeta().checks.pending}</span>
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().checks.conflict > 0}>
-                            <span class="badge badge-warning badge-sm gap-0.5">
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                              </svg>
-                              {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().reviews.APPROVED > 0}>
-                            <span class="badge badge-success badge-sm">
-                              {`Approved ×${summaryMeta().reviews.APPROVED}`}
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
-                            <span class="badge badge-warning badge-sm">
-                              {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
-                            <span class="badge badge-info badge-sm">
-                              {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
-                            </span>
-                          </Show>
-                          <For each={summaryMeta().roles}>
-                            {([role, count]) => (
-                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                role === "author" ? "bg-primary/10 text-primary" :
-                                role === "reviewer" ? "bg-secondary/10 text-secondary" :
-                                role === "assignee" ? "bg-accent/10 text-accent" :
-                                "bg-base-300 text-base-content/70"
-                              }`}>
-                                {`${role} ×${count}`}
+                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
+                            <Show when={summaryMeta().checks.success > 0}>
+                              <span class="flex items-center gap-0.5">
+                                <span class="inline-block w-2 h-2 rounded-full bg-success" />
+                                <span>{summaryMeta().checks.success}</span>
                               </span>
-                            )}
-                          </For>
-                        </span>
-                      </Show>
+                            </Show>
+                            <Show when={summaryMeta().checks.failure > 0}>
+                              <span class="flex items-center gap-0.5">
+                                <span class="inline-block w-2 h-2 rounded-full bg-error" />
+                                <span>{summaryMeta().checks.failure}</span>
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().checks.pending > 0}>
+                              <span class="flex items-center gap-0.5">
+                                <span class="inline-block w-2 h-2 rounded-full bg-warning" />
+                                <span>{summaryMeta().checks.pending}</span>
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().checks.conflict > 0}>
+                              <span class="badge badge-warning badge-sm gap-0.5">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                  <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                                </svg>
+                                {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().reviews.APPROVED > 0}>
+                              <span class="badge badge-success badge-sm">
+                                {`Approved ×${summaryMeta().reviews.APPROVED}`}
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
+                              <span class="badge badge-warning badge-sm">
+                                {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
+                              <span class="badge badge-info badge-sm">
+                                {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
+                              </span>
+                            </Show>
+                            <For each={summaryMeta().roles}>
+                              {([role, count]) => (
+                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                  role === "author" ? "bg-primary/10 text-primary" :
+                                  role === "reviewer" ? "bg-secondary/10 text-secondary" :
+                                  role === "assignee" ? "bg-accent/10 text-accent" :
+                                  "bg-base-300 text-base-content/70"
+                                }`}>
+                                  {`${role} ×${count}`}
+                                </span>
+                              )}
+                            </For>
+                          </span>
+                        </Show>
                       </button>
                       <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
                     </div>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -497,7 +497,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         <ChevronIcon size="md" rotated={!isExpanded()} />
                         {repoGroup.repoFullName}
                         <Show when={!isExpanded()}>
-                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
                           <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
                           <Show when={summaryMeta().checks.success > 0}>
                             <span class="flex items-center gap-0.5">

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -272,7 +272,8 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   });
 
   createEffect(() => {
-    const names = repoGroups().map(g => g.repoFullName);
+    const names = activeRepoNames();
+    if (names.length === 0) return;
     pruneLockedRepos("pullRequests", names);
   });
 

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, For, Show, onCleanup } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
 import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type PullRequestFilterField } from "../../stores/view";
 import type { PullRequest } from "../../services/api";
@@ -18,8 +18,9 @@ import SizeBadge from "../shared/SizeBadge";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
-import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, type PeekUpdate } from "../../lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
+import { createFlashDetection } from "../../lib/flashDetection";
 import RepoLockControls from "../shared/RepoLockControls";
 
 export interface PullRequestsTabProps {
@@ -278,93 +279,19 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     pruneLockedRepos("pullRequests", names);
   });
 
-  const [peekUpdates, setPeekUpdates] = createSignal<ReadonlyMap<string, PeekUpdate>>(new Map());
-  let peekTimeout: ReturnType<typeof setTimeout> | undefined;
-
-  let prevPRValues = new Map<number, { checkStatus: string | null; reviewDecision: string | null }>();
-  let prevPRValuesInitialized = false;
-  let flashTimeout: ReturnType<typeof setTimeout> | undefined;
-  const [flashingPRIds, setFlashingPRIds] = createSignal<ReadonlySet<number>>(new Set());
-
-  createEffect(() => {
-    const prs = props.pullRequests;
-    const hotIds = props.hotPollingPRIds;
-
-    if (!prevPRValuesInitialized) {
-      prevPRValuesInitialized = true;
-      prevPRValues = new Map(prs.map(pr => [pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision }]));
-      return;
-    }
-
-    // Only detect changes for hot-polled items — full refresh replaces all data
-    // and would cause mass flashing if not gated.
-    if (!hotIds || hotIds.size === 0) {
-      for (const pr of prs) {
-        prevPRValues.set(pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision });
-      }
-      return;
-    }
-
-    const changed = new Set<number>();
-    for (const pr of prs) {
-      if (!hotIds.has(pr.id)) continue;
-      const prev = prevPRValues.get(pr.id);
-      if (prev && (prev.checkStatus !== pr.checkStatus || prev.reviewDecision !== pr.reviewDecision)) {
-        changed.add(pr.id);
-      }
-    }
-
-    for (const pr of prs) {
-      prevPRValues.set(pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision });
-    }
-
-    if (changed.size > 0) {
-      setFlashingPRIds(prev => new Set([...prev, ...changed]));
-      clearTimeout(flashTimeout);
-      flashTimeout = setTimeout(() => setFlashingPRIds(new Set<number>()), 1000);
-
-      // Peek: surface changed items in collapsed repos
-      const peeks = new Map<string, PeekUpdate>();
-      const peekCounts = new Map<string, number>();
-      const peekFirstLabels = new Map<string, string>();
-      for (const pr of prs) {
-        if (changed.has(pr.id)) {
-          const isCollapsed = !viewState.expandedRepos.pullRequests[pr.repoFullName];
-          if (isCollapsed) {
-            const count = (peekCounts.get(pr.repoFullName) ?? 0) + 1;
-            peekCounts.set(pr.repoFullName, count);
-            if (count === 1) {
-              const label = `#${pr.number} ${pr.title}`;
-              peekFirstLabels.set(pr.repoFullName, label);
-              peeks.set(pr.repoFullName, {
-                itemLabel: label,
-                newStatus: pr.checkStatus ?? pr.reviewDecision ?? "updated",
-              });
-            } else {
-              peeks.set(pr.repoFullName, {
-                itemLabel: `${peekFirstLabels.get(pr.repoFullName)} + ${count - 1} more`,
-                newStatus: peeks.get(pr.repoFullName)!.newStatus,
-              });
-            }
-          }
-        }
-      }
-      if (peeks.size > 0) {
-        setPeekUpdates(peeks);
-        clearTimeout(peekTimeout);
-        peekTimeout = setTimeout(() => setPeekUpdates(new Map()), 3000);
-      }
-    }
+  const { flashingIds: flashingPRIds, peekUpdates } = createFlashDetection({
+    getItems: () => props.pullRequests,
+    getHotIds: () => props.hotPollingPRIds,
+    getExpandedRepos: () => viewState.expandedRepos.pullRequests,
+    trackKey: (pr) => `${pr.checkStatus}|${pr.reviewDecision}`,
+    itemLabel: (pr) => `#${pr.number} ${pr.title}`,
+    itemStatus: (pr) => pr.checkStatus ?? pr.reviewDecision ?? "updated",
   });
 
   const highlightedReposPRs = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.pullRequests,
   );
-  onCleanup(() => {
-    clearTimeout(flashTimeout);
-    clearTimeout(peekTimeout);
-  });
 
   function handleSort(field: string, direction: "asc" | "desc") {
     setSortPreference("pullRequests", field, direction);

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -556,16 +556,14 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                       </button>
                       <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
                     </div>
-                    <Show when={!isExpanded() && peekUpdates().has(repoGroup.repoFullName)}>
-                      <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
-                        <span class="loading loading-spinner loading-xs text-primary/60" />
-                        <span class="truncate flex-1">
-                          {peekUpdates().get(repoGroup.repoFullName)!.itemLabel}
-                        </span>
-                        <span class="badge badge-xs badge-primary">
-                          {peekUpdates().get(repoGroup.repoFullName)!.newStatus}
-                        </span>
-                      </div>
+                    <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
+                      {(peek) => (
+                        <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
+                          <span class="loading loading-spinner loading-xs text-primary/60" />
+                          <span class="truncate flex-1">{peek().itemLabel}</span>
+                          <span class="badge badge-xs badge-primary">{peek().newStatus}</span>
+                        </div>
+                      )}
                     </Show>
                     <Show when={isExpanded()}>
                       <div role="list" class="divide-y divide-base-300">

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -326,6 +326,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
       // Peek: surface changed items in collapsed repos
       const peeks = new Map<string, PeekUpdate>();
       const peekCounts = new Map<string, number>();
+      const peekFirstLabels = new Map<string, string>();
       for (const pr of prs) {
         if (changed.has(pr.id)) {
           const isCollapsed = !viewState.expandedRepos.pullRequests[pr.repoFullName];
@@ -333,15 +334,16 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
             const count = (peekCounts.get(pr.repoFullName) ?? 0) + 1;
             peekCounts.set(pr.repoFullName, count);
             if (count === 1) {
+              const label = `#${pr.number} ${pr.title}`;
+              peekFirstLabels.set(pr.repoFullName, label);
               peeks.set(pr.repoFullName, {
-                itemLabel: `#${pr.number} ${pr.title}`,
+                itemLabel: label,
                 newStatus: pr.checkStatus ?? pr.reviewDecision ?? "updated",
               });
             } else {
-              const existing = peeks.get(pr.repoFullName)!;
               peeks.set(pr.repoFullName, {
-                itemLabel: `${existing.itemLabel.split(" + ")[0]} + ${count - 1} more`,
-                newStatus: existing.newStatus,
+                itemLabel: `${peekFirstLabels.get(pr.repoFullName)} + ${count - 1} more`,
+                newStatus: peeks.get(pr.repoFullName)!.newStatus,
               });
             }
           }

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -1,6 +1,6 @@
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show, onCleanup } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
-import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, type PullRequestFilterField } from "../../stores/view";
+import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type PullRequestFilterField } from "../../stores/view";
 import type { PullRequest } from "../../services/api";
 import { deriveInvolvementRoles, prSizeCategory } from "../../lib/format";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
@@ -18,7 +18,8 @@ import SizeBadge from "../shared/SizeBadge";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import ChevronIcon from "../shared/ChevronIcon";
-import { groupByRepo, computePageLayout, slicePageGroups } from "../../lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, detectReorderedRepos } from "../../lib/grouping";
+import RepoLockControls from "../shared/RepoLockControls";
 
 export interface PullRequestsTabProps {
   pullRequests: PullRequest[];
@@ -26,6 +27,7 @@ export interface PullRequestsTabProps {
   userLogin: string;
   allUsers?: { login: string; label: string }[];
   trackedUsers?: TrackedUser[];
+  hotPollingPRIds?: ReadonlySet<number>;
 }
 
 type SortField = "repo" | "title" | "author" | "createdAt" | "updatedAt" | "checkStatus" | "reviewDecision" | "size";
@@ -245,7 +247,9 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
   const prMeta = createMemo(() => filteredSortedWithMeta().meta);
 
-  const repoGroups = createMemo(() => groupByRepo(filteredSorted()));
+  const repoGroups = createMemo(() =>
+    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos.pullRequests)
+  );
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
@@ -265,6 +269,105 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     const names = activeRepoNames();
     if (names.length === 0) return;
     pruneExpandedRepos("pullRequests", names);
+  });
+
+  createEffect(() => {
+    const names = repoGroups().map(g => g.repoFullName);
+    pruneLockedRepos("pullRequests", names);
+  });
+
+  interface PeekUpdate {
+    itemLabel: string;
+    newStatus: string;
+  }
+  const [peekUpdates, setPeekUpdates] = createSignal<ReadonlyMap<string, PeekUpdate>>(new Map());
+  let peekTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  let prevPRValues = new Map<number, { checkStatus: string | null; reviewDecision: string | null }>();
+  let flashTimeout: ReturnType<typeof setTimeout> | undefined;
+  const [flashingPRIds, setFlashingPRIds] = createSignal<ReadonlySet<number>>(new Set());
+
+  createEffect(() => {
+    const prs = props.pullRequests;
+    const hotIds = props.hotPollingPRIds;
+
+    if (prevPRValues.size === 0) {
+      prevPRValues = new Map(prs.map(pr => [pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision }]));
+      return;
+    }
+
+    // Only detect changes for hot-polled items — full refresh replaces all data
+    // and would cause mass flashing if not gated.
+    if (!hotIds || hotIds.size === 0) {
+      prevPRValues = new Map(prs.map(pr => [pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision }]));
+      return;
+    }
+
+    const changed = new Set<number>();
+    for (const pr of prs) {
+      if (!hotIds.has(pr.id)) continue;
+      const prev = prevPRValues.get(pr.id);
+      if (prev && (prev.checkStatus !== pr.checkStatus || prev.reviewDecision !== pr.reviewDecision)) {
+        changed.add(pr.id);
+      }
+    }
+
+    prevPRValues = new Map(prs.map(pr => [pr.id, { checkStatus: pr.checkStatus, reviewDecision: pr.reviewDecision }]));
+
+    if (changed.size > 0) {
+      setFlashingPRIds(prev => new Set([...prev, ...changed]));
+      clearTimeout(flashTimeout);
+      flashTimeout = setTimeout(() => setFlashingPRIds(new Set<number>()), 1000);
+
+      // Peek: surface changed items in collapsed repos
+      const peeks = new Map<string, PeekUpdate>();
+      for (const pr of prs) {
+        if (changed.has(pr.id)) {
+          const isCollapsed = !viewState.expandedRepos.pullRequests[pr.repoFullName];
+          if (isCollapsed) {
+            peeks.set(pr.repoFullName, {
+              itemLabel: `#${pr.number} ${pr.title}`,
+              newStatus: pr.checkStatus ?? pr.reviewDecision ?? "updated",
+            });
+          }
+        }
+      }
+      if (peeks.size > 0) {
+        setPeekUpdates(peeks);
+        clearTimeout(peekTimeout);
+        peekTimeout = setTimeout(() => setPeekUpdates(new Map()), 3000);
+      }
+    }
+  });
+
+  let prevRepoOrderPRs: string[] = [];
+  let prevLockedOrderPRs: string[] = [];
+  let highlightTimeoutPRs: ReturnType<typeof setTimeout> | undefined;
+  const [highlightedReposPRs, setHighlightedReposPRs] = createSignal<ReadonlySet<string>>(new Set());
+
+  createEffect(() => {
+    const currentOrder = repoGroups().map(g => g.repoFullName);
+    const currentLocked = viewState.lockedRepos.pullRequests;
+
+    const lockedChanged = currentLocked.length !== prevLockedOrderPRs.length
+      || currentLocked.some((r, i) => r !== prevLockedOrderPRs[i]);
+
+    if (prevRepoOrderPRs.length > 0 && !lockedChanged) {
+      const moved = detectReorderedRepos(prevRepoOrderPRs, currentOrder);
+      if (moved.size > 0) {
+        setHighlightedReposPRs(moved);
+        clearTimeout(highlightTimeoutPRs);
+        highlightTimeoutPRs = setTimeout(() => setHighlightedReposPRs(new Set<string>()), 1500);
+      }
+    }
+
+    prevRepoOrderPRs = currentOrder;
+    prevLockedOrderPRs = [...currentLocked];
+  });
+  onCleanup(() => {
+    clearTimeout(flashTimeout);
+    clearTimeout(peekTimeout);
+    clearTimeout(highlightTimeoutPRs);
   });
 
   function handleSort(field: string, direction: "asc" | "desc") {
@@ -384,15 +487,16 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
 
                 return (
                   <div class="bg-base-100">
-                    <button
-                      onClick={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
-                      aria-expanded={isExpanded()}
-                      class="w-full flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors"
-                    >
-                      <ChevronIcon size="md" rotated={!isExpanded()} />
-                      {repoGroup.repoFullName}
-                      <Show when={!isExpanded()}>
-                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                    <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposPRs().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
+                      <button
+                        onClick={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
+                        aria-expanded={isExpanded()}
+                        class="flex-1 flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-base-content"
+                      >
+                        <ChevronIcon size="md" rotated={!isExpanded()} />
+                        {repoGroup.repoFullName}
+                        <Show when={!isExpanded()}>
+                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
                           <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
                           <Show when={summaryMeta().checks.success > 0}>
                             <span class="flex items-center gap-0.5">
@@ -449,7 +553,20 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                           </For>
                         </span>
                       </Show>
-                    </button>
+                      </button>
+                      <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
+                    </div>
+                    <Show when={!isExpanded() && peekUpdates().has(repoGroup.repoFullName)}>
+                      <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
+                        <span class="loading loading-spinner loading-xs text-primary/60" />
+                        <span class="truncate flex-1">
+                          {peekUpdates().get(repoGroup.repoFullName)!.itemLabel}
+                        </span>
+                        <span class="badge badge-xs badge-primary">
+                          {peekUpdates().get(repoGroup.repoFullName)!.newStatus}
+                        </span>
+                      </div>
+                    </Show>
                     <Show when={isExpanded()}>
                       <div role="list" class="divide-y divide-base-300">
                         <For each={repoGroup.items}>
@@ -475,6 +592,8 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                                       />
                                     : undefined
                                 }
+                                isPolling={props.hotPollingPRIds?.has(pr.id)}
+                                isFlashing={flashingPRIds().has(pr.id)}
                               >
                                 <div class="flex items-center gap-2 flex-wrap">
                                   <Show when={pr.enriched !== false}>

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -21,6 +21,7 @@ function StatusIcon(props: { status: string; conclusion: string | null }) {
         class="h-4 w-4 text-success shrink-0"
         viewBox="0 0 20 20"
         fill="currentColor"
+        role="img"
         aria-label="Success"
       >
         <path
@@ -40,6 +41,7 @@ function StatusIcon(props: { status: string; conclusion: string | null }) {
         class="h-4 w-4 text-error shrink-0"
         viewBox="0 0 20 20"
         fill="currentColor"
+        role="img"
         aria-label="Failure"
       >
         <path
@@ -59,6 +61,7 @@ function StatusIcon(props: { status: string; conclusion: string | null }) {
         class="h-4 w-4 text-base-content/40 shrink-0"
         viewBox="0 0 20 20"
         fill="currentColor"
+        role="img"
         aria-label="Cancelled"
       >
         <path
@@ -78,6 +81,7 @@ function StatusIcon(props: { status: string; conclusion: string | null }) {
         class="h-4 w-4 text-warning animate-spin shrink-0"
         fill="none"
         viewBox="0 0 24 24"
+        role="img"
         aria-label="In progress"
       >
         <circle
@@ -105,6 +109,7 @@ function StatusIcon(props: { status: string; conclusion: string | null }) {
       class="h-4 w-4 text-base-content/40 shrink-0"
       viewBox="0 0 20 20"
       fill="currentColor"
+      role="img"
       aria-label={label}
     >
       <path

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -8,6 +8,8 @@ interface WorkflowRunRowProps {
   run: WorkflowRun;
   onIgnore: (run: WorkflowRun) => void;
   density: Config["viewDensity"];
+  isPolling?: boolean;
+  isFlashing?: boolean;
 }
 
 function StatusIcon(props: { status: string; conclusion: string | null }) {
@@ -126,7 +128,7 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
 
   return (
     <div
-      class={`flex items-center gap-3 ${paddingClass()} hover:bg-base-200 group`}
+      class={`flex items-center gap-3 ${paddingClass()} hover:bg-base-200 group ${props.isFlashing ? "animate-flash" : props.isPolling ? "animate-shimmer" : ""}`}
     >
       <StatusIcon status={props.run.status} conclusion={props.run.conclusion} />
 
@@ -167,6 +169,10 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
       <span class="text-xs text-base-content/40 shrink-0">
         {relativeTime(props.run.createdAt)}
       </span>
+
+      <Show when={props.isPolling}>
+        <span class="loading loading-spinner loading-xs text-base-content/40" />
+      </Show>
 
       <button
         onClick={() => props.onIgnore(props.run)}

--- a/src/app/components/dashboard/WorkflowSummaryCard.tsx
+++ b/src/app/components/dashboard/WorkflowSummaryCard.tsx
@@ -9,6 +9,8 @@ interface WorkflowSummaryCardProps {
   onToggle: () => void;
   onIgnoreRun: (run: WorkflowRun) => void;
   density: "compact" | "comfortable";
+  hotPollingRunIds?: ReadonlySet<number>;
+  flashingRunIds?: ReadonlySet<number>;
 }
 
 export default function WorkflowSummaryCard(props: WorkflowSummaryCardProps) {
@@ -107,6 +109,8 @@ export default function WorkflowSummaryCard(props: WorkflowSummaryCardProps) {
                 run={run}
                 onIgnore={props.onIgnoreRun}
                 density={props.density}
+                isPolling={props.hotPollingRunIds?.has(run.id)}
+                isFlashing={props.flashingRunIds?.has(run.id)}
               />
             )}
           </For>

--- a/src/app/components/dashboard/WorkflowSummaryCard.tsx
+++ b/src/app/components/dashboard/WorkflowSummaryCard.tsx
@@ -80,17 +80,17 @@ export default function WorkflowSummaryCard(props: WorkflowSummaryCardProps) {
         </span>
         <div class="flex items-center gap-1.5 shrink-0">
           <Show when={counts().success > 0}>
-            <span class="text-xs font-medium text-success" title={`${counts().success} successful`}>
+            <span class="text-xs font-medium text-success" title={`${counts().success} successful`} aria-label={`${counts().success} successful`}>
               {counts().success}
             </span>
           </Show>
           <Show when={counts().failure > 0}>
-            <span class="text-xs font-medium text-error" title={`${counts().failure} failed`}>
+            <span class="text-xs font-medium text-error" title={`${counts().failure} failed`} aria-label={`${counts().failure} failed`}>
               {counts().failure}
             </span>
           </Show>
           <Show when={counts().running > 0}>
-            <span class="text-xs font-medium text-warning" title={`${counts().running} running`}>
+            <span class="text-xs font-medium text-warning" title={`${counts().running} running`} aria-label={`${counts().running} running`}>
               {counts().running}
             </span>
           </Show>

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -13,7 +13,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
     return {
       isLocked: idx !== -1,
       isFirst: idx === 0,
-      isLast: idx === list.length - 1,
+      isLast: idx !== -1 && idx === list.length - 1,
     };
   });
 

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -23,7 +23,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         when={lockInfo().isLocked}
         fallback={
           <button
-            class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
+            class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
             onClick={() => lockRepo(props.tab, props.repoFullName)}
             title="Pin this repo to top of list"
             aria-label={`Pin ${props.repoFullName} to top of list`}

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -1,0 +1,74 @@
+import { Show, createMemo } from "solid-js";
+import { viewState, lockRepo, unlockRepo, moveLockedRepo, type LockedReposTab } from "../../stores/view";
+
+interface RepoLockControlsProps {
+  tab: LockedReposTab;
+  repoFullName: string;
+}
+
+export default function RepoLockControls(props: RepoLockControlsProps) {
+  const lockInfo = createMemo(() => {
+    const list = viewState.lockedRepos[props.tab];
+    const idx = list.indexOf(props.repoFullName);
+    return {
+      isLocked: idx !== -1,
+      isFirst: idx === 0,
+      isLast: idx === list.length - 1,
+    };
+  });
+
+  return (
+    <div class="flex items-center gap-0.5 pr-2" onClick={(e) => e.stopPropagation()}>
+      <Show
+        when={lockInfo().isLocked}
+        fallback={
+          <button
+            class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
+            onClick={() => lockRepo(props.tab, props.repoFullName)}
+            title="Pin this repo to top of list"
+            aria-label={`Pin ${props.repoFullName} to top of list`}
+          >
+            {/* Heroicons 20px solid: lock-open */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-base-content/40">
+              <path d="M14.5 1A4.5 4.5 0 0010 5.5V9H3a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-1.5V5.5a3 3 0 116 0v2.75a.75.75 0 001.5 0V5.5A4.5 4.5 0 0014.5 1z" />
+            </svg>
+          </button>
+        }
+      >
+        <button
+          class="btn btn-ghost btn-xs"
+          onClick={() => unlockRepo(props.tab, props.repoFullName)}
+          title="Pinned to top. Click to unpin."
+          aria-label={`Unpin ${props.repoFullName}`}
+        >
+          {/* Heroicons 20px solid: lock-closed */}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-primary">
+            <path fill-rule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clip-rule="evenodd" />
+          </svg>
+        </button>
+        <button
+          class="btn btn-ghost btn-xs"
+          onClick={() => moveLockedRepo(props.tab, props.repoFullName, "up")}
+          disabled={lockInfo().isFirst}
+          aria-label={`Move ${props.repoFullName} up`}
+        >
+          {/* Heroicons 20px solid: chevron-up */}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
+            <path fill-rule="evenodd" d="M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z" clip-rule="evenodd" />
+          </svg>
+        </button>
+        <button
+          class="btn btn-ghost btn-xs"
+          onClick={() => moveLockedRepo(props.tab, props.repoFullName, "down")}
+          disabled={lockInfo().isLast}
+          aria-label={`Move ${props.repoFullName} down`}
+        >
+          {/* Heroicons 20px solid: chevron-down */}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
+            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </Show>
+    </div>
+  );
+}

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -17,6 +17,41 @@
   animation: slow-pulse 3s ease-in-out infinite;
 }
 
+/* ── Hot-poll shimmer animation ──────────────────────────────────────────── */
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+@utility animate-shimmer {
+  background: linear-gradient(90deg, transparent 25%, oklch(from var(--color-base-content) l c h / 0.06) 50%, transparent 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+/* ── Value-change flash animation ────────────────────────────────────────── */
+
+@keyframes flash {
+  0% { background-color: oklch(from var(--color-primary) l c h / 0.15); }
+  100% { background-color: transparent; }
+}
+
+@utility animate-flash {
+  animation: flash 1s ease-out forwards;
+}
+
+/* ── Repo reorder highlight animation ────────────────────────────────────── */
+
+@keyframes reorder-highlight {
+  0% { background-color: oklch(from var(--color-warning) l c h / 0.12); }
+  100% { background-color: transparent; }
+}
+
+@utility animate-reorder-highlight {
+  animation: reorder-highlight 1.5s ease-out forwards;
+}
+
 /* ── Notification animations ──────────────────────────────────────────────── */
 
 @keyframes toast-slide-in {
@@ -94,7 +129,9 @@
 @media (prefers-reduced-motion: reduce) {
   .animate-toast-in, .animate-toast-out,
   .animate-drawer-in, .animate-drawer-out,
-  .animate-overlay-in, .animate-overlay-out {
+  .animate-overlay-in, .animate-overlay-out,
+  .animate-shimmer, .animate-flash, .animate-reorder-highlight,
+  .loading {
     animation: none;
   }
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -127,6 +127,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .animate-slow-pulse,
   .animate-toast-in, .animate-toast-out,
   .animate-drawer-in, .animate-drawer-out,
   .animate-overlay-in, .animate-overlay-out,

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -20,12 +20,12 @@
 /* ── Hot-poll shimmer animation ──────────────────────────────────────────── */
 
 @keyframes shimmer {
-  0% { background-position: -200% 0; }
-  100% { background-position: 200% 0; }
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
 @utility animate-shimmer {
-  background: linear-gradient(90deg, transparent 25%, oklch(from var(--color-base-content) l c h / 0.06) 50%, transparent 75%);
+  background: linear-gradient(90deg, transparent 25%, oklch(from var(--color-base-content) l c h / 0.15) 50%, transparent 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
 }
@@ -33,7 +33,7 @@
 /* ── Value-change flash animation ────────────────────────────────────────── */
 
 @keyframes flash {
-  0% { background-color: oklch(from var(--color-primary) l c h / 0.15); }
+  0% { background-color: oklch(from var(--color-primary) l c h / 0.35); }
   100% { background-color: transparent; }
 }
 
@@ -44,7 +44,7 @@
 /* ── Repo reorder highlight animation ────────────────────────────────────── */
 
 @keyframes reorder-highlight {
-  0% { background-color: oklch(from var(--color-warning) l c h / 0.12); }
+  0% { background-color: oklch(from var(--color-warning) l c h / 0.30); }
   100% { background-color: transparent; }
 }
 

--- a/src/app/lib/collections.ts
+++ b/src/app/lib/collections.ts
@@ -1,0 +1,7 @@
+export function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+}

--- a/src/app/lib/flashDetection.ts
+++ b/src/app/lib/flashDetection.ts
@@ -1,0 +1,98 @@
+import { createSignal, createEffect, onCleanup, type Accessor } from "solid-js";
+import type { PeekUpdate } from "./grouping";
+
+export function createFlashDetection<T extends { id: number; repoFullName: string }>(opts: {
+  getItems: Accessor<T[]>;
+  getHotIds: Accessor<ReadonlySet<number> | undefined>;
+  getExpandedRepos: Accessor<Record<string, boolean>>;
+  trackKey: (item: T) => string;
+  itemLabel: (item: T) => string;
+  itemStatus: (item: T) => string;
+}): {
+  flashingIds: Accessor<ReadonlySet<number>>;
+  peekUpdates: Accessor<ReadonlyMap<string, PeekUpdate>>;
+} {
+  const [peekUpdates, setPeekUpdates] = createSignal<ReadonlyMap<string, PeekUpdate>>(new Map());
+  let peekTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  let prevValues = new Map<number, string>();
+  let initialized = false;
+  let flashTimeout: ReturnType<typeof setTimeout> | undefined;
+  const [flashingIds, setFlashingIds] = createSignal<ReadonlySet<number>>(new Set());
+
+  createEffect(() => {
+    const items = opts.getItems();
+    const hotIds = opts.getHotIds();
+
+    if (!initialized) {
+      initialized = true;
+      prevValues = new Map(items.map(item => [item.id, opts.trackKey(item)]));
+      return;
+    }
+
+    // Full refresh path — rebuild map to prune stale entries.
+    // Items only leave the dataset on full refresh (hotIds empty), not during hot polls.
+    if (!hotIds || hotIds.size === 0) {
+      prevValues = new Map(items.map(item => [item.id, opts.trackKey(item)]));
+      return;
+    }
+
+    const changed = new Set<number>();
+    for (const item of items) {
+      if (!hotIds.has(item.id)) continue;
+      const prev = prevValues.get(item.id);
+      if (prev !== undefined && prev !== opts.trackKey(item)) {
+        changed.add(item.id);
+      }
+    }
+
+    // Hot-poll path — update in-place (items don't change set between hot polls)
+    for (const item of items) {
+      prevValues.set(item.id, opts.trackKey(item));
+    }
+
+    if (changed.size > 0) {
+      setFlashingIds(prev => new Set([...prev, ...changed]));
+      clearTimeout(flashTimeout);
+      flashTimeout = setTimeout(() => setFlashingIds(new Set<number>()), 1000);
+
+      const peeks = new Map<string, PeekUpdate>();
+      const peekCounts = new Map<string, number>();
+      const peekFirstLabels = new Map<string, string>();
+      const expandedRepos = opts.getExpandedRepos();
+      for (const item of items) {
+        if (changed.has(item.id)) {
+          if (!expandedRepos[item.repoFullName]) {
+            const count = (peekCounts.get(item.repoFullName) ?? 0) + 1;
+            peekCounts.set(item.repoFullName, count);
+            if (count === 1) {
+              const label = opts.itemLabel(item);
+              peekFirstLabels.set(item.repoFullName, label);
+              peeks.set(item.repoFullName, {
+                itemLabel: label,
+                newStatus: opts.itemStatus(item),
+              });
+            } else {
+              peeks.set(item.repoFullName, {
+                itemLabel: `${peekFirstLabels.get(item.repoFullName)} + ${count - 1} more`,
+                newStatus: peeks.get(item.repoFullName)!.newStatus,
+              });
+            }
+          }
+        }
+      }
+      if (peeks.size > 0) {
+        setPeekUpdates(peeks);
+        clearTimeout(peekTimeout);
+        peekTimeout = setTimeout(() => setPeekUpdates(new Map()), 3000);
+      }
+    }
+  });
+
+  onCleanup(() => {
+    clearTimeout(flashTimeout);
+    clearTimeout(peekTimeout);
+  });
+
+  return { flashingIds, peekUpdates };
+}

--- a/src/app/lib/flashDetection.ts
+++ b/src/app/lib/flashDetection.ts
@@ -1,5 +1,9 @@
 import { createSignal, createEffect, onCleanup, type Accessor } from "solid-js";
-import type { PeekUpdate } from "./grouping";
+
+export interface PeekUpdate {
+  itemLabel: string;
+  newStatus: string;
+}
 
 export function createFlashDetection<T extends { id: number; repoFullName: string }>(opts: {
   getItems: Accessor<T[]>;
@@ -37,18 +41,17 @@ export function createFlashDetection<T extends { id: number; repoFullName: strin
       return;
     }
 
+    // Single pass: detect changes for hot-polled items + update prevValues
     const changed = new Set<number>();
     for (const item of items) {
-      if (!hotIds.has(item.id)) continue;
-      const prev = prevValues.get(item.id);
-      if (prev !== undefined && prev !== opts.trackKey(item)) {
-        changed.add(item.id);
+      const key = opts.trackKey(item);
+      if (hotIds.has(item.id)) {
+        const prev = prevValues.get(item.id);
+        if (prev !== undefined && prev !== key) {
+          changed.add(item.id);
+        }
       }
-    }
-
-    // Hot-poll path — update in-place (items don't change set between hot polls)
-    for (const item of items) {
-      prevValues.set(item.id, opts.trackKey(item));
+      prevValues.set(item.id, key);
     }
 
     if (changed.size > 0) {

--- a/src/app/lib/grouping.ts
+++ b/src/app/lib/grouping.ts
@@ -49,16 +49,21 @@ export function slicePageGroups<T>(
   return groups.slice(start, end);
 }
 
+export interface PeekUpdate {
+  itemLabel: string;
+  newStatus: string;
+}
+
 export function orderRepoGroups<G extends { repoFullName: string }>(
   groups: G[],
   lockedOrder: string[]
 ): G[] {
-  const lockedSet = new Set(lockedOrder);
+  const lockedIndex = new Map(lockedOrder.map((name, i) => [name, i]));
   const locked: G[] = [];
   const unlocked: G[] = [];
 
   for (const group of groups) {
-    if (lockedSet.has(group.repoFullName)) {
+    if (lockedIndex.has(group.repoFullName)) {
       locked.push(group);
     } else {
       unlocked.push(group);
@@ -66,7 +71,7 @@ export function orderRepoGroups<G extends { repoFullName: string }>(
   }
 
   locked.sort((a, b) =>
-    lockedOrder.indexOf(a.repoFullName) - lockedOrder.indexOf(b.repoFullName)
+    (lockedIndex.get(a.repoFullName) ?? 0) - (lockedIndex.get(b.repoFullName) ?? 0)
   );
 
   return [...locked, ...unlocked];

--- a/src/app/lib/grouping.ts
+++ b/src/app/lib/grouping.ts
@@ -49,11 +49,6 @@ export function slicePageGroups<T>(
   return groups.slice(start, end);
 }
 
-export interface PeekUpdate {
-  itemLabel: string;
-  newStatus: string;
-}
-
 export function orderRepoGroups<G extends { repoFullName: string }>(
   groups: G[],
   lockedOrder: string[]

--- a/src/app/lib/grouping.ts
+++ b/src/app/lib/grouping.ts
@@ -48,3 +48,41 @@ export function slicePageGroups<T>(
   const end = clampedPage + 1 < boundaries.length ? boundaries[clampedPage + 1] : groups.length;
   return groups.slice(start, end);
 }
+
+export function orderRepoGroups<G extends { repoFullName: string }>(
+  groups: G[],
+  lockedOrder: string[]
+): G[] {
+  const lockedSet = new Set(lockedOrder);
+  const locked: G[] = [];
+  const unlocked: G[] = [];
+
+  for (const group of groups) {
+    if (lockedSet.has(group.repoFullName)) {
+      locked.push(group);
+    } else {
+      unlocked.push(group);
+    }
+  }
+
+  locked.sort((a, b) =>
+    lockedOrder.indexOf(a.repoFullName) - lockedOrder.indexOf(b.repoFullName)
+  );
+
+  return [...locked, ...unlocked];
+}
+
+export function detectReorderedRepos(
+  previousOrder: string[],
+  currentOrder: string[]
+): Set<string> {
+  const moved = new Set<string>();
+  const prevIndex = new Map(previousOrder.map((name, i) => [name, i]));
+  for (let i = 0; i < currentOrder.length; i++) {
+    const prev = prevIndex.get(currentOrder[i]);
+    if (prev !== undefined && prev !== i) {
+      moved.add(currentOrder[i]);
+    }
+  }
+  return moved;
+}

--- a/src/app/lib/reorderHighlight.ts
+++ b/src/app/lib/reorderHighlight.ts
@@ -1,0 +1,35 @@
+import { createSignal, createEffect, onCleanup, type Accessor } from "solid-js";
+import { detectReorderedRepos } from "./grouping";
+
+export function createReorderHighlight(
+  getRepoOrder: Accessor<string[]>,
+  getLockedOrder: Accessor<string[]>,
+): Accessor<ReadonlySet<string>> {
+  let prevOrder: string[] = [];
+  let prevLocked: string[] = [];
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const [highlighted, setHighlighted] = createSignal<ReadonlySet<string>>(new Set());
+
+  createEffect(() => {
+    const currentOrder = getRepoOrder();
+    const currentLocked = getLockedOrder();
+
+    const lockedChanged = currentLocked.length !== prevLocked.length
+      || currentLocked.some((r, i) => r !== prevLocked[i]);
+
+    if (prevOrder.length > 0 && !lockedChanged) {
+      const moved = detectReorderedRepos(prevOrder, currentOrder);
+      if (moved.size > 0) {
+        setHighlighted(moved);
+        clearTimeout(timeout);
+        timeout = setTimeout(() => setHighlighted(new Set<string>()), 1500);
+      }
+    }
+
+    prevOrder = currentOrder;
+    prevLocked = [...currentLocked];
+  });
+  onCleanup(() => clearTimeout(timeout));
+
+  return highlighted;
+}

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -4,6 +4,12 @@ import type { TrackedUser } from "../stores/config";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
+interface GraphQLRateLimit {
+  limit: number;
+  remaining: number;
+  resetAt: string;
+}
+
 export interface OrgEntry {
   login: string;
   avatarUrl: string;
@@ -267,7 +273,7 @@ interface GraphQLIssueSearchResponse {
     pageInfo: { hasNextPage: boolean; endCursor: string | null };
     nodes: (GraphQLIssueNode | null)[];
   };
-  rateLimit?: { limit: number; remaining: number; resetAt: string };
+  rateLimit?: GraphQLRateLimit;
 }
 
 interface GraphQLPRNode {
@@ -314,7 +320,7 @@ interface GraphQLPRSearchResponse {
     pageInfo: { hasNextPage: boolean; endCursor: string | null };
     nodes: (GraphQLPRNode | null)[];
   };
-  rateLimit?: { limit: number; remaining: number; resetAt: string };
+  rateLimit?: GraphQLRateLimit;
 }
 
 interface ForkCandidate {
@@ -329,8 +335,8 @@ interface ForkRepoResult {
 }
 
 interface ForkQueryResponse {
-  rateLimit?: { limit: number; remaining: number; resetAt: string };
-  [key: string]: ForkRepoResult | { limit: number; remaining: number; resetAt: string } | undefined | null;
+  rateLimit?: GraphQLRateLimit;
+  [key: string]: ForkRepoResult | GraphQLRateLimit | undefined | null;
 }
 
 // ── GraphQL search query constants ───────────────────────────────────────────
@@ -511,7 +517,7 @@ interface LightPRSearchResponse {
     pageInfo: { hasNextPage: boolean; endCursor: string | null };
     nodes: (GraphQLLightPRNode | null)[];
   };
-  rateLimit?: { limit: number; remaining: number; resetAt: string };
+  rateLimit?: GraphQLRateLimit;
 }
 
 /** Phase 2 backfill query: enriches PRs with heavy fields using node IDs. */
@@ -581,7 +587,7 @@ interface HotPRStatusNode {
 
 interface HotPRStatusResponse {
   nodes: (HotPRStatusNode | null)[];
-  rateLimit?: { limit: number; remaining: number; resetAt: string };
+  rateLimit?: GraphQLRateLimit;
 }
 
 interface GraphQLLightPRNode {
@@ -643,12 +649,12 @@ interface LightCombinedSearchResponse {
     pageInfo: { hasNextPage: boolean; endCursor: string | null };
     nodes: (GraphQLLightPRNode | null)[];
   };
-  rateLimit?: { limit: number; remaining: number; resetAt: string };
+  rateLimit?: GraphQLRateLimit;
 }
 
 interface HeavyBackfillResponse {
   nodes: (GraphQLHeavyPRNode | null)[];
-  rateLimit?: { limit: number; remaining: number; resetAt: string };
+  rateLimit?: GraphQLRateLimit;
 }
 
 // Max node IDs per nodes() query (GitHub limit)
@@ -667,7 +673,7 @@ interface SearchPageResult<T> {
  * caller-provided `processNode` callback. Handles partial errors, cap enforcement,
  * and rate limit tracking. Returns the count of items added by processNode.
  */
-async function paginateGraphQLSearch<TResponse extends { search: SearchPageResult<TNode>; rateLimit?: { limit: number; remaining: number; resetAt: string } }, TNode>(
+async function paginateGraphQLSearch<TResponse extends { search: SearchPageResult<TNode>; rateLimit?: GraphQLRateLimit }, TNode>(
   octokit: GitHubOctokit,
   query: string,
   queryString: string,
@@ -823,7 +829,7 @@ async function runForkPRFallback(
 
     try {
       const forkResponse = await octokit.graphql<ForkQueryResponse>(forkQuery, variables);
-      if (forkResponse.rateLimit) updateGraphqlRateLimit(forkResponse.rateLimit as { limit: number; remaining: number; resetAt: string });
+      if (forkResponse.rateLimit) updateGraphqlRateLimit(forkResponse.rateLimit as GraphQLRateLimit);
 
       for (let i = 0; i < forkChunk.length; i++) {
         const data = forkResponse[`fork${i}`] as ForkRepoResult | null | undefined;
@@ -1612,7 +1618,7 @@ async function graphqlSearchPRs(
 
       try {
         const forkResponse = await octokit.graphql<ForkQueryResponse>(forkQuery, variables);
-        if (forkResponse.rateLimit) updateGraphqlRateLimit(forkResponse.rateLimit as { limit: number; remaining: number; resetAt: string });
+        if (forkResponse.rateLimit) updateGraphqlRateLimit(forkResponse.rateLimit as GraphQLRateLimit);
 
         for (let i = 0; i < forkChunk.length; i++) {
           const data = forkResponse[`fork${i}`] as ForkRepoResult | null | undefined;

--- a/src/app/services/github.ts
+++ b/src/app/services/github.ts
@@ -34,13 +34,13 @@ export function getGraphqlRateLimit(): RateLimitInfo | null {
   return _graphqlRateLimit();
 }
 
-function safePositiveInt(raw: number | undefined, fallback: number): number {
+function safePositiveNumber(raw: number | undefined, fallback: number): number {
   return raw != null && Number.isFinite(raw) && raw > 0 ? raw : fallback;
 }
 
 export function updateGraphqlRateLimit(rateLimit: { limit: number; remaining: number; resetAt: string }): void {
   _setGraphqlRateLimit({
-    limit: safePositiveInt(rateLimit.limit, _graphqlRateLimit()?.limit ?? 5000),
+    limit: safePositiveNumber(rateLimit.limit, _graphqlRateLimit()?.limit ?? 5000),
     remaining: rateLimit.remaining,
     resetAt: new Date(rateLimit.resetAt), // ISO 8601 string → Date
   });
@@ -53,7 +53,7 @@ export function updateRateLimitFromHeaders(headers: Record<string, string>): voi
   if (remaining !== undefined && reset !== undefined) {
     const parsedLimit = limit !== undefined ? parseInt(limit, 10) : NaN;
     _setCoreRateLimit({
-      limit: safePositiveInt(parsedLimit, 5000),
+      limit: safePositiveNumber(parsedLimit, 5000),
       remaining: parseInt(remaining, 10),
       resetAt: new Date(parseInt(reset, 10) * 1000),
     });

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -556,7 +556,11 @@ export function createHotPollCoordinator(
     prUpdates: Map<number, HotPRStatusUpdate>,
     runUpdates: Map<number, HotWorkflowRunUpdate>,
     generation: number
-  ) => void
+  ) => void,
+  options?: {
+    onStart?: (prDbIds: ReadonlySet<number>, runIds: ReadonlySet<number>) => void;
+    onEnd?: () => void;
+  }
 ): { destroy: () => void } {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   let chainGeneration = 0;
@@ -588,12 +592,22 @@ export function createHotPollCoordinator(
       return;
     }
 
+    // Skip fetch when no authenticated client (e.g., mid-logout)
+    // Guarded: getClient() can throw during auth state transitions
+    let client: ReturnType<typeof getClient>;
     try {
-      // Skip fetch when no authenticated client (e.g., mid-logout)
-      if (!getClient()) {
-        schedule(myGeneration);
-        return;
-      }
+      client = getClient();
+    } catch {
+      schedule(myGeneration);
+      return;
+    }
+    if (!client) {
+      schedule(myGeneration);
+      return;
+    }
+
+    options?.onStart?.(new Set(_hotPRs.values()), new Set(_hotRuns.keys()));
+    try {
       const { prUpdates, runUpdates, generation, hadErrors } = await fetchHotData();
       if (myGeneration !== chainGeneration) return; // Chain destroyed during fetch
       if (hadErrors) {
@@ -610,6 +624,10 @@ export function createHotPollCoordinator(
       consecutiveFailures++;
       const message = err instanceof Error ? err.message : "Unknown hot-poll error";
       pushError("hot-poll", message, true);
+    } finally {
+      if (myGeneration === chainGeneration) {
+        options?.onEnd?.();
+      }
     }
 
     schedule(myGeneration);

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -565,13 +565,18 @@ export function createHotPollCoordinator(
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   let chainGeneration = 0;
   let consecutiveFailures = 0;
+  let startedCycle = false; // tracks whether onStart was called for the active chain
   const MAX_BACKOFF_MULTIPLIER = 8; // caps at 8× the base interval
 
   function destroy(): void {
     // Invalidates any in-flight cycle(); createEffect captures the new value as the next chain's seed
     chainGeneration++;
     consecutiveFailures = 0;
-    options?.onEnd?.(); // Clear shimmer indicators on coordinator destruction
+    // Clear shimmer only if an onStart was active (avoids spurious onEnd on init)
+    if (startedCycle) {
+      startedCycle = false;
+      options?.onEnd?.();
+    }
     if (timeoutId !== null) {
       clearTimeout(timeoutId);
       timeoutId = null;
@@ -607,6 +612,7 @@ export function createHotPollCoordinator(
       return;
     }
 
+    startedCycle = true;
     options?.onStart?.(new Set(_hotPRs.values()), new Set(_hotRuns.keys()));
     try {
       const { prUpdates, runUpdates, generation, hadErrors } = await fetchHotData();
@@ -627,6 +633,7 @@ export function createHotPollCoordinator(
       pushError("hot-poll", message, true);
     } finally {
       if (myGeneration === chainGeneration) {
+        startedCycle = false;
         options?.onEnd?.();
       }
     }

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -571,6 +571,7 @@ export function createHotPollCoordinator(
     // Invalidates any in-flight cycle(); createEffect captures the new value as the next chain's seed
     chainGeneration++;
     consecutiveFailures = 0;
+    options?.onEnd?.(); // Clear shimmer indicators on coordinator destruction
     if (timeoutId !== null) {
       clearTimeout(timeoutId);
       timeoutId = null;

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -80,11 +80,21 @@ export const ViewStateSchema = z.object({
     pullRequests: {},
     actions: {},
   }),
+  lockedRepos: z.object({
+    issues: z.array(z.string()).default([]),
+    pullRequests: z.array(z.string()).default([]),
+    actions: z.array(z.string()).default([]),
+  }).default({
+    issues: [],
+    pullRequests: [],
+    actions: [],
+  }),
 });
 
 export type ViewState = z.infer<typeof ViewStateSchema>;
 export type IgnoredItem = ViewState["ignoredItems"][number];
 export type SortPreference = ViewState["sortPreferences"][string];
+export type LockedReposTab = keyof ViewState["lockedRepos"];
 
 function loadViewState(): ViewState {
   try {
@@ -116,6 +126,7 @@ export function resetViewState(): void {
     },
     showPrRuns: false,
     expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
+    lockedRepos: { issues: [], pullRequests: [], actions: [] },
   });
 }
 
@@ -265,6 +276,51 @@ export function pruneExpandedRepos(
       }
     })
   );
+}
+
+export function lockRepo(tab: LockedReposTab, repoFullName: string): void {
+  setViewState(produce((draft) => {
+    if (!draft.lockedRepos[tab].includes(repoFullName)) {
+      draft.lockedRepos[tab].push(repoFullName);
+    }
+  }));
+}
+
+export function unlockRepo(tab: LockedReposTab, repoFullName: string): void {
+  setViewState(produce((draft) => {
+    draft.lockedRepos[tab] = draft.lockedRepos[tab].filter(r => r !== repoFullName);
+  }));
+}
+
+export function moveLockedRepo(
+  tab: LockedReposTab,
+  repoFullName: string,
+  direction: "up" | "down"
+): void {
+  setViewState(produce((draft) => {
+    const arr = draft.lockedRepos[tab];
+    const idx = arr.indexOf(repoFullName);
+    if (idx === -1) return;
+    const targetIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (targetIdx < 0 || targetIdx >= arr.length) return;
+    const tmp = arr[idx];
+    arr[idx] = arr[targetIdx];
+    arr[targetIdx] = tmp;
+  }));
+}
+
+export function pruneLockedRepos(
+  tab: LockedReposTab,
+  activeRepoNames: string[]
+): void {
+  const current = untrack(() => viewState.lockedRepos[tab]);
+  if (current.length === 0) return;
+  const activeSet = new Set(activeRepoNames);
+  const filtered = current.filter(name => activeSet.has(name));
+  if (filtered.length === current.length) return;
+  setViewState(produce((draft) => {
+    draft.lockedRepos[tab] = filtered;
+  }));
 }
 
 export function initViewPersistence(): void {

--- a/tests/components/ActionsTab.test.tsx
+++ b/tests/components/ActionsTab.test.tsx
@@ -5,7 +5,7 @@ import { createSignal } from "solid-js";
 import ActionsTab from "../../src/app/components/dashboard/ActionsTab";
 import type { WorkflowRun } from "../../src/app/services/api";
 import * as viewStore from "../../src/app/stores/view";
-import { viewState } from "../../src/app/stores/view";
+import { viewState, setAllExpanded } from "../../src/app/stores/view";
 import { makeWorkflowRun, resetViewStore } from "../helpers/index";
 
 beforeEach(() => {
@@ -434,5 +434,39 @@ describe("ActionsTab", () => {
     // Workflow name visible means the repo group is expanded
     expect(screen.getAllByText("CI").length).toBeGreaterThanOrEqual(1);
     expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
+  });
+
+  it("passes hotPollingRunIds to workflow summary cards", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ id: 10, repoFullName: "org/repo", workflowId: 1, name: "CI", status: "in_progress", conclusion: null }),
+      makeWorkflowRun({ id: 20, repoFullName: "org/repo", workflowId: 1, name: "CI", status: "completed", conclusion: "success" }),
+    ];
+    setAllExpanded("actions", ["org/repo"], true);
+    const { container } = render(() => (
+      <ActionsTab workflowRuns={runs} hotPollingRunIds={new Set([10])} />
+    ));
+    // Click workflow card header to expand and show individual run rows
+    const ciHeader = screen.getByText("CI");
+    await user.click(ciHeader);
+    // Now WorkflowRunRow elements should be visible with shimmer on the hot-polled run
+    const runRows = container.querySelectorAll("[class*='flex items-center gap-3']");
+    expect(runRows.length).toBeGreaterThanOrEqual(2);
+    expect(runRows[0]?.classList.contains("animate-shimmer")).toBe(true);
+    expect(runRows[1]?.classList.contains("animate-shimmer")).toBe(false);
+  });
+
+  it("does not apply shimmer when hotPollingRunIds is undefined", async () => {
+    const user = userEvent.setup();
+    const runs = [
+      makeWorkflowRun({ id: 1, repoFullName: "org/repo", workflowId: 1, name: "CI", status: "in_progress", conclusion: null }),
+    ];
+    setAllExpanded("actions", ["org/repo"], true);
+    const { container } = render(() => <ActionsTab workflowRuns={runs} />);
+    await user.click(screen.getByText("CI"));
+    const runRows = container.querySelectorAll("[class*='flex items-center gap-3']");
+    for (const row of runRows) {
+      expect(row.classList.contains("animate-shimmer")).toBe(false);
+    }
   });
 });

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -132,4 +132,38 @@ describe("ItemRow", () => {
     render(() => <ItemRow {...defaultProps} hideRepo={false} />);
     screen.getByText("octocat/Hello-World");
   });
+
+  it("applies shimmer class when isPolling is true", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} isPolling={true} />);
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(true);
+    expect(container.querySelector(".loading-spinner")).toBeTruthy();
+  });
+
+  it("does not apply shimmer class when isPolling is false", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} isPolling={false} />);
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(false);
+    expect(container.querySelector(".loading-spinner")).toBeFalsy();
+  });
+
+  it("does not apply shimmer class when isPolling is omitted", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} />);
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(false);
+    expect(container.querySelector(".loading-spinner")).toBeFalsy();
+  });
+
+  it("applies flash class when isFlashing is true", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} isFlashing={true} />);
+    expect(container.firstElementChild?.classList.contains("animate-flash")).toBe(true);
+  });
+
+  it("does not apply flash class when isFlashing is false", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} isFlashing={false} />);
+    expect(container.firstElementChild?.classList.contains("animate-flash")).toBe(false);
+  });
+
+  it("flash takes precedence over shimmer", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} isFlashing={true} isPolling={true} />);
+    expect(container.firstElementChild?.classList.contains("animate-flash")).toBe(true);
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(false);
+  });
 });

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -627,4 +627,33 @@ describe("PullRequestsTab", () => {
     screen.getByText("org/repo-b");
     screen.getByText("Repo B PR 0");
   });
+
+  it("applies shimmer class to rows whose IDs are in hotPollingPRIds", () => {
+    const prs = [
+      makePullRequest({ id: 42, number: 42, title: "Hot PR", repoFullName: "org/repo" }),
+      makePullRequest({ id: 99, number: 99, title: "Cold PR", repoFullName: "org/repo" }),
+    ];
+    setAllExpanded("pullRequests", ["org/repo"], true);
+    const { container } = render(() => (
+      <PullRequestsTab pullRequests={prs} userLogin="" hotPollingPRIds={new Set([42])} />
+    ));
+    const rows = container.querySelectorAll("[role='listitem']");
+    expect(rows.length).toBe(2);
+    // First row (id=42, hot-polled) should have shimmer
+    expect(rows[0]?.querySelector(".animate-shimmer")).toBeTruthy();
+    // Second row (id=99, not hot-polled) should not
+    expect(rows[1]?.querySelector(".animate-shimmer")).toBeFalsy();
+  });
+
+  it("does not apply shimmer when hotPollingPRIds is undefined", () => {
+    const prs = [
+      makePullRequest({ id: 1, number: 1, title: "Normal PR", repoFullName: "org/repo" }),
+    ];
+    setAllExpanded("pullRequests", ["org/repo"], true);
+    const { container } = render(() => (
+      <PullRequestsTab pullRequests={prs} userLogin="" />
+    ));
+    const rows = container.querySelectorAll("[role='listitem']");
+    expect(rows[0]?.querySelector(".animate-shimmer")).toBeFalsy();
+  });
 });

--- a/tests/components/WorkflowRunRow.test.tsx
+++ b/tests/components/WorkflowRunRow.test.tsx
@@ -128,6 +128,30 @@ describe("WorkflowRunRow", () => {
     expect(row?.className).toContain("px-4");
   });
 
+  it("applies shimmer class when isPolling is true", () => {
+    const { container } = render(() => (
+      <WorkflowRunRow run={makeWorkflowRun()} onIgnore={() => {}} density="comfortable" isPolling={true} />
+    ));
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(true);
+    expect(container.querySelector(".loading-spinner")).toBeTruthy();
+  });
+
+  it("does not apply shimmer when isPolling is false", () => {
+    const { container } = render(() => (
+      <WorkflowRunRow run={makeWorkflowRun()} onIgnore={() => {}} density="comfortable" isPolling={false} />
+    ));
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(false);
+    expect(container.querySelector(".loading-spinner")).toBeFalsy();
+  });
+
+  it("does not apply shimmer when isPolling is omitted", () => {
+    const { container } = render(() => (
+      <WorkflowRunRow run={makeWorkflowRun()} onIgnore={() => {}} density="comfortable" />
+    ));
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(false);
+    expect(container.querySelector(".loading-spinner")).toBeFalsy();
+  });
+
   it("applies flash class when isFlashing is true", () => {
     const { container } = render(() => (
       <WorkflowRunRow run={makeWorkflowRun()} onIgnore={() => {}} density="comfortable" isFlashing={true} />

--- a/tests/components/WorkflowRunRow.test.tsx
+++ b/tests/components/WorkflowRunRow.test.tsx
@@ -127,4 +127,19 @@ describe("WorkflowRunRow", () => {
     expect(row?.className).toContain("py-2.5");
     expect(row?.className).toContain("px-4");
   });
+
+  it("applies flash class when isFlashing is true", () => {
+    const { container } = render(() => (
+      <WorkflowRunRow run={makeWorkflowRun()} onIgnore={() => {}} density="comfortable" isFlashing={true} />
+    ));
+    expect(container.firstElementChild?.classList.contains("animate-flash")).toBe(true);
+  });
+
+  it("flash takes precedence over shimmer", () => {
+    const { container } = render(() => (
+      <WorkflowRunRow run={makeWorkflowRun()} onIgnore={() => {}} density="comfortable" isFlashing={true} isPolling={true} />
+    ));
+    expect(container.firstElementChild?.classList.contains("animate-flash")).toBe(true);
+    expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(false);
+  });
 });

--- a/tests/components/WorkflowSummaryCard.test.tsx
+++ b/tests/components/WorkflowSummaryCard.test.tsx
@@ -175,4 +175,52 @@ describe("WorkflowSummaryCard", () => {
     const card = container.firstElementChild as HTMLElement;
     expect(card.className).toContain("border-l-warning");
   });
+
+  it("passes isPolling to WorkflowRunRow when hotPollingRunIds contains run ID", () => {
+    const runs = [
+      makeWorkflowRun({ id: 10, conclusion: null, status: "in_progress" }),
+      makeWorkflowRun({ id: 20, conclusion: "success", status: "completed" }),
+    ];
+    const hotPollingRunIds = new Set([10]);
+    const { container } = render(() => (
+      <WorkflowSummaryCard
+        workflowName="CI"
+        runs={runs}
+        expanded={true}
+        onToggle={() => {}}
+        onIgnoreRun={() => {}}
+        density="comfortable"
+        hotPollingRunIds={hotPollingRunIds}
+      />
+    ));
+    const rows = container.querySelectorAll("[class*='flex items-center gap-3']");
+    // First row (id=10, in hot poll set) should have shimmer
+    expect(rows[0]?.classList.contains("animate-shimmer")).toBe(true);
+    // Second row (id=20, not in hot poll set) should not
+    expect(rows[1]?.classList.contains("animate-shimmer")).toBe(false);
+  });
+
+  it("passes isFlashing to WorkflowRunRow when flashingRunIds contains run ID", () => {
+    const runs = [
+      makeWorkflowRun({ id: 10, conclusion: "success", status: "completed" }),
+      makeWorkflowRun({ id: 20, conclusion: "success", status: "completed" }),
+    ];
+    const flashingRunIds = new Set([20]);
+    const { container } = render(() => (
+      <WorkflowSummaryCard
+        workflowName="CI"
+        runs={runs}
+        expanded={true}
+        onToggle={() => {}}
+        onIgnoreRun={() => {}}
+        density="comfortable"
+        flashingRunIds={flashingRunIds}
+      />
+    ));
+    const rows = container.querySelectorAll("[class*='flex items-center gap-3']");
+    // First row (id=10, not flashing) should not have flash
+    expect(rows[0]?.classList.contains("animate-flash")).toBe(false);
+    // Second row (id=20, flashing) should have flash
+    expect(rows[1]?.classList.contains("animate-flash")).toBe(true);
+  });
 });

--- a/tests/components/shared/RepoLockControls.test.tsx
+++ b/tests/components/shared/RepoLockControls.test.tsx
@@ -82,7 +82,7 @@ describe("RepoLockControls", () => {
     expect(downBtn.disabled).toBe(true);
   });
 
-  it("stopPropagation — parent click NOT triggered on button click", () => {
+  it("stopPropagation — parent click NOT triggered on locked button click", () => {
     lockRepo("issues", "owner/repo");
     const parentClick = vi.fn();
     render(() => (
@@ -91,6 +91,17 @@ describe("RepoLockControls", () => {
       </div>
     ));
     fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it("stopPropagation — parent click NOT triggered on pin button click", () => {
+    const parentClick = vi.fn();
+    render(() => (
+      <div onClick={parentClick}>
+        <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      </div>
+    ));
+    fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
     expect(parentClick).not.toHaveBeenCalled();
   });
 });

--- a/tests/components/shared/RepoLockControls.test.tsx
+++ b/tests/components/shared/RepoLockControls.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+import RepoLockControls from "../../../src/app/components/shared/RepoLockControls";
+import { resetViewState, viewState, lockRepo } from "../../../src/app/stores/view";
+
+beforeEach(() => {
+  resetViewState();
+});
+
+describe("RepoLockControls", () => {
+  it("renders unlock (pin) icon when repo is not locked", () => {
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    expect(screen.getByLabelText("Pin owner/repo to top of list")).toBeTruthy();
+  });
+
+  it("renders lock icon + chevrons when repo IS locked", () => {
+    lockRepo("issues", "owner/repo");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    expect(screen.getByLabelText("Unpin owner/repo")).toBeTruthy();
+    expect(screen.getByLabelText("Move owner/repo up")).toBeTruthy();
+    expect(screen.getByLabelText("Move owner/repo down")).toBeTruthy();
+  });
+
+  it("click pin icon → locks the repo", () => {
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
+    expect(viewState.lockedRepos.issues).toContain("owner/repo");
+  });
+
+  it("click lock icon → unlocks the repo", () => {
+    lockRepo("issues", "owner/repo");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
+    expect(viewState.lockedRepos.issues).not.toContain("owner/repo");
+  });
+
+  it("up button moves repo up in order", () => {
+    lockRepo("issues", "owner/a");
+    lockRepo("issues", "owner/b");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/b" />
+    ));
+    fireEvent.click(screen.getByLabelText("Move owner/b up"));
+    expect(viewState.lockedRepos.issues[0]).toBe("owner/b");
+    expect(viewState.lockedRepos.issues[1]).toBe("owner/a");
+  });
+
+  it("down button moves repo down in order", () => {
+    lockRepo("issues", "owner/a");
+    lockRepo("issues", "owner/b");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/a" />
+    ));
+    fireEvent.click(screen.getByLabelText("Move owner/a down"));
+    expect(viewState.lockedRepos.issues[0]).toBe("owner/b");
+    expect(viewState.lockedRepos.issues[1]).toBe("owner/a");
+  });
+
+  it("up button is disabled when repo is first in locked list", () => {
+    lockRepo("issues", "owner/repo");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    const upBtn = screen.getByLabelText("Move owner/repo up") as HTMLButtonElement;
+    expect(upBtn.disabled).toBe(true);
+  });
+
+  it("down button is disabled when repo is last in locked list", () => {
+    lockRepo("issues", "owner/repo");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    const downBtn = screen.getByLabelText("Move owner/repo down") as HTMLButtonElement;
+    expect(downBtn.disabled).toBe(true);
+  });
+
+  it("stopPropagation — parent click NOT triggered on button click", () => {
+    lockRepo("issues", "owner/repo");
+    const parentClick = vi.fn();
+    render(() => (
+      <div onClick={parentClick}>
+        <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      </div>
+    ));
+    fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/collections.test.ts
+++ b/tests/lib/collections.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { setsEqual } from "../../src/app/lib/collections";
+
+describe("setsEqual", () => {
+  it("returns true for identical sets", () => {
+    expect(setsEqual(new Set([1, 2, 3]), new Set([1, 2, 3]))).toBe(true);
+  });
+
+  it("returns true for two empty sets", () => {
+    expect(setsEqual(new Set(), new Set())).toBe(true);
+  });
+
+  it("returns false for different sizes", () => {
+    expect(setsEqual(new Set([1, 2]), new Set([1]))).toBe(false);
+  });
+
+  it("returns false for same size but different elements", () => {
+    expect(setsEqual(new Set([1, 2]), new Set([2, 3]))).toBe(false);
+  });
+
+  it("works with string sets", () => {
+    expect(setsEqual(new Set(["a", "b"]), new Set(["b", "a"]))).toBe(true);
+    expect(setsEqual(new Set(["a"]), new Set(["b"]))).toBe(false);
+  });
+});

--- a/tests/lib/flashDetection.test.ts
+++ b/tests/lib/flashDetection.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { createFlashDetection } from "../../src/app/lib/flashDetection";
+
+interface MockItem {
+  id: number;
+  repoFullName: string;
+  status: string;
+}
+
+describe("createFlashDetection", () => {
+  it("returns empty flashingIds and peekUpdates on initialization", () => {
+    createRoot((dispose) => {
+      const items: MockItem[] = [
+        { id: 1, repoFullName: "org/repo", status: "pending" },
+      ];
+      const { flashingIds, peekUpdates } = createFlashDetection({
+        getItems: () => items,
+        getHotIds: () => undefined,
+        getExpandedRepos: () => ({}),
+        trackKey: (item) => item.status,
+        itemLabel: (item) => `Item ${item.id}`,
+        itemStatus: (item) => item.status,
+      });
+
+      expect(flashingIds()).toBeInstanceOf(Set);
+      expect(flashingIds().size).toBe(0);
+      expect(peekUpdates()).toBeInstanceOf(Map);
+      expect(peekUpdates().size).toBe(0);
+
+      dispose();
+    });
+  });
+
+  it("does not flash when hotIds is empty (mass-flash gate)", () => {
+    createRoot((dispose) => {
+      const [items, setItems] = createSignal<MockItem[]>([
+        { id: 1, repoFullName: "org/repo", status: "pending" },
+      ]);
+      const { flashingIds } = createFlashDetection({
+        getItems: items,
+        getHotIds: () => new Set<number>(),
+        getExpandedRepos: () => ({}),
+        trackKey: (item) => item.status,
+        itemLabel: (item) => `Item ${item.id}`,
+        itemStatus: (item) => item.status,
+      });
+
+      // Change status without hot IDs — should not flash
+      setItems([{ id: 1, repoFullName: "org/repo", status: "success" }]);
+      expect(flashingIds().size).toBe(0);
+
+      dispose();
+    });
+  });
+
+  it("does not flash when hotIds is undefined", () => {
+    createRoot((dispose) => {
+      const [items, setItems] = createSignal<MockItem[]>([
+        { id: 1, repoFullName: "org/repo", status: "pending" },
+      ]);
+      const { flashingIds } = createFlashDetection({
+        getItems: items,
+        getHotIds: () => undefined,
+        getExpandedRepos: () => ({}),
+        trackKey: (item) => item.status,
+        itemLabel: (item) => `Item ${item.id}`,
+        itemStatus: (item) => item.status,
+      });
+
+      setItems([{ id: 1, repoFullName: "org/repo", status: "success" }]);
+      expect(flashingIds().size).toBe(0);
+
+      dispose();
+    });
+  });
+
+  it("prunes stale entries on full-refresh path", () => {
+    createRoot((dispose) => {
+      const [items, setItems] = createSignal<MockItem[]>([
+        { id: 1, repoFullName: "org/repo", status: "pending" },
+        { id: 2, repoFullName: "org/repo", status: "success" },
+      ]);
+      const { flashingIds } = createFlashDetection({
+        getItems: items,
+        getHotIds: () => undefined,
+        getExpandedRepos: () => ({}),
+        trackKey: (item) => item.status,
+        itemLabel: (item) => `Item ${item.id}`,
+        itemStatus: (item) => item.status,
+      });
+
+      // Remove item 2 (simulates PR closed on full refresh)
+      setItems([{ id: 1, repoFullName: "org/repo", status: "pending" }]);
+
+      // No crash, no flash — stale entry for id=2 was pruned
+      expect(flashingIds().size).toBe(0);
+
+      dispose();
+    });
+  });
+});

--- a/tests/lib/grouping-lock.test.ts
+++ b/tests/lib/grouping-lock.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { orderRepoGroups, detectReorderedRepos } from "../../src/app/lib/grouping";
+
+describe("orderRepoGroups", () => {
+  it("places locked repos first in locked order", () => {
+    const groups = [
+      { repoFullName: "org/c", items: [] },
+      { repoFullName: "org/a", items: [] },
+      { repoFullName: "org/b", items: [] },
+    ];
+    const result = orderRepoGroups(groups, ["org/b", "org/a"]);
+    expect(result.map(g => g.repoFullName)).toEqual(["org/b", "org/a", "org/c"]);
+  });
+
+  it("returns original order with empty locked array", () => {
+    const groups = [
+      { repoFullName: "org/c", items: [] },
+      { repoFullName: "org/a", items: [] },
+    ];
+    const result = orderRepoGroups(groups, []);
+    expect(result.map(g => g.repoFullName)).toEqual(["org/c", "org/a"]);
+  });
+
+  it("ignores stale locked names not in groups", () => {
+    const groups = [
+      { repoFullName: "org/a", items: [] },
+      { repoFullName: "org/b", items: [] },
+    ];
+    const result = orderRepoGroups(groups, ["org/z", "org/a"]);
+    expect(result.map(g => g.repoFullName)).toEqual(["org/a", "org/b"]);
+  });
+
+  it("works with objects that have extra fields", () => {
+    const groups = [
+      { repoFullName: "org/a", workflows: [{ id: 1 }] },
+      { repoFullName: "org/b", workflows: [] },
+    ];
+    const result = orderRepoGroups(groups, ["org/b"]);
+    expect(result.map(g => g.repoFullName)).toEqual(["org/b", "org/a"]);
+    expect(result[1]).toHaveProperty("workflows");
+  });
+});
+
+describe("detectReorderedRepos", () => {
+  it("detects moved repos", () => {
+    const prev = ["org/a", "org/b", "org/c"];
+    const curr = ["org/c", "org/a", "org/b"];
+    const moved = detectReorderedRepos(prev, curr);
+    expect(moved).toEqual(new Set(["org/a", "org/b", "org/c"]));
+  });
+
+  it("returns empty set when order unchanged", () => {
+    const order = ["org/a", "org/b"];
+    expect(detectReorderedRepos(order, order)).toEqual(new Set());
+  });
+
+  it("ignores new repos not in previous", () => {
+    const prev = ["org/a"];
+    const curr = ["org/a", "org/b"];
+    expect(detectReorderedRepos(prev, curr)).toEqual(new Set());
+  });
+
+  it("ignores removed repos", () => {
+    const prev = ["org/a", "org/b"];
+    const curr = ["org/b"];
+    // org/b was at index 1, now at index 0 -> moved
+    expect(detectReorderedRepos(prev, curr)).toEqual(new Set(["org/b"]));
+  });
+});

--- a/tests/lib/reorderHighlight.test.ts
+++ b/tests/lib/reorderHighlight.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { createReorderHighlight } from "../../src/app/lib/reorderHighlight";
+
+describe("createReorderHighlight", () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns an accessor that starts as empty set", () => {
+    createRoot((dispose) => {
+      const [order] = createSignal<string[]>(["a", "b"]);
+      const [locked] = createSignal<string[]>([]);
+      const highlighted = createReorderHighlight(order, locked);
+
+      expect(highlighted()).toBeInstanceOf(Set);
+      expect(highlighted().size).toBe(0);
+
+      dispose();
+    });
+  });
+
+  it("does not highlight on first render (initialization)", () => {
+    createRoot((dispose) => {
+      const [order] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked] = createSignal<string[]>([]);
+      const highlighted = createReorderHighlight(order, locked);
+
+      // First render seeds prevOrder — no detection
+      expect(highlighted().size).toBe(0);
+      dispose();
+    });
+  });
+
+  it("cleans up timeout on dispose", () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    createRoot((dispose) => {
+      const [order] = createSignal<string[]>(["a", "b"]);
+      const [locked] = createSignal<string[]>([]);
+      createReorderHighlight(order, locked);
+      dispose();
+    });
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/tests/lib/reorderHighlight.test.ts
+++ b/tests/lib/reorderHighlight.test.ts
@@ -1,10 +1,8 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createRoot, createSignal } from "solid-js";
 import { createReorderHighlight } from "../../src/app/lib/reorderHighlight";
 
 describe("createReorderHighlight", () => {
-  afterEach(() => { vi.useRealTimers(); });
-
   it("returns an accessor that starts as empty set", () => {
     createRoot((dispose) => {
       const [order] = createSignal<string[]>(["a", "b"]);
@@ -30,19 +28,4 @@ describe("createReorderHighlight", () => {
     });
   });
 
-  it("registers onCleanup for timeout disposal", () => {
-    vi.useFakeTimers();
-    createRoot((dispose) => {
-      const [order] = createSignal<string[]>(["a", "b"]);
-      const [locked] = createSignal<string[]>([]);
-      const highlighted = createReorderHighlight(order, locked);
-
-      // Verify the returned accessor is usable within the root
-      expect(highlighted()).toBeInstanceOf(Set);
-      expect(highlighted().size).toBe(0);
-
-      // Dispose should not throw (onCleanup is registered correctly)
-      dispose();
-    });
-  });
 });

--- a/tests/lib/reorderHighlight.test.ts
+++ b/tests/lib/reorderHighlight.test.ts
@@ -30,16 +30,19 @@ describe("createReorderHighlight", () => {
     });
   });
 
-  it("cleans up timeout on dispose", () => {
+  it("registers onCleanup for timeout disposal", () => {
     vi.useFakeTimers();
-    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
     createRoot((dispose) => {
       const [order] = createSignal<string[]>(["a", "b"]);
       const [locked] = createSignal<string[]>([]);
-      createReorderHighlight(order, locked);
+      const highlighted = createReorderHighlight(order, locked);
+
+      // Verify the returned accessor is usable within the root
+      expect(highlighted()).toBeInstanceOf(Set);
+      expect(highlighted().size).toBe(0);
+
+      // Dispose should not throw (onCleanup is registered correctly)
       dispose();
     });
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-    clearTimeoutSpy.mockRestore();
   });
 });

--- a/tests/services/hot-poll.test.ts
+++ b/tests/services/hot-poll.test.ts
@@ -631,9 +631,9 @@ describe("createHotPollCoordinator", () => {
     });
   });
 
-  it("calls pushError when cycle throws", async () => {
+  it("silently reschedules when getClient throws", async () => {
     const onHotData = vi.fn();
-    // Make getClient() throw (now inside the try block) to trigger the catch path
+    // getClient() throw is caught by the pre-onStart guard — schedules next cycle without pushError
     mockGetClient.mockImplementation(() => { throw new Error("auth crash"); });
 
     rebuildHotSets({
@@ -647,7 +647,7 @@ describe("createHotPollCoordinator", () => {
     await createRoot(async (dispose) => {
       createHotPollCoordinator(() => 10, onHotData);
       await vi.advanceTimersByTimeAsync(10_000);
-      expect(pushError).toHaveBeenCalledWith("hot-poll", "auth crash", true);
+      expect(pushError).not.toHaveBeenCalled();
       expect(onHotData).not.toHaveBeenCalled();
       dispose();
     });

--- a/tests/services/hot-poll.test.ts
+++ b/tests/services/hot-poll.test.ts
@@ -653,6 +653,87 @@ describe("createHotPollCoordinator", () => {
     });
   });
 
+  it("calls onStart with correct IDs and onEnd after cycle", async () => {
+    const onHotData = vi.fn();
+    const onStart = vi.fn();
+    const onEnd = vi.fn();
+    mockGetClient.mockReturnValue(makeOctokit());
+
+    rebuildHotSets({
+      ...emptyData,
+      pullRequests: [makePullRequest({ id: 42, nodeId: "PR_node42", repoFullName: "o/r" })],
+      workflowRuns: [makeWorkflowRun({ id: 7, status: "in_progress", conclusion: null, repoFullName: "o/r" })],
+    });
+
+    await createRoot(async (dispose) => {
+      createHotPollCoordinator(() => 10, onHotData, { onStart, onEnd });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onStart).toHaveBeenCalledTimes(1);
+      const [prIds, runIds] = onStart.mock.calls[0];
+      expect(prIds).toBeInstanceOf(Set);
+      expect(prIds.has(42)).toBe(true);
+      expect(runIds).toBeInstanceOf(Set);
+      expect(runIds.has(7)).toBe(true);
+      expect(onEnd).toHaveBeenCalledTimes(1);
+      dispose();
+    });
+  });
+
+  it("does not call onStart when hot sets are empty", async () => {
+    const onHotData = vi.fn();
+    const onStart = vi.fn();
+    const onEnd = vi.fn();
+    mockGetClient.mockReturnValue(makeOctokit());
+
+    clearHotSets();
+
+    await createRoot(async (dispose) => {
+      createHotPollCoordinator(() => 10, onHotData, { onStart, onEnd });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onStart).not.toHaveBeenCalled();
+      expect(onEnd).not.toHaveBeenCalled();
+      dispose();
+    });
+  });
+
+  it("calls onEnd on destroy when a cycle was active", async () => {
+    const onHotData = vi.fn();
+    const onStart = vi.fn();
+    const onEnd = vi.fn();
+    mockGetClient.mockReturnValue(makeOctokit());
+
+    rebuildHotSets({
+      ...emptyData,
+      workflowRuns: [makeWorkflowRun({ id: 1, status: "in_progress", conclusion: null, repoFullName: "o/r" })],
+    });
+
+    await createRoot(async (dispose) => {
+      createHotPollCoordinator(() => 10, onHotData, { onStart, onEnd });
+      // Let one cycle start
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onStart).toHaveBeenCalledTimes(1);
+      // onEnd fires from the completed cycle's finally block
+      expect(onEnd).toHaveBeenCalledTimes(1);
+      dispose();
+    });
+  });
+
+  it("does not call onEnd on destroy when no cycle ran", async () => {
+    const onHotData = vi.fn();
+    const onEnd = vi.fn();
+    mockGetClient.mockReturnValue(makeOctokit());
+
+    // No hot items → cycle will skip (no onStart)
+    clearHotSets();
+
+    await createRoot(async (dispose) => {
+      const coordinator = createHotPollCoordinator(() => 10, onHotData, { onEnd });
+      coordinator.destroy();
+      expect(onEnd).not.toHaveBeenCalled();
+      dispose();
+    });
+  });
+
   it("does not schedule when interval is 0", async () => {
     const onHotData = vi.fn();
     mockGetClient.mockReturnValue(makeOctokit());

--- a/tests/services/hot-poll.test.ts
+++ b/tests/services/hot-poll.test.ts
@@ -734,6 +734,33 @@ describe("createHotPollCoordinator", () => {
     });
   });
 
+  it("calls onEnd on error/throw path", async () => {
+    const onHotData = vi.fn();
+    const onStart = vi.fn();
+    const onEnd = vi.fn();
+    // getClient() returns a valid client so onStart fires, but fetchHotData rejects
+    const octokit = makeOctokit();
+    mockGetClient.mockReturnValue(octokit);
+    // Make the graphql call throw (fetchHotData will throw)
+    octokit.graphql = vi.fn().mockRejectedValue(new Error("network failure"));
+
+    rebuildHotSets({
+      ...emptyData,
+      pullRequests: [makePullRequest({ id: 42, nodeId: "PR_node42", repoFullName: "o/r" })],
+    });
+
+    const { pushError } = await import("../../src/app/lib/errors");
+    (pushError as ReturnType<typeof vi.fn>).mockClear();
+
+    await createRoot(async (dispose) => {
+      createHotPollCoordinator(() => 10, onHotData, { onStart, onEnd });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onStart).toHaveBeenCalledTimes(1);
+      expect(onEnd).toHaveBeenCalledTimes(1);
+      dispose();
+    });
+  });
+
   it("does not schedule when interval is 0", async () => {
     const onHotData = vi.fn();
     mockGetClient.mockReturnValue(makeOctokit());

--- a/tests/stores/view-lock.test.ts
+++ b/tests/stores/view-lock.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  viewState,
+  resetViewState,
+  lockRepo,
+  unlockRepo,
+  moveLockedRepo,
+  pruneLockedRepos,
+  ViewStateSchema,
+} from "../../src/app/stores/view";
+
+describe("view lock store", () => {
+  beforeEach(() => {
+    resetViewState();
+  });
+
+  describe("lockRepo", () => {
+    it("locks a repo", () => {
+      lockRepo("issues", "org/repo-a");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
+    });
+
+    it("appends to end", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("issues", "org/repo-b");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-b"]);
+    });
+
+    it("deduplicates", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("issues", "org/repo-a");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
+    });
+
+    it("locks per-tab independently", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("pullRequests", "org/repo-b");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
+      expect(viewState.lockedRepos.pullRequests).toEqual(["org/repo-b"]);
+      expect(viewState.lockedRepos.actions).toEqual([]);
+    });
+  });
+
+  describe("unlockRepo", () => {
+    it("removes from locked array", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("issues", "org/repo-b");
+      unlockRepo("issues", "org/repo-a");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-b"]);
+    });
+
+    it("no-op if not locked", () => {
+      unlockRepo("issues", "org/repo-a");
+      expect(viewState.lockedRepos.issues).toEqual([]);
+    });
+  });
+
+  describe("moveLockedRepo", () => {
+    it("swaps with neighbor up", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("issues", "org/repo-b");
+      lockRepo("issues", "org/repo-c");
+      moveLockedRepo("issues", "org/repo-b", "up");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-b", "org/repo-a", "org/repo-c"]);
+    });
+
+    it("swaps with neighbor down", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("issues", "org/repo-b");
+      lockRepo("issues", "org/repo-c");
+      moveLockedRepo("issues", "org/repo-b", "down");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-c", "org/repo-b"]);
+    });
+
+    it("no-op at top boundary", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("issues", "org/repo-b");
+      moveLockedRepo("issues", "org/repo-a", "up");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-b"]);
+    });
+
+    it("no-op at bottom boundary", () => {
+      lockRepo("issues", "org/repo-a");
+      lockRepo("issues", "org/repo-b");
+      moveLockedRepo("issues", "org/repo-b", "down");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-b"]);
+    });
+
+    it("no-op if not locked", () => {
+      lockRepo("issues", "org/repo-a");
+      moveLockedRepo("issues", "org/repo-z", "up");
+      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
+    });
+  });
+
+  describe("pruneLockedRepos", () => {
+    it("removes stale names", () => {
+      lockRepo("pullRequests", "org/repo-a");
+      lockRepo("pullRequests", "org/repo-b");
+      lockRepo("pullRequests", "org/repo-c");
+      pruneLockedRepos("pullRequests", ["org/repo-a", "org/repo-c"]);
+      expect(viewState.lockedRepos.pullRequests).toEqual(["org/repo-a", "org/repo-c"]);
+    });
+
+    it("preserves order of active repos", () => {
+      lockRepo("pullRequests", "org/repo-c");
+      lockRepo("pullRequests", "org/repo-a");
+      lockRepo("pullRequests", "org/repo-b");
+      pruneLockedRepos("pullRequests", ["org/repo-b", "org/repo-c"]);
+      expect(viewState.lockedRepos.pullRequests).toEqual(["org/repo-c", "org/repo-b"]);
+    });
+
+    it("no-op when empty", () => {
+      pruneLockedRepos("pullRequests", ["org/repo-a"]);
+      expect(viewState.lockedRepos.pullRequests).toEqual([]);
+    });
+
+    it("no-op when all active", () => {
+      lockRepo("actions", "org/repo-a");
+      pruneLockedRepos("actions", ["org/repo-a", "org/repo-b"]);
+      expect(viewState.lockedRepos.actions).toEqual(["org/repo-a"]);
+    });
+  });
+
+  describe("schema migration", () => {
+    it("defaults lockedRepos when absent", () => {
+      const result = ViewStateSchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.lockedRepos).toEqual({
+          issues: [],
+          pullRequests: [],
+          actions: [],
+        });
+      }
+    });
+
+    it("preserves existing data without lockedRepos", () => {
+      const result = ViewStateSchema.safeParse({
+        lastActiveTab: "issues",
+        expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.lastActiveTab).toBe("issues");
+        expect(result.data.lockedRepos).toEqual({
+          issues: [],
+          pullRequests: [],
+          actions: [],
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds hot-poll shimmer/flash animations on item rows with inline peek for collapsed repo headers
- Adds per-tab repo lock controls with locked-first ordering and reorder highlight animation
- Includes pre-existing accessibility fixes (role=img, aria-labels, reduced-motion, keyboard focus)