### PR TITLE
feat: adds bot user tracking and per-repo monitor-all mode

### DIFF
--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -19,7 +19,8 @@ import {
   fetchAllData,
   type DashboardData,
 } from "../../services/poll";
-import { clearAuth, user, onAuthCleared, DASHBOARD_STORAGE_KEY } from "../../stores/auth";
+import { expireToken, user, onAuthCleared, DASHBOARD_STORAGE_KEY } from "../../stores/auth";
+import { pushNotification } from "../../lib/errors";
 import { getClient, getGraphqlRateLimit } from "../../services/github";
 import { formatCount } from "../../lib/format";
 import { setsEqual } from "../../lib/collections";
@@ -191,7 +192,7 @@ async function pollFetch(): Promise<DashboardData> {
         try {
           localStorage.setItem(DASHBOARD_STORAGE_KEY, JSON.stringify(cachePayload));
         } catch {
-          // localStorage full or unavailable — non-fatal
+          pushNotification("localStorage:dashboard", "Dashboard cache write failed — storage may be full", "warning");
         }
       }, 0);
     } else {
@@ -208,9 +209,9 @@ async function pollFetch(): Promise<DashboardData> {
         : null;
 
     if (status === 401) {
-      // Hard redirect (not navigate()) forces a full page reload, which clears
-      // module-level state like _coordinator and dashboardData for the next user.
-      clearAuth();
+      // Token invalid — clear token only, preserve user config/view/dashboard.
+      // Hard redirect forces a full page reload, clearing module-level state.
+      expireToken();
       window.location.replace("/login");
     }
     setDashboardData("loading", false);

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -359,6 +359,7 @@ export default function DashboardPage() {
                   userLogin={userLogin()}
                   allUsers={allUsers()}
                   trackedUsers={config.trackedUsers}
+                  monitoredRepos={config.monitoredRepos}
                 />
               </Match>
               <Match when={activeTab() === "pullRequests"}>
@@ -369,6 +370,7 @@ export default function DashboardPage() {
                   allUsers={allUsers()}
                   trackedUsers={config.trackedUsers}
                   hotPollingPRIds={hotPollingPRIds()}
+                  monitoredRepos={config.monitoredRepos}
                 />
               </Match>
               <Match when={activeTab() === "actions"}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -25,6 +25,7 @@ export interface IssuesTabProps {
   userLogin: string;
   allUsers?: { login: string; label: string }[];
   trackedUsers?: TrackedUser[];
+  monitoredRepos?: { fullName: string }[];
 }
 
 type SortField = "repo" | "title" | "author" | "createdAt" | "updatedAt" | "comments";
@@ -66,6 +67,10 @@ export default function IssuesTab(props: IssuesTabProps) {
 
   const upstreamRepoSet = createMemo(() =>
     new Set((config.upstreamRepos ?? []).map(r => r.fullName))
+  );
+
+  const monitoredRepoNameSet = createMemo(() =>
+    new Set((props.monitoredRepos ?? []).map(r => r.fullName))
   );
 
   const filterGroups = createMemo<FilterChipGroupDef[]>(() => {
@@ -114,10 +119,13 @@ export default function IssuesTab(props: IssuesTabProps) {
       }
 
       if (tabFilter.user !== "all") {
-        const validUser = !props.allUsers || props.allUsers.some(u => u.login === tabFilter.user);
-        if (validUser) {
-          const surfacedBy = issue.surfacedBy ?? [props.userLogin.toLowerCase()];
-          if (!surfacedBy.includes(tabFilter.user)) return false;
+        // Items from monitored repos bypass the surfacedBy filter (all activity is shown)
+        if (!monitoredRepoNameSet().has(issue.repoFullName)) {
+          const validUser = !props.allUsers || props.allUsers.some(u => u.login === tabFilter.user);
+          if (validUser) {
+            const surfacedBy = issue.surfacedBy ?? [props.userLogin.toLowerCase()];
+            if (!surfacedBy.includes(tabFilter.user)) return false;
+          }
         }
       }
 
@@ -305,6 +313,9 @@ export default function IssuesTab(props: IssuesTabProps) {
                       >
                         <ChevronIcon size="md" rotated={!isExpanded()} />
                         {repoGroup.repoFullName}
+                        <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
+                          <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                        </Show>
                         <Show when={!isExpanded()}>
                           <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
                             <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
 import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type IssueFilterField } from "../../stores/view";
-import type { Issue } from "../../services/api";
+import type { Issue, RepoRef } from "../../services/api";
 import ItemRow from "./ItemRow";
 import UserAvatarBadge, { buildSurfacedByUsers } from "../shared/UserAvatarBadge";
 import IgnoreBadge from "./IgnoreBadge";
@@ -25,7 +25,7 @@ export interface IssuesTabProps {
   userLogin: string;
   allUsers?: { login: string; label: string }[];
   trackedUsers?: TrackedUser[];
-  monitoredRepos?: { fullName: string }[];
+  monitoredRepos?: RepoRef[];
 }
 
 type SortField = "repo" | "title" | "author" | "createdAt" | "updatedAt" | "comments";

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -30,6 +30,7 @@ export interface PullRequestsTabProps {
   allUsers?: { login: string; label: string }[];
   trackedUsers?: TrackedUser[];
   hotPollingPRIds?: ReadonlySet<number>;
+  monitoredRepos?: { fullName: string }[];
 }
 
 type SortField = "repo" | "title" | "author" | "createdAt" | "updatedAt" | "checkStatus" | "reviewDecision" | "size";
@@ -135,6 +136,10 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
     new Set((config.upstreamRepos ?? []).map(r => r.fullName))
   );
 
+  const monitoredRepoNameSet = createMemo(() =>
+    new Set((props.monitoredRepos ?? []).map(r => r.fullName))
+  );
+
   const filterGroups = createMemo<FilterChipGroupDef[]>(() => {
     const users = props.allUsers;
     if (!users || users.length <= 1) return prFilterGroups;
@@ -199,10 +204,13 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
       }
 
       if (tabFilters.user !== "all") {
-        const validUser = !props.allUsers || props.allUsers.some(u => u.login === tabFilters.user);
-        if (validUser) {
-          const surfacedBy = pr.surfacedBy ?? [props.userLogin.toLowerCase()];
-          if (!surfacedBy.includes(tabFilters.user)) return false;
+        // Items from monitored repos bypass the surfacedBy filter (all activity is shown)
+        if (!monitoredRepoNameSet().has(pr.repoFullName)) {
+          const validUser = !props.allUsers || props.allUsers.some(u => u.login === tabFilters.user);
+          if (validUser) {
+            const surfacedBy = pr.surfacedBy ?? [props.userLogin.toLowerCase()];
+            if (!surfacedBy.includes(tabFilters.user)) return false;
+          }
         }
       }
 
@@ -418,6 +426,9 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                       >
                         <ChevronIcon size="md" rotated={!isExpanded()} />
                         {repoGroup.repoFullName}
+                        <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
+                          <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                        </Show>
                         <Show when={!isExpanded()}>
                           <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
                             <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
 import { viewState, setSortPreference, ignoreItem, unignoreItem, setTabFilter, resetTabFilter, resetAllTabFilters, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type PullRequestFilterField } from "../../stores/view";
-import type { PullRequest } from "../../services/api";
+import type { PullRequest, RepoRef } from "../../services/api";
 import { deriveInvolvementRoles, prSizeCategory } from "../../lib/format";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import ItemRow from "./ItemRow";
@@ -30,7 +30,7 @@ export interface PullRequestsTabProps {
   allUsers?: { login: string; label: string }[];
   trackedUsers?: TrackedUser[];
   hotPollingPRIds?: ReadonlySet<number>;
-  monitoredRepos?: { fullName: string }[];
+  monitoredRepos?: RepoRef[];
 }
 
 type SortField = "repo" | "title" | "author" | "createdAt" | "updatedAt" | "checkStatus" | "reviewDecision" | "size";

--- a/src/app/components/onboarding/OnboardingWizard.tsx
+++ b/src/app/components/onboarding/OnboardingWizard.tsx
@@ -19,6 +19,9 @@ export default function OnboardingWizard() {
   const [upstreamRepos, setUpstreamRepos] = createSignal<RepoRef[]>(
     config.upstreamRepos.length > 0 ? [...config.upstreamRepos] : []
   );
+  const [monitoredRepos, setMonitoredRepos] = createSignal<RepoRef[]>(
+    config.monitoredRepos.length > 0 ? [...config.monitoredRepos] : []
+  );
 
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal<string | null>(null);
@@ -53,10 +56,14 @@ export default function OnboardingWizard() {
 
   function handleFinish() {
     const uniqueOrgs = [...new Set(selectedRepos().map((r) => r.owner))];
+    // Prune monitoredRepos to only repos still in selectedRepos
+    const selectedSet = new Set(selectedRepos().map((r) => r.fullName));
+    const prunedMonitoredRepos = monitoredRepos().filter((r) => selectedSet.has(r.fullName));
     updateConfig({
       selectedOrgs: uniqueOrgs,
       selectedRepos: selectedRepos(),
       upstreamRepos: upstreamRepos(),
+      monitoredRepos: prunedMonitoredRepos,
       onboardingComplete: true,
     });
     // Flush synchronously — the debounced persistence effect won't fire before page unload
@@ -116,6 +123,14 @@ export default function OnboardingWizard() {
                   upstreamRepos={upstreamRepos()}
                   onUpstreamChange={setUpstreamRepos}
                   trackedUsers={config.trackedUsers}
+                  monitoredRepos={monitoredRepos()}
+                  onMonitorToggle={(repo, monitored) => {
+                    if (monitored) {
+                      setMonitoredRepos((prev) => prev.some((r) => r.fullName === repo.fullName) ? prev : [...prev, repo]);
+                    } else {
+                      setMonitoredRepos((prev) => prev.filter((r) => r.fullName !== repo.fullName));
+                    }
+                  }}
                 />
               </Match>
             </Switch>

--- a/src/app/components/onboarding/OnboardingWizard.tsx
+++ b/src/app/components/onboarding/OnboardingWizard.tsx
@@ -57,14 +57,11 @@ export default function OnboardingWizard() {
 
   function handleFinish() {
     const uniqueOrgs = [...new Set(selectedRepos().map((r) => r.owner))];
-    // Prune monitoredRepos to only repos still in selectedRepos
-    const selectedSet = new Set(selectedRepos().map((r) => r.fullName));
-    const prunedMonitoredRepos = monitoredRepos().filter((r) => selectedSet.has(r.fullName));
     updateConfig({
       selectedOrgs: uniqueOrgs,
       selectedRepos: selectedRepos(),
       upstreamRepos: upstreamRepos(),
-      monitoredRepos: prunedMonitoredRepos,
+      monitoredRepos: monitoredRepos(),
       onboardingComplete: true,
     });
     // Flush synchronously — the debounced persistence effect won't fire before page unload

--- a/src/app/components/onboarding/OnboardingWizard.tsx
+++ b/src/app/components/onboarding/OnboardingWizard.tsx
@@ -7,6 +7,7 @@ import {
   Match,
 } from "solid-js";
 import { config, updateConfig, CONFIG_STORAGE_KEY } from "../../stores/config";
+import { pushNotification } from "../../lib/errors";
 import { fetchOrgs, type OrgEntry, type RepoRef } from "../../services/api";
 import { getClient } from "../../services/github";
 import RepoSelector from "./RepoSelector";
@@ -67,7 +68,11 @@ export default function OnboardingWizard() {
       onboardingComplete: true,
     });
     // Flush synchronously — the debounced persistence effect won't fire before page unload
-    localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
+    try {
+      localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
+    } catch {
+      pushNotification("localStorage:config", "Config write failed — storage may be full", "warning");
+    }
     window.location.replace("/dashboard");
   }
 

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -10,6 +10,7 @@ import {
 import { fetchOrgs, fetchRepos, discoverUpstreamRepos, OrgEntry, RepoRef, RepoEntry } from "../../services/api";
 import { getClient } from "../../services/github";
 import { user } from "../../stores/auth";
+import type { TrackedUser } from "../../stores/config";
 import { relativeTime } from "../../lib/format";
 import LoadingSpinner from "../shared/LoadingSpinner";
 import FilterInput from "../shared/FilterInput";
@@ -25,7 +26,9 @@ interface RepoSelectorProps {
   showUpstreamDiscovery?: boolean;
   upstreamRepos?: RepoRef[];
   onUpstreamChange?: (repos: RepoRef[]) => void;
-  trackedUsers?: { login: string; avatarUrl: string; name: string | null }[];
+  trackedUsers?: TrackedUser[];
+  monitoredRepos?: RepoRef[];
+  onMonitorToggle?: (repo: RepoRef, monitored: boolean) => void;
 }
 
 interface OrgRepoState {
@@ -223,6 +226,10 @@ export default function RepoSelector(props: RepoSelectorProps) {
 
   const selectedSet = createMemo(() =>
     new Set(props.selected.map((r) => r.fullName))
+  );
+
+  const monitoredSet = createMemo(() =>
+    new Set((props.monitoredRepos ?? []).map((r) => r.fullName))
   );
 
   const sortedOrgStates = createMemo(() => {
@@ -527,26 +534,48 @@ export default function RepoSelector(props: RepoSelectorProps) {
                         {(repo) => {
                           return (
                             <li>
-                              <label class="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-base-200">
-                                <input
-                                  type="checkbox"
-                                  checked={isSelected(repo().fullName)}
-                                  onChange={() => toggleRepo(repo())}
-                                  class="checkbox checkbox-primary checkbox-sm mt-0.5"
-                                />
-                                <div class="min-w-0 flex-1">
-                                  <div class="flex items-center gap-2">
-                                    <span class="min-w-0 truncate text-sm font-medium text-base-content">
-                                      {repo().name}
-                                    </span>
-                                    <Show when={repo().pushedAt}>
-                                      <span class="ml-auto shrink-0 text-xs text-base-content/60">
-                                        {relativeTime(repo().pushedAt!)}
+                              <div class="flex items-center">
+                                <label class="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-base-200 flex-1">
+                                  <input
+                                    type="checkbox"
+                                    checked={isSelected(repo().fullName)}
+                                    onChange={() => toggleRepo(repo())}
+                                    class="checkbox checkbox-primary checkbox-sm mt-0.5"
+                                  />
+                                  <div class="min-w-0 flex-1">
+                                    <div class="flex items-center gap-2">
+                                      <span class="min-w-0 truncate text-sm font-medium text-base-content">
+                                        {repo().name}
                                       </span>
-                                    </Show>
+                                      <Show when={repo().pushedAt}>
+                                        <span class="ml-auto shrink-0 text-xs text-base-content/60">
+                                          {relativeTime(repo().pushedAt!)}
+                                        </span>
+                                      </Show>
+                                    </div>
                                   </div>
-                                </div>
-                              </label>
+                                </label>
+                                <Show when={isSelected(repo().fullName) && props.onMonitorToggle && !upstreamSelectedSet().has(repo().fullName)}>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      props.onMonitorToggle?.(toRepoRef(repo()), !monitoredSet().has(repo().fullName));
+                                    }}
+                                    class="btn btn-ghost btn-sm btn-circle mr-2"
+                                    classList={{ "opacity-40": !monitoredSet().has(repo().fullName) }}
+                                    title={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
+                                    aria-label={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
+                                    aria-pressed={monitoredSet().has(repo().fullName)}
+                                  >
+                                    {/* Heroicons eye outline 16px */}
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width={2} aria-hidden="true">
+                                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                      <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                    </svg>
+                                  </button>
+                                </Show>
+                              </div>
                             </li>
                           );
                         }}

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -563,7 +563,10 @@ export default function RepoSelector(props: RepoSelectorProps) {
                                       props.onMonitorToggle?.(toRepoRef(repo()), !monitoredSet().has(repo().fullName));
                                     }}
                                     class="btn btn-ghost btn-sm btn-circle mr-2"
-                                    classList={{ "opacity-40": !monitoredSet().has(repo().fullName) }}
+                                    classList={{
+                                      "text-info": monitoredSet().has(repo().fullName),
+                                      "text-base-content/20": !monitoredSet().has(repo().fullName),
+                                    }}
                                     title={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
                                     aria-label={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
                                     aria-pressed={monitoredSet().has(repo().fullName)}

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -326,7 +326,7 @@ export default function SettingsPage() {
                   onUpstreamChange={handleUpstreamChange}
                   trackedUsers={config.trackedUsers}
                   monitoredRepos={config.monitoredRepos}
-                  onMonitorToggle={(repo, monitored) => setMonitoredRepo(repo, monitored)}
+                  onMonitorToggle={setMonitoredRepo}
                 />
               </div>
             </Show>

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { createSignal, Show, onCleanup } from "solid-js";
 import { useNavigate } from "@solidjs/router";
-import { config, updateConfig } from "../../stores/config";
+import { config, updateConfig, setMonitoredRepo } from "../../stores/config";
 import { clearAuth } from "../../stores/auth";
 import { clearCache } from "../../stores/cache";
 import { pushNotification } from "../../lib/errors";
@@ -142,6 +142,7 @@ export default function SettingsPage() {
         selectedOrgs: config.selectedOrgs,
         selectedRepos: config.selectedRepos,
         upstreamRepos: config.upstreamRepos,
+        monitoredRepos: config.monitoredRepos,
         trackedUsers: config.trackedUsers,
         refreshInterval: config.refreshInterval,
         hotPollInterval: config.hotPollInterval,
@@ -324,6 +325,8 @@ export default function SettingsPage() {
                   upstreamRepos={localUpstream()}
                   onUpstreamChange={handleUpstreamChange}
                   trackedUsers={config.trackedUsers}
+                  monitoredRepos={config.monitoredRepos}
+                  onMonitorToggle={(repo, monitored) => setMonitoredRepo(repo, monitored)}
                 />
               </div>
             </Show>

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show, onCleanup } from "solid-js";
+import { createSignal, createMemo, Show, onCleanup } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { config, updateConfig, setMonitoredRepo } from "../../stores/config";
 import { clearAuth } from "../../stores/auth";
@@ -53,6 +53,10 @@ export default function SettingsPage() {
   const [localOrgs, setLocalOrgs] = createSignal<string[]>(config.selectedOrgs);
   const [localRepos, setLocalRepos] = createSignal<RepoRef[]>(config.selectedRepos);
   const [localUpstream, setLocalUpstream] = createSignal<RepoRef[]>(config.upstreamRepos);
+
+  const monitoredRepoNames = createMemo(() =>
+    config.monitoredRepos.map(r => r.fullName).join(", ")
+  );
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -303,6 +307,15 @@ export default function SettingsPage() {
                   <Show when={localRepos().length > 50}>
                     <p class="text-xs text-warning">
                       Tracking {localRepos().length} repos will use significant API quota per poll cycle
+                    </p>
+                  </Show>
+                  <Show when={config.monitoredRepos.length > 0}>
+                    <p class="text-xs text-info flex items-center gap-1 mt-0.5">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width={2} aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                      </svg>
+                      Monitoring all: {monitoredRepoNames()}
                     </p>
                   </Show>
                 </div>

--- a/src/app/components/settings/TrackedUsersSection.tsx
+++ b/src/app/components/settings/TrackedUsersSection.tsx
@@ -118,11 +118,16 @@ export default function TrackedUsersSection(props: TrackedUsersSectionProps) {
               <span class="text-sm font-medium truncate">
                 {trackedUser.name ?? trackedUser.login}
               </span>
-              <Show when={trackedUser.name}>
-                <span class="text-xs text-base-content/60 truncate">
-                  {trackedUser.login}
-                </span>
-              </Show>
+              <div class="flex items-center gap-1">
+                <Show when={trackedUser.name}>
+                  <span class="text-xs text-base-content/60 truncate">
+                    {trackedUser.login}
+                  </span>
+                </Show>
+                <Show when={trackedUser.type === "bot"}>
+                  <span class="badge badge-xs badge-outline" aria-label={`${trackedUser.login} is a bot account`}>bot</span>
+                </Show>
+              </div>
             </div>
             <button
               type="button"

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -430,8 +430,6 @@ const PR_SEARCH_QUERY = `
   }
 `;
 
-// ── GraphQL combined search query ─────────────────────────────────────────────
-
 // ── Two-phase rendering: light + heavy queries ───────────────────────────────
 
 const LIGHT_PR_FRAGMENT = `
@@ -1105,13 +1103,13 @@ async function graphqlLightCombinedSearch(
 
   if (issues.length >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Issue search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/issues", `Issue search results capped at 1,000 — some items are hidden`, "warning");
+    pushNotification("search/issues", `Issue search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
     issues.splice(SEARCH_RESULT_CAP);
   }
 
   if (prMap.size >= SEARCH_RESULT_CAP) {
     console.warn(`[api] PR search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/prs", `PR search results capped at 1,000 — some items are hidden`, "warning");
+    pushNotification("search/prs", `PR search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
   }
 
   const pullRequests = [...prMap.values()];
@@ -1211,13 +1209,13 @@ async function graphqlUnfilteredSearch(
 
   if (issues.length >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Unfiltered issue results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/unfiltered-issues", `Monitored repo issue results capped at 1,000 — some items are hidden`, "warning");
+    pushNotification("search/unfiltered-issues", `Monitored repo issue results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
     issues.splice(SEARCH_RESULT_CAP);
   }
 
   if (prMap.size >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Unfiltered PR results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/unfiltered-prs", `Monitored repo PR results capped at 1,000 — some items are hidden`, "warning");
+    pushNotification("search/unfiltered-prs", `Monitored repo PR results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
   }
 
   const pullRequests = [...prMap.values()];
@@ -1412,7 +1410,7 @@ export async function fetchIssuesAndPullRequests(
   userLogin: string,
   onLightData?: (data: FetchIssuesAndPRsResult) => void,
   trackedUsers?: TrackedUser[],
-  monitoredRepos?: { fullName: string }[],
+  monitoredRepos?: RepoRef[],
 ): Promise<FetchIssuesAndPRsResult> {
   if (!octokit) throw new Error("No GitHub client available");
 
@@ -1619,7 +1617,7 @@ async function graphqlSearchIssues(
 
   if (issues.length >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Issue search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/issues", `Issue search results capped at 1,000 — some items are hidden`, "warning");
+    pushNotification("search/issues", `Issue search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
     issues.splice(SEARCH_RESULT_CAP);
   }
 
@@ -1759,7 +1757,7 @@ async function graphqlSearchPRs(
 
   if (prMap.size >= SEARCH_RESULT_CAP) {
     console.warn(`[api] PR search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/prs", `PR search results capped at 1,000 — some items are hidden`, "warning");
+    pushNotification("search/prs", `PR search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
   }
 
   // Fork PR fallback: for PRs with null checkStatus where head repo owner differs from base

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -914,8 +914,6 @@ export interface FetchIssuesAndPRsResult {
 interface LightSearchResult {
   issues: Issue[];
   pullRequests: PullRequest[];
-  /** GraphQL node IDs for phase 2 backfill */
-  prNodeIds: string[];
   errors: ApiError[];
 }
 
@@ -1058,6 +1056,32 @@ async function executeLightCombinedQuery(
   }
 }
 
+/** Cap-check, notify, and assemble a LightSearchResult from working collections. */
+function finalizeSearchResult(
+  issues: Issue[],
+  prMap: Map<number, PullRequest>,
+  errors: ApiError[],
+  issueSource: string,
+  prSource: string,
+  issueLabel: string,
+  prLabel: string,
+): LightSearchResult {
+  if (issues.length >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] ${issueLabel} capped at ${SEARCH_RESULT_CAP}`);
+    pushNotification(issueSource, `${issueLabel} capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
+    issues.splice(SEARCH_RESULT_CAP);
+  }
+
+  if (prMap.size >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] ${prLabel} capped at ${SEARCH_RESULT_CAP}`);
+    pushNotification(prSource, `${prLabel} capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
+  }
+
+  const pullRequests = [...prMap.values()];
+  if (pullRequests.length >= SEARCH_RESULT_CAP) pullRequests.splice(SEARCH_RESULT_CAP);
+  return { issues, pullRequests, errors };
+}
+
 /**
  * Phase 1: light combined search. Fetches issues fully and PRs with minimal fields.
  * Returns light PRs (enriched: false) and their GraphQL node IDs for phase 2 backfill.
@@ -1071,7 +1095,6 @@ async function graphqlLightCombinedSearch(
     return {
       issues: [],
       pullRequests: [],
-      prNodeIds: [],
       errors: [{ repo: "search", statusCode: null, message: "Invalid userLogin", retryable: false }],
     };
   }
@@ -1101,22 +1124,11 @@ async function graphqlLightCombinedSearch(
     }
   }));
 
-  if (issues.length >= SEARCH_RESULT_CAP) {
-    console.warn(`[api] Issue search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/issues", `Issue search results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
-    issues.splice(SEARCH_RESULT_CAP);
-  }
-
-  if (prMap.size >= SEARCH_RESULT_CAP) {
-    console.warn(`[api] PR search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/prs", `PR search results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
-  }
-
-  const pullRequests = [...prMap.values()];
-  if (pullRequests.length >= SEARCH_RESULT_CAP) pullRequests.splice(SEARCH_RESULT_CAP);
-  const prNodeIds = pullRequests.map((pr) => nodeIdMap.get(pr.id)).filter((id): id is string => id != null);
-
-  return { issues, pullRequests, prNodeIds, errors };
+  return finalizeSearchResult(
+    issues, prMap, errors,
+    "search/issues", "search/prs",
+    "Issue search results", "PR search results",
+  );
 }
 
 /**
@@ -1129,7 +1141,7 @@ async function graphqlUnfilteredSearch(
   octokit: GitHubOctokit,
   repos: RepoRef[]
 ): Promise<LightSearchResult> {
-  if (repos.length === 0) return { issues: [], pullRequests: [], prNodeIds: [], errors: [] };
+  if (repos.length === 0) return { issues: [], pullRequests: [], errors: [] };
 
   const chunks = chunkArray(repos, SEARCH_REPO_BATCH_SIZE);
   const issueSeen = new Set<number>();
@@ -1207,21 +1219,11 @@ async function graphqlUnfilteredSearch(
     }
   }));
 
-  if (issues.length >= SEARCH_RESULT_CAP) {
-    console.warn(`[api] Unfiltered issue results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/unfiltered-issues", `Monitored repo issue results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
-    issues.splice(SEARCH_RESULT_CAP);
-  }
-
-  if (prMap.size >= SEARCH_RESULT_CAP) {
-    console.warn(`[api] Unfiltered PR results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/unfiltered-prs", `Monitored repo PR results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
-  }
-
-  const pullRequests = [...prMap.values()];
-  if (pullRequests.length >= SEARCH_RESULT_CAP) pullRequests.splice(SEARCH_RESULT_CAP);
-  const prNodeIds = pullRequests.map((pr) => nodeIdMap.get(pr.id)).filter((id): id is string => id != null);
-  return { issues, pullRequests, prNodeIds, errors };
+  return finalizeSearchResult(
+    issues, prMap, errors,
+    "search/unfiltered-issues", "search/unfiltered-prs",
+    "Monitored repo issue results", "Monitored repo PR results",
+  );
 }
 
 // ── Two-phase: heavy backfill ─────────────────────────────────────────────────
@@ -1356,7 +1358,6 @@ function mergeEnrichment(
  * Merges tracked user search results into the main issue/PR maps.
  * Items already present get the tracked user's login appended to surfacedBy.
  * New items are added with surfacedBy: [trackedLogin].
- * Returns a union of all prNodeIds for backfill.
  */
 function mergeTrackedUserResults(
   issueMap: Map<number, Issue>,
@@ -1475,7 +1476,7 @@ export async function fetchIssuesAndPullRequests(
   // Unfiltered search for monitored repos — runs in parallel with tracked searches
   const unfilteredPromise = monitoredReposList.length > 0
     ? graphqlUnfilteredSearch(octokit, monitoredReposList)
-    : Promise.resolve({ issues: [], pullRequests: [], prNodeIds: [], errors: [] } as LightSearchResult);
+    : Promise.resolve({ issues: [], pullRequests: [], errors: [] } as LightSearchResult);
 
   const [mainBackfill, trackedResults, unfilteredResult] = await Promise.all([
     mainBackfillPromise,
@@ -2210,7 +2211,7 @@ export async function validateGitHubUser(
     login: raw.login.toLowerCase(),
     avatarUrl,
     name: raw.name ?? null,
-    type: raw.type === "Bot" ? "bot" as const : "user" as const,
+    type: raw.type === "Bot" ? "bot" : "user",
   };
 }
 

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -1103,13 +1103,13 @@ async function graphqlLightCombinedSearch(
 
   if (issues.length >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Issue search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/issues", `Issue search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
+    pushNotification("search/issues", `Issue search results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
     issues.splice(SEARCH_RESULT_CAP);
   }
 
   if (prMap.size >= SEARCH_RESULT_CAP) {
     console.warn(`[api] PR search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/prs", `PR search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
+    pushNotification("search/prs", `PR search results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
   }
 
   const pullRequests = [...prMap.values()];
@@ -1209,13 +1209,13 @@ async function graphqlUnfilteredSearch(
 
   if (issues.length >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Unfiltered issue results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/unfiltered-issues", `Monitored repo issue results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
+    pushNotification("search/unfiltered-issues", `Monitored repo issue results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
     issues.splice(SEARCH_RESULT_CAP);
   }
 
   if (prMap.size >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Unfiltered PR results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/unfiltered-prs", `Monitored repo PR results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
+    pushNotification("search/unfiltered-prs", `Monitored repo PR results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
   }
 
   const pullRequests = [...prMap.values()];
@@ -1617,7 +1617,7 @@ async function graphqlSearchIssues(
 
   if (issues.length >= SEARCH_RESULT_CAP) {
     console.warn(`[api] Issue search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/issues", `Issue search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
+    pushNotification("search/issues", `Issue search results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
     issues.splice(SEARCH_RESULT_CAP);
   }
 
@@ -1757,7 +1757,7 @@ async function graphqlSearchPRs(
 
   if (prMap.size >= SEARCH_RESULT_CAP) {
     console.warn(`[api] PR search results capped at ${SEARCH_RESULT_CAP}`);
-    pushNotification("search/prs", `PR search results capped at ${SEARCH_RESULT_CAP.toLocaleString()} — some items are hidden`, "warning");
+    pushNotification("search/prs", `PR search results capped at ${SEARCH_RESULT_CAP.toLocaleString("en-US")} — some items are hidden`, "warning");
   }
 
   // Fork PR fallback: for PRs with null checkStatus where head repo owner differs from base

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -206,8 +206,9 @@ function extractSearchPartialData<T>(err: unknown): T | null {
 }
 
 const VALID_REPO_NAME = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
-const VALID_LOGIN = /^[A-Za-z0-9-]{1,39}$/;
-const VALID_TRACKED_LOGIN = VALID_LOGIN;
+// Allows alphanumeric/hyphen base (1-39 chars) with optional literal [bot] suffix for GitHub
+// App bot accounts. Case-sensitive [bot] is intentional — GitHub always uses lowercase.
+const VALID_TRACKED_LOGIN = /^[A-Za-z0-9-]{1,39}(\[bot\])?$/;
 
 function chunkArray<T>(arr: T[], size: number): T[][] {
   const chunks: T[][] = [];
@@ -493,6 +494,61 @@ const LIGHT_COMBINED_SEARCH_QUERY = `
   }
   ${LIGHT_PR_FRAGMENT}
 `;
+
+/**
+ * Unfiltered search query for monitored repos — fetches all open issues and PRs
+ * without any involves: qualifier. Used when a repo is marked for monitor-all mode.
+ * Variables: $issueQ, $prQ, $issueCursor, $prCursor.
+ */
+const UNFILTERED_SEARCH_QUERY = `
+  query($issueQ: String!, $prQ: String!, $issueCursor: String, $prCursor: String) {
+    issues: search(query: $issueQ, type: ISSUE, first: 50, after: $issueCursor) {
+      issueCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        ... on Issue {
+          databaseId
+          number
+          title
+          state
+          url
+          createdAt
+          updatedAt
+          author { login avatarUrl }
+          labels(first: 10) { nodes { name color } }
+          assignees(first: 10) { nodes { login } }
+          repository { nameWithOwner }
+          comments { totalCount }
+        }
+      }
+    }
+    prs: search(query: $prQ, type: ISSUE, first: 50, after: $prCursor) {
+      issueCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        ... on PullRequest {
+          ...LightPRFields
+        }
+      }
+    }
+    rateLimit { limit remaining resetAt }
+  }
+  ${LIGHT_PR_FRAGMENT}
+`;
+
+interface UnfilteredSearchResponse {
+  issues: {
+    issueCount: number;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    nodes: (GraphQLIssueNode | null)[];
+  };
+  prs: {
+    issueCount: number;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    nodes: (GraphQLLightPRNode | null)[];
+  };
+  rateLimit?: GraphQLRateLimit;
+}
 
 /** Standalone light PR search query for pagination follow-ups. */
 const LIGHT_PR_SEARCH_QUERY = `
@@ -1024,7 +1080,7 @@ async function graphqlLightCombinedSearch(
   repos: RepoRef[],
   userLogin: string
 ): Promise<LightSearchResult> {
-  if (!VALID_LOGIN.test(userLogin)) {
+  if (!VALID_TRACKED_LOGIN.test(userLogin)) {
     return {
       issues: [],
       pullRequests: [],
@@ -1075,6 +1131,113 @@ async function graphqlLightCombinedSearch(
   if (pullRequests.length >= PR_CAP) pullRequests.splice(PR_CAP);
   const prNodeIds = pullRequests.map((pr) => nodeIdMap.get(pr.id)).filter((id): id is string => id != null);
 
+  return { issues, pullRequests, prNodeIds, errors };
+}
+
+/**
+ * Unfiltered search for monitored repos — returns all open issues + PRs without
+ * any user qualifier (no involves:, no review-requested:). Intentionally accepts
+ * no user login parameter; input is limited to repo names validated through
+ * buildRepoQualifiers (which applies VALID_REPO_NAME).
+ */
+async function graphqlUnfilteredSearch(
+  octokit: GitHubOctokit,
+  repos: RepoRef[]
+): Promise<LightSearchResult> {
+  if (repos.length === 0) return { issues: [], pullRequests: [], prNodeIds: [], errors: [] };
+
+  const chunks = chunkArray(repos, SEARCH_REPO_BATCH_SIZE);
+  const issueSeen = new Set<number>();
+  const issues: Issue[] = [];
+  const prMap = new Map<number, PullRequest>();
+  const nodeIdMap = new Map<number, string>();
+  const errors: ApiError[] = [];
+  const ISSUE_CAP = 1000;
+  const PR_CAP = 1000;
+
+  await Promise.allSettled(chunks.map(async (chunk, chunkIdx) => {
+    const repoQualifiers = buildRepoQualifiers(chunk);
+    const issueQ = `is:issue is:open ${repoQualifiers}`;
+    const prQ = `is:pr is:open ${repoQualifiers}`;
+    const batchLabel = `unfiltered-batch-${chunkIdx + 1}/${chunks.length}`;
+
+    try {
+      let response: UnfilteredSearchResponse;
+      let isPartial = false;
+      try {
+        response = await octokit.graphql<UnfilteredSearchResponse>(UNFILTERED_SEARCH_QUERY, {
+          issueQ, prQ, issueCursor: null, prCursor: null,
+        });
+      } catch (err) {
+        const partial = (err && typeof err === "object" && "data" in err && err.data && typeof err.data === "object")
+          ? err.data as Partial<UnfilteredSearchResponse>
+          : null;
+        if (partial && (partial.issues || partial.prs)) {
+          response = {
+            issues: partial.issues ?? { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            prs: partial.prs ?? { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            rateLimit: partial.rateLimit,
+          };
+          isPartial = true;
+          const { message } = extractRejectionError(err);
+          errors.push({ repo: batchLabel, statusCode: null, message, retryable: true });
+        } else {
+          const { statusCode, message } = extractRejectionError(err);
+          errors.push({ repo: batchLabel, statusCode, message, retryable: statusCode === null || statusCode >= 500 });
+          return;
+        }
+      }
+
+      if (response.rateLimit) updateGraphqlRateLimit(response.rateLimit);
+
+      for (const node of response.issues.nodes) {
+        if (issues.length >= ISSUE_CAP) break;
+        if (!node) continue;
+        processIssueNode(node, issueSeen, issues);
+      }
+      for (const node of response.prs.nodes) {
+        if (prMap.size >= PR_CAP) break;
+        if (!node) continue;
+        processLightPRNode(node, prMap, nodeIdMap);
+      }
+
+      if (isPartial) return;
+
+      if (response.issues.pageInfo.hasNextPage && response.issues.pageInfo.endCursor && issues.length < ISSUE_CAP) {
+        await paginateGraphQLSearch<GraphQLIssueSearchResponse, GraphQLIssueNode>(
+          octokit, ISSUES_SEARCH_QUERY, issueQ, batchLabel, errors,
+          (node) => processIssueNode(node, issueSeen, issues),
+          () => issues.length, ISSUE_CAP, response.issues.pageInfo.endCursor,
+        );
+      }
+
+      if (response.prs.pageInfo.hasNextPage && response.prs.pageInfo.endCursor && prMap.size < PR_CAP) {
+        await paginateGraphQLSearch<LightPRSearchResponse, GraphQLLightPRNode>(
+          octokit, LIGHT_PR_SEARCH_QUERY, prQ, batchLabel, errors,
+          (node) => processLightPRNode(node, prMap, nodeIdMap),
+          () => prMap.size, PR_CAP, response.prs.pageInfo.endCursor,
+        );
+      }
+    } catch (err) {
+      const { statusCode, message } = extractRejectionError(err);
+      errors.push({ repo: batchLabel, statusCode, message, retryable: statusCode === null || statusCode >= 500 });
+    }
+  }));
+
+  if (issues.length >= ISSUE_CAP) {
+    console.warn(`[api] Unfiltered issue results capped at ${ISSUE_CAP}`);
+    pushNotification("search/unfiltered-issues", `Monitored repo issue results capped at 1,000 — some items are hidden`, "warning");
+    issues.splice(ISSUE_CAP);
+  }
+
+  if (prMap.size >= PR_CAP) {
+    console.warn(`[api] Unfiltered PR results capped at ${PR_CAP}`);
+    pushNotification("search/unfiltered-prs", `Monitored repo PR results capped at 1,000 — some items are hidden`, "warning");
+  }
+
+  const pullRequests = [...prMap.values()];
+  if (pullRequests.length >= PR_CAP) pullRequests.splice(PR_CAP);
+  const prNodeIds = pullRequests.map((pr) => nodeIdMap.get(pr.id)).filter((id): id is string => id != null);
   return { issues, pullRequests, prNodeIds, errors };
 }
 
@@ -1264,12 +1427,18 @@ export async function fetchIssuesAndPullRequests(
   userLogin: string,
   onLightData?: (data: FetchIssuesAndPRsResult) => void,
   trackedUsers?: TrackedUser[],
+  monitoredRepos?: { fullName: string }[],
 ): Promise<FetchIssuesAndPRsResult> {
   if (!octokit) throw new Error("No GitHub client available");
 
   const hasTrackedUsers = (trackedUsers?.length ?? 0) > 0;
 
-  // Early exit — tracked user searches are scoped to repos, so no repos = no results
+  // Partition repos into normal (involves: search) and monitored (unfiltered search)
+  const monitoredSet = new Set((monitoredRepos ?? []).map((r) => r.fullName));
+  const normalRepos = repos.filter((r) => !monitoredSet.has(r.fullName));
+  const monitoredReposList = repos.filter((r) => monitoredSet.has(r.fullName));
+
+  // Early exit — if no repos at all, return empty
   if (repos.length === 0) {
     return { issues: [], pullRequests: [], errors: [] };
   }
@@ -1282,9 +1451,9 @@ export async function fetchIssuesAndPullRequests(
   const prMap = new Map<number, PullRequest>();
   const nodeIdMap = new Map<number, string>();
 
-  // Phase 1: main user light search (skipped when repos empty)
-  if (repos.length > 0 && userLogin) {
-    const lightResult = await graphqlLightCombinedSearch(octokit, repos, userLogin);
+  // Phase 1: main user light search over normal repos (those not in monitoredRepos)
+  if (normalRepos.length > 0 && userLogin) {
+    const lightResult = await graphqlLightCombinedSearch(octokit, normalRepos, userLogin);
     allErrors.push(...lightResult.errors);
 
     // Annotate main user's items with surfacedBy BEFORE firing onLightData
@@ -1313,19 +1482,49 @@ export async function fetchIssuesAndPullRequests(
     ? fetchPREnrichment(octokit, mainNodeIds)
     : Promise.resolve({ enrichments: new Map<number, PREnrichmentData>(), errors: [] as ApiError[] });
 
-  // Tracked user searches — scoped to the same repos as the main user
+  // Tracked user searches — scoped to normalRepos (monitored repos are already covered by
+  // graphqlUnfilteredSearch, so running involves: on them would only duplicate work)
+  const trackedSearchRepos = normalRepos.length > 0 ? normalRepos : repos;
   const trackedSearchPromise = hasTrackedUsers && repos.length > 0
-    ? Promise.allSettled(trackedUsers!.map((u) => graphqlLightCombinedSearch(octokit, repos, u.login)))
+    ? Promise.allSettled(trackedUsers!.map((u) => graphqlLightCombinedSearch(octokit, trackedSearchRepos, u.login)))
     : Promise.resolve([] as PromiseSettledResult<LightSearchResult>[]);
 
-  const [mainBackfill, trackedResults] = await Promise.all([mainBackfillPromise, trackedSearchPromise]);
+  // Unfiltered search for monitored repos — runs in parallel with tracked searches
+  const unfilteredPromise = monitoredReposList.length > 0
+    ? graphqlUnfilteredSearch(octokit, monitoredReposList)
+    : Promise.resolve({ issues: [], pullRequests: [], prNodeIds: [], errors: [] } as LightSearchResult);
+
+  const [mainBackfill, trackedResults, unfilteredResult] = await Promise.all([
+    mainBackfillPromise,
+    trackedSearchPromise,
+    unfilteredPromise,
+  ]);
 
   // Merge main backfill results
   const backfillErrors = [...mainBackfill.errors];
   const forkInfoMap = new Map<number, { owner: string; repoName: string }>();
 
-  // Merge tracked user results and collect new (delta) node IDs
-  const preTrackedPrIds = new Set(prMap.keys());
+  // Capture which PR IDs already exist BEFORE adding any new results (monitored or tracked users).
+  // Delta backfill uses this set to identify PRs that need enrichment.
+  const preNewPrIds = new Set(prMap.keys());
+
+  // Merge unfiltered (monitored repo) results BEFORE tracked user merge.
+  // Only insert items not already present from the involves: search (preserves surfacedBy).
+  allErrors.push(...unfilteredResult.errors);
+  for (const issue of unfilteredResult.issues) {
+    if (!issueMap.has(issue.id)) {
+      issueMap.set(issue.id, issue); // no surfacedBy — monitored repo item
+    }
+  }
+  for (const pr of unfilteredResult.pullRequests) {
+    if (!prMap.has(pr.id)) {
+      prMap.set(pr.id, pr); // no surfacedBy — monitored repo item
+      if (pr.nodeId) nodeIdMap.set(pr.id, pr.nodeId);
+    }
+  }
+
+  // Merge tracked user results and collect new (delta) node IDs for both
+  // monitored repo PRs (added above) and tracked user PRs (added below).
   if (hasTrackedUsers) {
     const settled = trackedResults as PromiseSettledResult<LightSearchResult>[];
     for (let i = 0; i < settled.length; i++) {
@@ -1349,10 +1548,11 @@ export async function fetchIssuesAndPullRequests(
     ? mergeEnrichment(mergedPRs, mainBackfill.enrichments, forkInfoMap)
     : mergedPRs;
 
-  // Delta backfill: enrich only NEW PRs from tracked users (not already in main user's set)
+  // Delta backfill: enrich PRs not already covered by main backfill —
+  // includes both monitored repo PRs and new PRs from tracked users
   const deltaNodeIds: string[] = [];
   for (const pr of mergedPRs) {
-    if (!preTrackedPrIds.has(pr.id)) {
+    if (!preNewPrIds.has(pr.id)) {
       const nodeId = nodeIdMap.get(pr.id);
       if (nodeId) deltaNodeIds.push(nodeId);
     }
@@ -1384,7 +1584,7 @@ async function graphqlSearchIssues(
   repos: RepoRef[],
   userLogin: string
 ): Promise<FetchIssuesResult> {
-  if (!VALID_LOGIN.test(userLogin)) return { issues: [], errors: [{ repo: "search", statusCode: null, message: "Invalid userLogin", retryable: false }] };
+  if (!VALID_TRACKED_LOGIN.test(userLogin)) return { issues: [], errors: [{ repo: "search", statusCode: null, message: "Invalid userLogin", retryable: false }] };
 
   const chunks = chunkArray(repos, SEARCH_REPO_BATCH_SIZE);
   const seen = new Set<number>();
@@ -1478,7 +1678,7 @@ async function graphqlSearchPRs(
   repos: RepoRef[],
   userLogin: string
 ): Promise<FetchPullRequestsResult> {
-  if (!VALID_LOGIN.test(userLogin)) return { pullRequests: [], errors: [{ repo: "pr-search", statusCode: null, message: "Invalid userLogin", retryable: false }] };
+  if (!VALID_TRACKED_LOGIN.test(userLogin)) return { pullRequests: [], errors: [{ repo: "pr-search", statusCode: null, message: "Invalid userLogin", retryable: false }] };
 
   const chunks = chunkArray(repos, SEARCH_REPO_BATCH_SIZE);
   const prMap = new Map<number, PullRequest>();
@@ -1993,6 +2193,7 @@ interface RawGitHubUser {
   login: string;
   avatar_url: string;
   name: string | null;
+  type: string;
 }
 
 /**
@@ -2028,6 +2229,7 @@ export async function validateGitHubUser(
     login: raw.login.toLowerCase(),
     avatarUrl,
     name: raw.name ?? null,
+    type: raw.type === "Bot" ? "bot" as const : "user" as const,
   };
 }
 

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -210,6 +210,8 @@ const VALID_REPO_NAME = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 // App bot accounts. Case-sensitive [bot] is intentional — GitHub always uses lowercase.
 const VALID_TRACKED_LOGIN = /^[A-Za-z0-9-]{1,39}(\[bot\])?$/;
 
+const SEARCH_RESULT_CAP = 1000;
+
 function chunkArray<T>(arr: T[], size: number): T[][] {
   const chunks: T[][] = [];
   for (let i = 0; i < arr.length; i += size) {
@@ -342,6 +344,23 @@ interface ForkQueryResponse {
 
 // ── GraphQL search query constants ───────────────────────────────────────────
 
+const LIGHT_ISSUE_FRAGMENT = `
+  fragment LightIssueFields on Issue {
+    databaseId
+    number
+    title
+    state
+    url
+    createdAt
+    updatedAt
+    author { login avatarUrl }
+    labels(first: 10) { nodes { name color } }
+    assignees(first: 10) { nodes { login } }
+    repository { nameWithOwner }
+    comments { totalCount }
+  }
+`;
+
 const ISSUES_SEARCH_QUERY = `
   query($q: String!, $cursor: String) {
     search(query: $q, type: ISSUE, first: 50, after: $cursor) {
@@ -349,23 +368,13 @@ const ISSUES_SEARCH_QUERY = `
       pageInfo { hasNextPage endCursor }
       nodes {
         ... on Issue {
-          databaseId
-          number
-          title
-          state
-          url
-          createdAt
-          updatedAt
-          author { login avatarUrl }
-          labels(first: 10) { nodes { name color } }
-          assignees(first: 10) { nodes { login } }
-          repository { nameWithOwner }
-          comments { totalCount }
+          ...LightIssueFields
         }
       }
     }
     rateLimit { limit remaining resetAt }
   }
+  ${LIGHT_ISSUE_FRAGMENT}
 `;
 
 const PR_SEARCH_QUERY = `
@@ -457,18 +466,7 @@ const LIGHT_COMBINED_SEARCH_QUERY = `
       pageInfo { hasNextPage endCursor }
       nodes {
         ... on Issue {
-          databaseId
-          number
-          title
-          state
-          url
-          createdAt
-          updatedAt
-          author { login avatarUrl }
-          labels(first: 10) { nodes { name color } }
-          assignees(first: 10) { nodes { login } }
-          repository { nameWithOwner }
-          comments { totalCount }
+          ...LightIssueFields
         }
       }
     }
@@ -492,6 +490,7 @@ const LIGHT_COMBINED_SEARCH_QUERY = `
     }
     rateLimit { limit remaining resetAt }
   }
+  ${LIGHT_ISSUE_FRAGMENT}
   ${LIGHT_PR_FRAGMENT}
 `;
 
@@ -507,18 +506,7 @@ const UNFILTERED_SEARCH_QUERY = `
       pageInfo { hasNextPage endCursor }
       nodes {
         ... on Issue {
-          databaseId
-          number
-          title
-          state
-          url
-          createdAt
-          updatedAt
-          author { login avatarUrl }
-          labels(first: 10) { nodes { name color } }
-          assignees(first: 10) { nodes { login } }
-          repository { nameWithOwner }
-          comments { totalCount }
+          ...LightIssueFields
         }
       }
     }
@@ -533,6 +521,7 @@ const UNFILTERED_SEARCH_QUERY = `
     }
     rateLimit { limit remaining resetAt }
   }
+  ${LIGHT_ISSUE_FRAGMENT}
   ${LIGHT_PR_FRAGMENT}
 `;
 
@@ -1095,8 +1084,6 @@ async function graphqlLightCombinedSearch(
   const prMap = new Map<number, PullRequest>();
   const nodeIdMap = new Map<number, string>();
   const errors: ApiError[] = [];
-  const ISSUE_CAP = 1000;
-  const PR_CAP = 1000;
 
   await Promise.allSettled(chunks.map(async (chunk, chunkIdx) => {
     const repoQualifiers = buildRepoQualifiers(chunk);
@@ -1108,7 +1095,7 @@ async function graphqlLightCombinedSearch(
     try {
       await executeLightCombinedQuery(
         octokit, issueQ, prInvQ, prRevQ, batchLabel,
-        issueSeen, issues, prMap, nodeIdMap, errors, ISSUE_CAP, PR_CAP,
+        issueSeen, issues, prMap, nodeIdMap, errors, SEARCH_RESULT_CAP, SEARCH_RESULT_CAP,
       );
     } catch (err) {
       const { statusCode, message } = extractRejectionError(err);
@@ -1116,19 +1103,19 @@ async function graphqlLightCombinedSearch(
     }
   }));
 
-  if (issues.length >= ISSUE_CAP) {
-    console.warn(`[api] Issue search results capped at ${ISSUE_CAP}`);
+  if (issues.length >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] Issue search results capped at ${SEARCH_RESULT_CAP}`);
     pushNotification("search/issues", `Issue search results capped at 1,000 — some items are hidden`, "warning");
-    issues.splice(ISSUE_CAP);
+    issues.splice(SEARCH_RESULT_CAP);
   }
 
-  if (prMap.size >= PR_CAP) {
-    console.warn(`[api] PR search results capped at ${PR_CAP}`);
+  if (prMap.size >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] PR search results capped at ${SEARCH_RESULT_CAP}`);
     pushNotification("search/prs", `PR search results capped at 1,000 — some items are hidden`, "warning");
   }
 
   const pullRequests = [...prMap.values()];
-  if (pullRequests.length >= PR_CAP) pullRequests.splice(PR_CAP);
+  if (pullRequests.length >= SEARCH_RESULT_CAP) pullRequests.splice(SEARCH_RESULT_CAP);
   const prNodeIds = pullRequests.map((pr) => nodeIdMap.get(pr.id)).filter((id): id is string => id != null);
 
   return { issues, pullRequests, prNodeIds, errors };
@@ -1152,8 +1139,6 @@ async function graphqlUnfilteredSearch(
   const prMap = new Map<number, PullRequest>();
   const nodeIdMap = new Map<number, string>();
   const errors: ApiError[] = [];
-  const ISSUE_CAP = 1000;
-  const PR_CAP = 1000;
 
   await Promise.allSettled(chunks.map(async (chunk, chunkIdx) => {
     const repoQualifiers = buildRepoQualifiers(chunk);
@@ -1191,31 +1176,31 @@ async function graphqlUnfilteredSearch(
       if (response.rateLimit) updateGraphqlRateLimit(response.rateLimit);
 
       for (const node of response.issues.nodes) {
-        if (issues.length >= ISSUE_CAP) break;
+        if (issues.length >= SEARCH_RESULT_CAP) break;
         if (!node) continue;
         processIssueNode(node, issueSeen, issues);
       }
       for (const node of response.prs.nodes) {
-        if (prMap.size >= PR_CAP) break;
+        if (prMap.size >= SEARCH_RESULT_CAP) break;
         if (!node) continue;
         processLightPRNode(node, prMap, nodeIdMap);
       }
 
       if (isPartial) return;
 
-      if (response.issues.pageInfo.hasNextPage && response.issues.pageInfo.endCursor && issues.length < ISSUE_CAP) {
+      if (response.issues.pageInfo.hasNextPage && response.issues.pageInfo.endCursor && issues.length < SEARCH_RESULT_CAP) {
         await paginateGraphQLSearch<GraphQLIssueSearchResponse, GraphQLIssueNode>(
           octokit, ISSUES_SEARCH_QUERY, issueQ, batchLabel, errors,
           (node) => processIssueNode(node, issueSeen, issues),
-          () => issues.length, ISSUE_CAP, response.issues.pageInfo.endCursor,
+          () => issues.length, SEARCH_RESULT_CAP, response.issues.pageInfo.endCursor,
         );
       }
 
-      if (response.prs.pageInfo.hasNextPage && response.prs.pageInfo.endCursor && prMap.size < PR_CAP) {
+      if (response.prs.pageInfo.hasNextPage && response.prs.pageInfo.endCursor && prMap.size < SEARCH_RESULT_CAP) {
         await paginateGraphQLSearch<LightPRSearchResponse, GraphQLLightPRNode>(
           octokit, LIGHT_PR_SEARCH_QUERY, prQ, batchLabel, errors,
           (node) => processLightPRNode(node, prMap, nodeIdMap),
-          () => prMap.size, PR_CAP, response.prs.pageInfo.endCursor,
+          () => prMap.size, SEARCH_RESULT_CAP, response.prs.pageInfo.endCursor,
         );
       }
     } catch (err) {
@@ -1224,19 +1209,19 @@ async function graphqlUnfilteredSearch(
     }
   }));
 
-  if (issues.length >= ISSUE_CAP) {
-    console.warn(`[api] Unfiltered issue results capped at ${ISSUE_CAP}`);
+  if (issues.length >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] Unfiltered issue results capped at ${SEARCH_RESULT_CAP}`);
     pushNotification("search/unfiltered-issues", `Monitored repo issue results capped at 1,000 — some items are hidden`, "warning");
-    issues.splice(ISSUE_CAP);
+    issues.splice(SEARCH_RESULT_CAP);
   }
 
-  if (prMap.size >= PR_CAP) {
-    console.warn(`[api] Unfiltered PR results capped at ${PR_CAP}`);
+  if (prMap.size >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] Unfiltered PR results capped at ${SEARCH_RESULT_CAP}`);
     pushNotification("search/unfiltered-prs", `Monitored repo PR results capped at 1,000 — some items are hidden`, "warning");
   }
 
   const pullRequests = [...prMap.values()];
-  if (pullRequests.length >= PR_CAP) pullRequests.splice(PR_CAP);
+  if (pullRequests.length >= SEARCH_RESULT_CAP) pullRequests.splice(SEARCH_RESULT_CAP);
   const prNodeIds = pullRequests.map((pr) => nodeIdMap.get(pr.id)).filter((id): id is string => id != null);
   return { issues, pullRequests, prNodeIds, errors };
 }
@@ -1482,11 +1467,11 @@ export async function fetchIssuesAndPullRequests(
     ? fetchPREnrichment(octokit, mainNodeIds)
     : Promise.resolve({ enrichments: new Map<number, PREnrichmentData>(), errors: [] as ApiError[] });
 
-  // Tracked user searches — scoped to normalRepos (monitored repos are already covered by
-  // graphqlUnfilteredSearch, so running involves: on them would only duplicate work)
-  const trackedSearchRepos = normalRepos.length > 0 ? normalRepos : repos;
-  const trackedSearchPromise = hasTrackedUsers && repos.length > 0
-    ? Promise.allSettled(trackedUsers!.map((u) => graphqlLightCombinedSearch(octokit, trackedSearchRepos, u.login)))
+  // Tracked user searches — scoped to normalRepos only. Monitored repos are already
+  // covered by graphqlUnfilteredSearch (all open items, no user qualifier), so running
+  // involves: on them would duplicate work and add spurious surfacedBy annotations.
+  const trackedSearchPromise = hasTrackedUsers && normalRepos.length > 0
+    ? Promise.allSettled(trackedUsers!.map((u) => graphqlLightCombinedSearch(octokit, normalRepos, u.login)))
     : Promise.resolve([] as PromiseSettledResult<LightSearchResult>[]);
 
   // Unfiltered search for monitored repos — runs in parallel with tracked searches
@@ -1590,7 +1575,6 @@ async function graphqlSearchIssues(
   const seen = new Set<number>();
   const issues: Issue[] = [];
   const errors: ApiError[] = [];
-  const CAP = 1000;
 
   const chunkResults = await Promise.allSettled(chunks.map(async (chunk, chunkIdx) => {
     const repoQualifiers = buildRepoQualifiers(chunk);
@@ -1622,7 +1606,7 @@ async function graphqlSearchIssues(
         return true;
       },
       () => issues.length,
-      CAP,
+      SEARCH_RESULT_CAP,
     );
   }));
 
@@ -1633,10 +1617,10 @@ async function graphqlSearchIssues(
     }
   }
 
-  if (issues.length >= CAP) {
-    console.warn(`[api] Issue search results capped at ${CAP}`);
+  if (issues.length >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] Issue search results capped at ${SEARCH_RESULT_CAP}`);
     pushNotification("search/issues", `Issue search results capped at 1,000 — some items are hidden`, "warning");
-    issues.splice(CAP);
+    issues.splice(SEARCH_RESULT_CAP);
   }
 
   return { issues, errors };
@@ -1684,7 +1668,6 @@ async function graphqlSearchPRs(
   const prMap = new Map<number, PullRequest>();
   const forkInfoMap = new Map<number, { owner: string; repoName: string }>();
   const errors: ApiError[] = [];
-  const CAP = 1000;
 
   function processPRNode(node: GraphQLPRNode): boolean {
     if (node.databaseId == null || !node.repository) return false;
@@ -1761,7 +1744,7 @@ async function graphqlSearchPRs(
       await paginateGraphQLSearch<GraphQLPRSearchResponse, GraphQLPRNode>(
         octokit, PR_SEARCH_QUERY, queryString,
         `pr-search-batch-${chunkIdx + 1}/${chunks.length}`,
-        errors, processPRNode, () => prMap.size, CAP,
+        errors, processPRNode, () => prMap.size, SEARCH_RESULT_CAP,
       );
     })
   );
@@ -1774,8 +1757,8 @@ async function graphqlSearchPRs(
     }
   }
 
-  if (prMap.size >= CAP) {
-    console.warn(`[api] PR search results capped at ${CAP}`);
+  if (prMap.size >= SEARCH_RESULT_CAP) {
+    console.warn(`[api] PR search results capped at ${SEARCH_RESULT_CAP}`);
     pushNotification("search/prs", `PR search results capped at 1,000 — some items are hidden`, "warning");
   }
 
@@ -1849,7 +1832,7 @@ async function graphqlSearchPRs(
   }
 
   const pullRequests = [...prMap.values()];
-  if (pullRequests.length >= CAP) pullRequests.splice(CAP);
+  if (pullRequests.length >= SEARCH_RESULT_CAP) pullRequests.splice(SEARCH_RESULT_CAP);
   return { pullRequests, errors };
 }
 

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -90,13 +90,17 @@ onAuthCleared(resetPollState);
 // When tracked users or monitored repos change, reset notification state so the
 // next poll cycle silently seeds items without flooding "new item" notifications.
 // Tracks a serialized key (sorted logins/fullNames) so swapping entries at the
-// same array length still triggers the reset.
+// same array length still triggers the reset. Boolean mount flags ensure the
+// initial effect run is always skipped (key="" is a valid state for empty arrays).
+let _trackedUsersMounted = false;
 let _trackedUsersKey = "";
+let _monitoredReposMounted = false;
 let _monitoredReposKey = "";
 createRoot(() => {
   createEffect(() => {
     const key = (config.trackedUsers ?? []).map((u) => u.login).sort().join(",");
-    if (_trackedUsersKey === "") {
+    if (!_trackedUsersMounted) {
+      _trackedUsersMounted = true;
       _trackedUsersKey = key;
       return;
     }
@@ -108,7 +112,8 @@ createRoot(() => {
 
   createEffect(() => {
     const key = (config.monitoredRepos ?? []).map((r) => r.fullName).sort().join(",");
-    if (_monitoredReposKey === "") {
+    if (!_monitoredReposMounted) {
+      _monitoredReposMounted = true;
       _monitoredReposKey = key;
       return;
     }

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -92,6 +92,9 @@ onAuthCleared(resetPollState);
 // Tracks a serialized key (sorted logins/fullNames) so swapping entries at the
 // same array length still triggers the reset. Boolean mount flags ensure the
 // initial effect run is always skipped (key="" is a valid state for empty arrays).
+// NOTE: Mount flags are intentionally permanent (module lifetime) and NOT cleared
+// by resetPollState(). The createRoot runs once at module load; the effects
+// continue tracking config changes across auth cycles without re-mounting.
 let _trackedUsersMounted = false;
 let _trackedUsersKey = "";
 let _monitoredReposMounted = false;

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -109,6 +109,7 @@ createRoot(() => {
     }
     if (key !== _trackedUsersKey) {
       _trackedUsersKey = key;
+      _lastSuccessfulFetch = null; // Force next poll to bypass notifications gate
       untrack(() => _resetNotificationState());
     }
   });
@@ -122,6 +123,7 @@ createRoot(() => {
     }
     if (key !== _monitoredReposKey) {
       _monitoredReposKey = key;
+      _lastSuccessfulFetch = null; // Force next poll to bypass notifications gate
       untrack(() => _resetNotificationState());
     }
   });
@@ -458,7 +460,7 @@ export function rebuildHotSets(data: DashboardData): void {
   _hotRuns.clear();
 
   for (const pr of data.pullRequests) {
-    if ((pr.checkStatus === "pending" || pr.checkStatus === null) && pr.nodeId) {
+    if (pr.enriched && pr.checkStatus === "pending" && pr.nodeId) {
       if (_hotPRs.size >= MAX_HOT_PRS) {
         console.warn(`[hot-poll] PR cap reached (${MAX_HOT_PRS}), skipping remaining`);
         break;

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -105,6 +105,20 @@ createRoot(() => {
   });
 });
 
+// When monitoredRepos changes, reset notification state so the next poll cycle
+// silently seeds the newly monitored repo's items without flooding with notifications.
+let _monitoredReposMounted = false;
+createRoot(() => {
+  createEffect(() => {
+    void (config.monitoredRepos?.length ?? 0);
+    if (!_monitoredReposMounted) {
+      _monitoredReposMounted = true;
+      return;
+    }
+    untrack(() => _resetNotificationState());
+  });
+});
+
 /**
  * Checks if anything changed since last poll using the Notifications API.
  * Returns true if there are new notifications (or first check), false if unchanged.
@@ -215,10 +229,13 @@ export async function fetchAllData(
   }
 
   const trackedUsers = config.trackedUsers ?? [];
+  const monitoredRepos = config.monitoredRepos ?? [];
 
   // Issues + PRs use a two-phase approach: light query first (phase 1),
   // then heavy backfill (phase 2). Workflow runs use REST core.
   // All streams run in parallel (GraphQL 5000 pts/hr + REST core 5000/hr).
+  // Note: monitoredRepos are NOT added to combinedRepos for workflow runs —
+  // Actions fetches are already per selectedRepo.
   const [issuesAndPrsResult, runResult] = await Promise.allSettled([
     fetchIssuesAndPullRequests(octokit, combinedRepos, userLogin, onLightData ? (lightData) => {
       // Phase 1: fire callback with light issues + PRs (no workflow runs yet)
@@ -228,7 +245,7 @@ export async function fetchAllData(
         workflowRuns: [],
         errors: lightData.errors,
       });
-    } : undefined, trackedUsers),
+    } : undefined, trackedUsers, monitoredRepos),
     fetchWorkflowRuns(octokit, selectedRepos, config.maxWorkflowsPerRepo, config.maxRunsPerWorkflow),
   ]);
 

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -87,35 +87,35 @@ export function resetPollState(): void {
 // Auto-reset poll state on logout (avoids circular dep with auth.ts)
 onAuthCleared(resetPollState);
 
-// When tracked users change, reset notification state so the next poll cycle
-// silently seeds all items (including the new tracked user's) without flooding
-// the user with "new item" notifications for pre-existing content.
-// Use a flag to skip the initial run (module-level mount).
-// Wrapped in createRoot to provide a reactive owner at module scope (per SolidJS gotcha).
-// Subscribes to array length only — fires on add/remove, not property mutations.
-let _trackedUsersMounted = false;
+// When tracked users or monitored repos change, reset notification state so the
+// next poll cycle silently seeds items without flooding "new item" notifications.
+// Tracks a serialized key (sorted logins/fullNames) so swapping entries at the
+// same array length still triggers the reset.
+let _trackedUsersKey = "";
+let _monitoredReposKey = "";
 createRoot(() => {
   createEffect(() => {
-    void (config.trackedUsers?.length ?? 0);
-    if (!_trackedUsersMounted) {
-      _trackedUsersMounted = true;
+    const key = (config.trackedUsers ?? []).map((u) => u.login).sort().join(",");
+    if (_trackedUsersKey === "") {
+      _trackedUsersKey = key;
       return;
     }
-    untrack(() => _resetNotificationState());
+    if (key !== _trackedUsersKey) {
+      _trackedUsersKey = key;
+      untrack(() => _resetNotificationState());
+    }
   });
-});
 
-// When monitoredRepos changes, reset notification state so the next poll cycle
-// silently seeds the newly monitored repo's items without flooding with notifications.
-let _monitoredReposMounted = false;
-createRoot(() => {
   createEffect(() => {
-    void (config.monitoredRepos?.length ?? 0);
-    if (!_monitoredReposMounted) {
-      _monitoredReposMounted = true;
+    const key = (config.monitoredRepos ?? []).map((r) => r.fullName).sort().join(",");
+    if (_monitoredReposKey === "") {
+      _monitoredReposKey = key;
       return;
     }
-    untrack(() => _resetNotificationState());
+    if (key !== _monitoredReposKey) {
+      _monitoredReposKey = key;
+      untrack(() => _resetNotificationState());
+    }
   });
 });
 

--- a/src/app/stores/auth.ts
+++ b/src/app/stores/auth.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { clearCache } from "./cache";
 import { CONFIG_STORAGE_KEY, resetConfig, updateConfig, config } from "./config";
 import { VIEW_STORAGE_KEY, resetViewState } from "./view";
+import { pushNotification } from "../lib/errors";
 
 export const AUTH_STORAGE_KEY = "github-tracker:auth-token";
 export const DASHBOARD_STORAGE_KEY = "github-tracker:dashboard";
@@ -40,9 +41,13 @@ export { user };
 // ── Actions ─────────────────────────────────────────────────────────────────
 
 export function setAuth(response: TokenExchangeResponse): void {
-  localStorage.setItem(AUTH_STORAGE_KEY, response.access_token);
+  try {
+    localStorage.setItem(AUTH_STORAGE_KEY, response.access_token);
+  } catch {
+    pushNotification("localStorage:auth", "Auth token write failed — storage may be full. Token exists in memory only this session.", "warning");
+  }
   _setToken(response.access_token);
-  console.info("[auth] access token set (localStorage)");
+  console.info("[auth] access token set");
 }
 
 export function setAuthFromPat(token: string, userData: GitHubUser): void {
@@ -89,37 +94,77 @@ export function clearAuth(): void {
   }
 }
 
+/** Clear only the auth token. Preserves all user data (config, view state, dashboard
+ *  cache) so the same user's preferences and cached data survive re-authentication.
+ *  Used when a token becomes invalid (expired PAT, revoked OAuth) — NOT for explicit
+ *  logout. Full data wipe (cross-user data isolation) is handled by clearAuth()
+ *  which is reserved for explicit user actions (Sign out, Reset all).
+ *
+ *  Callers MUST navigate away after calling this (e.g., window.location.replace or
+ *  router navigate to /login). The poll coordinator is not stopped here — page
+ *  navigation handles teardown. Use clearAuth() if not navigating. */
+export function expireToken(): void {
+  localStorage.removeItem(AUTH_STORAGE_KEY);
+  _setToken(null);
+  setUser(null);
+  console.info("[auth] token expired (user data preserved)");
+}
+
+const VALIDATE_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+} as const;
+
 export async function validateToken(): Promise<boolean> {
   const currentToken = _token();
   if (!currentToken) return false;
 
+  const headers = { ...VALIDATE_HEADERS, Authorization: `Bearer ${currentToken}` };
+
+  function handleSuccess(userData: GitHubUser): true {
+    setUser({ login: userData.login, avatar_url: userData.avatar_url, name: userData.name });
+    navigator.storage?.persist?.()?.catch(() => {});
+    return true;
+  }
+
   try {
-    const resp = await fetch("https://api.github.com/user", {
-      headers: {
-        Authorization: `Bearer ${currentToken}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    });
+    const resp = await fetch("https://api.github.com/user", { headers });
 
     if (resp.ok) {
-      const userData = (await resp.json()) as GitHubUser;
-      setUser({
-        login: userData.login,
-        avatar_url: userData.avatar_url,
-        name: userData.name,
-      });
-      return true;
+      return handleSuccess((await resp.json()) as GitHubUser);
     }
 
     if (resp.status === 401) {
-      const method = config.authMethod;
+      // GitHub API can return transient 401s due to database replication lag.
+      // Retry once after a delay before invalidating the token.
+      await new Promise((r) => setTimeout(r, 1000));
+      try {
+        const retry = await fetch("https://api.github.com/user", { headers });
+        if (retry.ok) {
+          return handleSuccess((await retry.json()) as GitHubUser);
+        }
+        if (retry.status !== 401) {
+          // Non-auth error on retry (e.g. 500) — preserve token, try next load
+          return false;
+        }
+      } catch {
+        // Network error on retry — preserve token, try next load
+        return false;
+      }
+
+      // Guard: if the token was replaced during the retry window (e.g., user
+      // re-authenticated via OAuth callback), don't invalidate the new token.
+      if (_token() !== currentToken) {
+        return false;
+      }
+
+      // Both attempts returned 401 — token is genuinely invalid
       console.info(
-        method === "pat"
-          ? "[auth] PAT invalid or expired — clearing auth"
-          : "[auth] access token invalid — clearing auth"
+        config.authMethod === "pat"
+          ? "[auth] PAT invalid or expired — clearing token"
+          : "[auth] access token invalid — clearing token"
       );
-      clearAuth();
+      expireToken();
       return false;
     }
 

--- a/src/app/stores/config.ts
+++ b/src/app/stores/config.ts
@@ -30,6 +30,7 @@ export const TrackedUserSchema = z.object({
     "Avatar URL must be from GitHub CDN"
   ),
   name: z.string().nullable(),
+  type: z.enum(["user", "bot"]).default("user"),
 });
 
 export type TrackedUser = z.infer<typeof TrackedUserSchema>;
@@ -38,6 +39,7 @@ export const ConfigSchema = z.object({
   selectedOrgs: z.array(z.string()).default([]),
   selectedRepos: z.array(RepoRefSchema).default([]),
   upstreamRepos: z.array(RepoRefSchema).default([]),
+  monitoredRepos: z.array(RepoRefSchema).default([]),
   trackedUsers: z.array(TrackedUserSchema).max(10).default([]),
   refreshInterval: z.number().min(0).max(3600).default(300),
   hotPollInterval: z.number().min(10).max(120).default(30),
@@ -94,6 +96,27 @@ export function updateConfig(partial: Partial<Config>): void {
   setConfig(
     produce((draft) => {
       Object.assign(draft, filtered);
+      if ("selectedRepos" in partial) {
+        const selectedSet = new Set(draft.selectedRepos.map((r) => r.fullName));
+        draft.monitoredRepos = draft.monitoredRepos.filter((r) => selectedSet.has(r.fullName));
+      }
+    })
+  );
+}
+
+export function setMonitoredRepo(repo: z.infer<typeof RepoRefSchema>, monitored: boolean): void {
+  setConfig(
+    produce((draft) => {
+      if (monitored) {
+        const inSelected = draft.selectedRepos.some((r) => r.fullName === repo.fullName);
+        if (!inSelected) return;
+        const alreadyMonitored = draft.monitoredRepos.some((r) => r.fullName === repo.fullName);
+        if (!alreadyMonitored) {
+          draft.monitoredRepos.push(repo);
+        }
+      } else {
+        draft.monitoredRepos = draft.monitoredRepos.filter((r) => r.fullName !== repo.fullName);
+      }
     })
   );
 }

--- a/src/app/stores/config.ts
+++ b/src/app/stores/config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { createStore, produce } from "solid-js/store";
 import { createEffect } from "solid-js";
+import { pushNotification } from "../lib/errors";
 
 export const CONFIG_STORAGE_KEY = "github-tracker:config";
 
@@ -39,7 +40,7 @@ export const ConfigSchema = z.object({
   selectedOrgs: z.array(z.string()).default([]),
   selectedRepos: z.array(RepoRefSchema).default([]),
   upstreamRepos: z.array(RepoRefSchema).default([]),
-  monitoredRepos: z.array(RepoRefSchema).default([]),
+  monitoredRepos: z.array(RepoRefSchema).max(10).default([]),
   trackedUsers: z.array(TrackedUserSchema).max(10).default([]),
   refreshInterval: z.number().min(0).max(3600).default(300),
   hotPollInterval: z.number().min(10).max(120).default(30),
@@ -110,6 +111,7 @@ export function setMonitoredRepo(repo: z.infer<typeof RepoRefSchema>, monitored:
       if (monitored) {
         const inSelected = draft.selectedRepos.some((r) => r.fullName === repo.fullName);
         if (!inSelected) return;
+        if (draft.monitoredRepos.length >= 10) return;
         const alreadyMonitored = draft.monitoredRepos.some((r) => r.fullName === repo.fullName);
         if (!alreadyMonitored) {
           draft.monitoredRepos.push(repo);
@@ -132,7 +134,11 @@ export function initConfigPersistence(): void {
     const snapshot = JSON.parse(JSON.stringify(config)) as Config;
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
-      localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(snapshot));
+      try {
+        localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(snapshot));
+      } catch {
+        pushNotification("localStorage:config", "Config write failed — storage may be full", "warning");
+      }
     }, 200);
   });
 }

--- a/src/app/stores/config.ts
+++ b/src/app/stores/config.ts
@@ -18,10 +18,12 @@ export function resolveTheme(theme: ThemeId): string {
   return prefersDark ? AUTO_DARK_THEME : AUTO_LIGHT_THEME;
 }
 
+const REPO_SEGMENT = /^[A-Za-z0-9._-]{1,100}$/;
+
 export const RepoRefSchema = z.object({
-  owner: z.string(),
-  name: z.string(),
-  fullName: z.string(),
+  owner: z.string().regex(REPO_SEGMENT),
+  name: z.string().regex(REPO_SEGMENT),
+  fullName: z.string().regex(/^[A-Za-z0-9._-]{1,100}\/[A-Za-z0-9._-]{1,100}$/),
 });
 
 export const TrackedUserSchema = z.object({

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { createStore, produce } from "solid-js/store";
 import { createEffect, onCleanup, untrack } from "solid-js";
+import { pushNotification } from "../lib/errors";
 
 export const VIEW_STORAGE_KEY = "github-tracker:view";
 
@@ -332,7 +333,7 @@ export function initViewPersistence(): void {
       try {
         localStorage.setItem(VIEW_STORAGE_KEY, json);
       } catch {
-        // QuotaExceededError — silently fail rather than kill the reactive graph
+        pushNotification("localStorage:view", "View state write failed — storage may be full", "warning");
       }
     }, 200);
     onCleanup(() => {

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@solidjs/router", () => ({
 const authClearCallbacks: (() => void)[] = [];
 vi.mock("../../src/app/stores/auth", () => ({
   clearAuth: vi.fn(),
+  expireToken: vi.fn(),
   token: () => "fake-token",
   user: () => ({ login: "testuser", avatar_url: "", name: "Test User" }),
   isAuthenticated: () => true,
@@ -127,6 +128,7 @@ beforeEach(async () => {
   capturedFetchAll = null;
   capturedOnHotData = null;
   vi.mocked(authStore.clearAuth).mockClear();
+  vi.mocked(authStore.expireToken).mockClear();
   vi.mocked(pollService.fetchAllData).mockResolvedValue({
     issues: [],
     pullRequests: [],
@@ -296,18 +298,20 @@ describe("DashboardPage — auth error handling", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("calls clearAuth and redirects to /login on 401 error (permanent token revoked)", async () => {
+  it("calls expireToken (not clearAuth) and redirects to /login on 401 error", async () => {
     const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
     vi.mocked(pollService.fetchAllData).mockRejectedValue(err401);
 
     render(() => <DashboardPage />);
     await waitFor(() => {
-      expect(authStore.clearAuth).toHaveBeenCalledOnce();
+      expect(authStore.expireToken).toHaveBeenCalledOnce();
       expect(mockLocationReplace).toHaveBeenCalledWith("/login");
     });
+    // clearAuth should NOT be called — user config/view preserved on token failure
+    expect(authStore.clearAuth).not.toHaveBeenCalled();
   });
 
-  it("does not call clearAuth for non-401 errors", async () => {
+  it("does not call expireToken or clearAuth for non-401 errors", async () => {
     const err500 = Object.assign(new Error("Server Error"), { status: 500 });
     vi.mocked(pollService.fetchAllData).mockRejectedValue(err500);
 
@@ -315,6 +319,7 @@ describe("DashboardPage — auth error handling", () => {
     // Flush all pending microtasks so the rejected promise settles
     await Promise.resolve();
     await Promise.resolve();
+    expect(authStore.expireToken).not.toHaveBeenCalled();
     expect(authStore.clearAuth).not.toHaveBeenCalled();
     expect(mockLocationReplace).not.toHaveBeenCalledWith("/login");
   });

--- a/tests/components/dashboard/IssuesTab.test.tsx
+++ b/tests/components/dashboard/IssuesTab.test.tsx
@@ -195,7 +195,7 @@ describe("IssuesTab — user filter logic", () => {
 describe("IssuesTab — avatar badge", () => {
   it("renders avatar img for items surfaced by tracked users", () => {
     const trackedUsers: TrackedUser[] = [
-      { login: "tracked1", avatarUrl: "https://avatars.githubusercontent.com/u/1", name: "Tracked One" },
+      { login: "tracked1", avatarUrl: "https://avatars.githubusercontent.com/u/1", name: "Tracked One", type: "user" as const },
     ];
     const issues = [
       makeIssue({ id: 1, title: "Tracked issue", repoFullName: "owner/repo", surfacedBy: ["tracked1"] }),
@@ -236,5 +236,78 @@ describe("IssuesTab — avatar badge", () => {
     ));
 
     expect(container.querySelector(".avatar")).toBeNull();
+  });
+});
+
+// ── IssuesTab — monitored repos bypass (C6) ───────────────────────────────────
+
+describe("IssuesTab — monitored repos filter bypass", () => {
+  it("shows issue from monitored repo even when user filter excludes it", () => {
+    const issues = [
+      makeIssue({ id: 1, title: "Monitored issue", repoFullName: "org/monitored", surfacedBy: ["other-user"] }),
+    ];
+    setTabFilter("issues", "user", "me");
+    setAllExpanded("issues", ["org/monitored"], true);
+
+    render(() => (
+      <IssuesTab
+        issues={issues}
+        userLogin="me"
+        allUsers={[{ login: "me", label: "Me" }, { login: "other-user", label: "other-user" }]}
+        monitoredRepos={[{ fullName: "org/monitored" }]}
+      />
+    ));
+
+    screen.getByText("Monitored issue");
+  });
+
+  it("hides issue from non-monitored repo when user filter excludes it", () => {
+    const issues = [
+      makeIssue({ id: 100, title: "Non-monitored issue", repoFullName: "org/regular", surfacedBy: ["other-user"] }),
+    ];
+    setTabFilter("issues", "user", "me");
+
+    render(() => (
+      <IssuesTab
+        issues={issues}
+        userLogin="me"
+        allUsers={[{ login: "me", label: "Me" }, { login: "other-user", label: "other-user" }]}
+        monitoredRepos={[]}
+      />
+    ));
+
+    expect(screen.queryByText("Non-monitored issue")).toBeNull();
+  });
+
+  it("renders 'Monitoring all' badge on monitored repo group header", () => {
+    const issues = [
+      makeIssue({ id: 200, title: "Issue in monitored repo", repoFullName: "org/monitored", surfacedBy: ["me"] }),
+    ];
+
+    render(() => (
+      <IssuesTab
+        issues={issues}
+        userLogin="me"
+        monitoredRepos={[{ fullName: "org/monitored" }]}
+      />
+    ));
+
+    screen.getByText("Monitoring all");
+  });
+
+  it("does not render 'Monitoring all' badge on non-monitored repo group header", () => {
+    const issues = [
+      makeIssue({ id: 300, title: "Issue in regular repo", repoFullName: "org/regular", surfacedBy: ["me"] }),
+    ];
+
+    render(() => (
+      <IssuesTab
+        issues={issues}
+        userLogin="me"
+        monitoredRepos={[]}
+      />
+    ));
+
+    expect(screen.queryByText("Monitoring all")).toBeNull();
   });
 });

--- a/tests/components/dashboard/IssuesTab.test.tsx
+++ b/tests/components/dashboard/IssuesTab.test.tsx
@@ -254,7 +254,7 @@ describe("IssuesTab — monitored repos filter bypass", () => {
         issues={issues}
         userLogin="me"
         allUsers={[{ login: "me", label: "Me" }, { login: "other-user", label: "other-user" }]}
-        monitoredRepos={[{ fullName: "org/monitored" }]}
+        monitoredRepos={[{ owner: "org", name: "monitored", fullName: "org/monitored" }]}
       />
     ));
 
@@ -288,7 +288,7 @@ describe("IssuesTab — monitored repos filter bypass", () => {
       <IssuesTab
         issues={issues}
         userLogin="me"
-        monitoredRepos={[{ fullName: "org/monitored" }]}
+        monitoredRepos={[{ owner: "org", name: "monitored", fullName: "org/monitored" }]}
       />
     ));
 

--- a/tests/components/dashboard/PullRequestsTab.test.tsx
+++ b/tests/components/dashboard/PullRequestsTab.test.tsx
@@ -204,7 +204,7 @@ describe("PullRequestsTab — monitored repos filter bypass", () => {
         pullRequests={prs}
         userLogin="me"
         allUsers={[{ login: "me", label: "Me" }, { login: "other-user", label: "other-user" }]}
-        monitoredRepos={[{ fullName: "org/monitored" }]}
+        monitoredRepos={[{ owner: "org", name: "monitored", fullName: "org/monitored" }]}
       />
     ));
 
@@ -238,7 +238,7 @@ describe("PullRequestsTab — monitored repos filter bypass", () => {
       <PullRequestsTab
         pullRequests={prs}
         userLogin="me"
-        monitoredRepos={[{ fullName: "org/monitored" }]}
+        monitoredRepos={[{ owner: "org", name: "monitored", fullName: "org/monitored" }]}
       />
     ));
 

--- a/tests/components/dashboard/PullRequestsTab.test.tsx
+++ b/tests/components/dashboard/PullRequestsTab.test.tsx
@@ -164,7 +164,7 @@ describe("PullRequestsTab — user filter logic", () => {
 describe("PullRequestsTab — avatar badge", () => {
   it("renders avatar img for PRs surfaced by tracked users", () => {
     const trackedUsers: TrackedUser[] = [
-      { login: "tracked1", avatarUrl: "https://avatars.githubusercontent.com/u/1", name: "Tracked One" },
+      { login: "tracked1", avatarUrl: "https://avatars.githubusercontent.com/u/1", name: "Tracked One", type: "user" as const },
     ];
     const prs = [
       makePullRequest({ id: 1, title: "Tracked PR", repoFullName: "owner/repo", surfacedBy: ["tracked1"] }),
@@ -186,5 +186,78 @@ describe("PullRequestsTab — avatar badge", () => {
 
     const img = screen.getByAltText("tracked1");
     expect(img.getAttribute("src")).toBe("https://avatars.githubusercontent.com/u/1");
+  });
+});
+
+// ── PullRequestsTab — monitored repos bypass (C6) ─────────────────────────────
+
+describe("PullRequestsTab — monitored repos filter bypass", () => {
+  it("shows PR from monitored repo even when user filter excludes it", () => {
+    const prs = [
+      makePullRequest({ id: 1, title: "Monitored PR", repoFullName: "org/monitored", surfacedBy: ["other-user"] }),
+    ];
+    setTabFilter("pullRequests", "user", "me");
+    setAllExpanded("pullRequests", ["org/monitored"], true);
+
+    render(() => (
+      <PullRequestsTab
+        pullRequests={prs}
+        userLogin="me"
+        allUsers={[{ login: "me", label: "Me" }, { login: "other-user", label: "other-user" }]}
+        monitoredRepos={[{ fullName: "org/monitored" }]}
+      />
+    ));
+
+    screen.getByText("Monitored PR");
+  });
+
+  it("hides PR from non-monitored repo when user filter excludes it", () => {
+    const prs = [
+      makePullRequest({ id: 100, title: "Non-monitored PR", repoFullName: "org/regular", surfacedBy: ["other-user"] }),
+    ];
+    setTabFilter("pullRequests", "user", "me");
+
+    render(() => (
+      <PullRequestsTab
+        pullRequests={prs}
+        userLogin="me"
+        allUsers={[{ login: "me", label: "Me" }, { login: "other-user", label: "other-user" }]}
+        monitoredRepos={[]}
+      />
+    ));
+
+    expect(screen.queryByText("Non-monitored PR")).toBeNull();
+  });
+
+  it("renders 'Monitoring all' badge on monitored PR repo group header", () => {
+    const prs = [
+      makePullRequest({ id: 200, title: "PR in monitored repo", repoFullName: "org/monitored", surfacedBy: ["me"] }),
+    ];
+
+    render(() => (
+      <PullRequestsTab
+        pullRequests={prs}
+        userLogin="me"
+        monitoredRepos={[{ fullName: "org/monitored" }]}
+      />
+    ));
+
+    screen.getByText("Monitoring all");
+  });
+
+  it("does not render 'Monitoring all' badge on non-monitored PR repo group header", () => {
+    const prs = [
+      makePullRequest({ id: 300, title: "PR in regular repo", repoFullName: "org/regular", surfacedBy: ["me"] }),
+    ];
+
+    render(() => (
+      <PullRequestsTab
+        pullRequests={prs}
+        userLogin="me"
+        monitoredRepos={[]}
+      />
+    ));
+
+    expect(screen.queryByText("Monitoring all")).toBeNull();
   });
 });

--- a/tests/components/onboarding/OnboardingWizard.test.tsx
+++ b/tests/components/onboarding/OnboardingWizard.test.tsx
@@ -18,6 +18,8 @@ vi.mock("../../../src/app/components/onboarding/RepoSelector", () => ({
     orgEntries?: OrgEntry[];
     selected: RepoRef[];
     onChange: (s: RepoRef[]) => void;
+    monitoredRepos?: RepoRef[];
+    onMonitorToggle?: (repo: RepoRef, monitored: boolean) => void;
   }) => (
     <div data-testid="repo-selector">
       <span data-testid="repo-selector-orgs">
@@ -32,7 +34,18 @@ vi.mock("../../../src/app/components/onboarding/RepoSelector", () => ({
       >
         Select Repo
       </button>
+      <button
+        onClick={() =>
+          props.onMonitorToggle?.(
+            { owner: "myorg", name: "myrepo", fullName: "myorg/myrepo" },
+            true
+          )
+        }
+      >
+        Toggle Monitor
+      </button>
       <span>Repos: {props.selected.length}</span>
+      <span data-testid="monitored-count">Monitored: {(props.monitoredRepos ?? []).length}</span>
     </div>
   ),
 }));
@@ -47,7 +60,7 @@ vi.mock("../../../src/app/components/shared/LoadingSpinner", () => ({
 // Mock config store
 vi.mock("../../../src/app/stores/config", () => ({
   CONFIG_STORAGE_KEY: "github-tracker:config",
-  config: { selectedOrgs: [], selectedRepos: [], upstreamRepos: [] },
+  config: { selectedOrgs: [], selectedRepos: [], upstreamRepos: [], monitoredRepos: [], trackedUsers: [] },
   updateConfig: vi.fn(),
 }));
 
@@ -257,5 +270,28 @@ describe("OnboardingWizard", () => {
     });
     await user.click(screen.getByText(/Finish Setup \(1 repo\)/));
     expect(window.location.replace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("passes monitoredRepos to updateConfig on finish (C4)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiModule.fetchOrgs).mockResolvedValue(mockOrgs);
+    render(() => <OnboardingWizard />);
+
+    await waitFor(() => screen.getByTestId("repo-selector"));
+
+    // Select a repo first
+    await user.click(screen.getByText("Select Repo"));
+    // Toggle monitor for that repo
+    await user.click(screen.getByText("Toggle Monitor"));
+
+    await waitFor(() => screen.getByText(/Finish Setup \(1 repo\)/));
+    await user.click(screen.getByText(/Finish Setup \(1 repo\)/));
+
+    expect(configStore.updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        monitoredRepos: [{ owner: "myorg", name: "myrepo", fullName: "myorg/myrepo" }],
+        selectedRepos: [{ owner: "myorg", name: "myrepo", fullName: "myorg/myrepo" }],
+      })
+    );
   });
 });

--- a/tests/components/onboarding/RepoSelector.test.tsx
+++ b/tests/components/onboarding/RepoSelector.test.tsx
@@ -691,3 +691,93 @@ describe("RepoSelector — upstream discovery", () => {
     });
   });
 });
+
+// ── Monitor toggle (C4) ────────────────────────────────────────────────────────
+
+describe("RepoSelector — monitor toggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.fetchRepos).mockImplementation((_client, org) => {
+      if (org === "myorg") return Promise.resolve(myorgRepos);
+      return Promise.resolve([]);
+    });
+  });
+
+  it("does not render monitor toggle when onMonitorToggle prop is absent", async () => {
+    const selected: RepoRef[] = [{ owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" }];
+    render(() => (
+      <RepoSelector
+        selectedOrgs={["myorg"]}
+        selected={selected}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => screen.getByText("repo-a"));
+    expect(screen.queryByLabelText(/monitor all activity/i)).toBeNull();
+  });
+
+  it("renders monitor toggle only for selected repos", async () => {
+    const selected: RepoRef[] = [{ owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" }];
+    // repo-b is not selected
+    render(() => (
+      <RepoSelector
+        selectedOrgs={["myorg"]}
+        selected={selected}
+        onChange={vi.fn()}
+        onMonitorToggle={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => screen.getByText("repo-a"));
+    // Toggle for selected repo-a should be present
+    screen.getByLabelText("Monitor all activity");
+    // Toggle for unselected repo-b should not be present
+    expect(screen.queryAllByLabelText(/monitor all activity/i)).toHaveLength(1);
+  });
+
+  it("calls onMonitorToggle with repo and monitored=true when repo is not monitored", async () => {
+    const onMonitorToggle = vi.fn();
+    const selected: RepoRef[] = [{ owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" }];
+    render(() => (
+      <RepoSelector
+        selectedOrgs={["myorg"]}
+        selected={selected}
+        onChange={vi.fn()}
+        onMonitorToggle={onMonitorToggle}
+        monitoredRepos={[]}
+      />
+    ));
+
+    await waitFor(() => screen.getByText("repo-a"));
+    const btn = screen.getByLabelText("Monitor all activity");
+    btn.click();
+    expect(onMonitorToggle).toHaveBeenCalledWith(
+      { owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" },
+      true
+    );
+  });
+
+  it("calls onMonitorToggle with monitored=false when repo is already monitored", async () => {
+    const onMonitorToggle = vi.fn();
+    const selected: RepoRef[] = [{ owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" }];
+    const monitoredRepos: RepoRef[] = [{ owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" }];
+    render(() => (
+      <RepoSelector
+        selectedOrgs={["myorg"]}
+        selected={selected}
+        onChange={vi.fn()}
+        onMonitorToggle={onMonitorToggle}
+        monitoredRepos={monitoredRepos}
+      />
+    ));
+
+    await waitFor(() => screen.getByText("repo-a"));
+    const btn = screen.getByLabelText("Stop monitoring all activity");
+    btn.click();
+    expect(onMonitorToggle).toHaveBeenCalledWith(
+      { owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" },
+      false
+    );
+  });
+});

--- a/tests/components/onboarding/RepoSelector.test.tsx
+++ b/tests/components/onboarding/RepoSelector.test.tsx
@@ -780,4 +780,22 @@ describe("RepoSelector — monitor toggle", () => {
       false
     );
   });
+
+  it("hides monitor toggle for upstream repos even when selected", async () => {
+    const selected: RepoRef[] = [{ owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" }];
+    const upstreamRepos: RepoRef[] = [{ owner: "myorg", name: "repo-a", fullName: "myorg/repo-a" }];
+    render(() => (
+      <RepoSelector
+        selectedOrgs={["myorg"]}
+        selected={selected}
+        onChange={vi.fn()}
+        onMonitorToggle={vi.fn()}
+        upstreamRepos={upstreamRepos}
+      />
+    ));
+
+    await waitFor(() => screen.getByText("repo-a"));
+    // Monitor toggle should not appear for upstream repos
+    expect(screen.queryByLabelText(/monitor all activity/i)).toBeNull();
+  });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -684,6 +684,31 @@ describe("SettingsPage — Manage org access button", () => {
 });
 
 describe("SettingsPage — monitor toggle wiring", () => {
+  it("shows monitored repos indicator when repos are monitored", () => {
+    updateConfig({
+      selectedRepos: [
+        { owner: "org", name: "repo1", fullName: "org/repo1" },
+        { owner: "org", name: "repo2", fullName: "org/repo2" },
+      ],
+      monitoredRepos: [
+        { owner: "org", name: "repo1", fullName: "org/repo1" },
+        { owner: "org", name: "repo2", fullName: "org/repo2" },
+      ],
+    });
+    renderSettings();
+
+    const indicator = screen.getByText(/Monitoring all:/);
+    expect(indicator.textContent).toContain("org/repo1");
+    expect(indicator.textContent).toContain("org/repo2");
+  });
+
+  it("hides monitored repos indicator when no repos are monitored", () => {
+    updateConfig({ monitoredRepos: [] });
+    renderSettings();
+
+    expect(screen.queryByText(/Monitoring all:/)).toBeNull();
+  });
+
   it("includes monitoredRepos in exported settings JSON", async () => {
     updateConfig({
       selectedRepos: [{ owner: "org", name: "repo1", fullName: "org/repo1" }],

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -682,3 +682,31 @@ describe("SettingsPage — Manage org access button", () => {
     expect(apiModule.fetchOrgs).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("SettingsPage — monitor toggle wiring", () => {
+  it("includes monitoredRepos in exported settings JSON", async () => {
+    updateConfig({
+      selectedRepos: [{ owner: "org", name: "repo1", fullName: "org/repo1" }],
+      monitoredRepos: [{ owner: "org", name: "repo1", fullName: "org/repo1" }],
+    });
+    renderSettings();
+
+    // Trigger export
+    const exportBtn = screen.getByRole("button", { name: /export/i });
+    const user = userEvent.setup();
+    const blobParts: BlobPart[] = [];
+    const originalBlob = globalThis.Blob;
+    globalThis.Blob = class MockBlob extends originalBlob {
+      constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+        super(parts, options);
+        if (parts) blobParts.push(...parts);
+      }
+    } as typeof Blob;
+
+    await user.click(exportBtn);
+
+    globalThis.Blob = originalBlob;
+    const json = JSON.parse(blobParts[0] as string);
+    expect(json.monitoredRepos).toEqual([{ owner: "org", name: "repo1", fullName: "org/repo1" }]);
+  });
+});

--- a/tests/components/settings/TrackedUsersSection.test.tsx
+++ b/tests/components/settings/TrackedUsersSection.test.tsx
@@ -50,6 +50,7 @@ function makeUser(overrides: Partial<TrackedUser> = {}): TrackedUser {
     login: "octocat",
     avatarUrl: "https://avatars.githubusercontent.com/u/583231",
     name: "The Octocat",
+    type: "user",
     ...overrides,
   };
 }
@@ -304,5 +305,61 @@ describe("TrackedUsersSection — removing a user", () => {
     screen.getByRole("button", { name: /remove user1/i });
     screen.getByRole("button", { name: /remove user2/i });
     screen.getByRole("button", { name: /remove user3/i });
+  });
+});
+
+// ── Bot badge UI (C2) ─────────────────────────────────────────────────────────
+
+describe("TrackedUsersSection — bot badge", () => {
+  it("renders bot badge for type:bot user", () => {
+    const users = [
+      makeUser({ login: "dependabot[bot]", name: null, type: "bot" }),
+    ];
+    render(() => <TrackedUsersSection users={users} onSave={vi.fn()} />);
+    screen.getByLabelText("dependabot[bot] is a bot account");
+  });
+
+  it("does not render bot badge for type:user", () => {
+    const users = [makeUser({ login: "octocat", type: "user" })];
+    render(() => <TrackedUsersSection users={users} onSave={vi.fn()} />);
+    expect(screen.queryByText("bot")).toBeNull();
+  });
+
+  it("renders bot badge only for bot users in mixed list", () => {
+    const users = [
+      makeUser({ login: "octocat", type: "user" }),
+      makeUser({ login: "dependabot[bot]", name: null, type: "bot", avatarUrl: "https://avatars.githubusercontent.com/u/27347476" }),
+    ];
+    render(() => <TrackedUsersSection users={users} onSave={vi.fn()} />);
+    const badges = screen.getAllByLabelText("dependabot[bot] is a bot account");
+    expect(badges).toHaveLength(1);
+  });
+
+  it("renders bot badge text 'bot'", () => {
+    const users = [
+      makeUser({ login: "khepri-bot[bot]", name: null, type: "bot" }),
+    ];
+    render(() => <TrackedUsersSection users={users} onSave={vi.fn()} />);
+    const badge = screen.getByLabelText("khepri-bot[bot] is a bot account");
+    expect(badge.textContent).toBe("bot");
+  });
+});
+
+describe("TrackedUsersSection — bot input handling", () => {
+  it("lowercases bot login with [bot] suffix before calling validateGitHubUser", async () => {
+    const botUser = makeUser({ login: "khepri-bot[bot]", name: null, type: "bot" });
+    vi.mocked(apiModule.validateGitHubUser).mockResolvedValue(botUser);
+
+    const onSave = vi.fn();
+    render(() => <TrackedUsersSection users={[]} onSave={onSave} />);
+
+    const input = screen.getByRole("textbox", { name: /github username/i }) as HTMLInputElement;
+    // Use fireEvent.input instead of userEvent.type — userEvent interprets [bot] as a special key sequence
+    fireEvent.input(input, { target: { value: "Khepri-Bot[bot]" } });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => {
+      expect(apiModule.validateGitHubUser).toHaveBeenCalledWith(expect.anything(), "khepri-bot[bot]");
+    });
   });
 });

--- a/tests/helpers/index.tsx
+++ b/tests/helpers/index.tsx
@@ -53,6 +53,7 @@ export function makePullRequest(overrides: Partial<PullRequest> = {}): PullReque
     labels: [],
     reviewDecision: null,
     totalReviewCount: 0,
+    enriched: true,
     surfacedBy: ["testuser"],
     ...overrides,
   };

--- a/tests/services/api-users.test.ts
+++ b/tests/services/api-users.test.ts
@@ -38,12 +38,14 @@ function makeUserResponse(overrides: {
   login?: string;
   avatar_url?: string;
   name?: string | null;
+  type?: string;
 } = {}) {
   return {
     data: {
       login: overrides.login ?? "octocat",
       avatar_url: overrides.avatar_url ?? "https://avatars.githubusercontent.com/u/583231?v=4",
       name: overrides.name !== undefined ? overrides.name : "The Octocat",
+      type: overrides.type ?? "User",
     },
   };
 }
@@ -105,6 +107,7 @@ describe("validateGitHubUser", () => {
       login: "octocat",
       avatarUrl: "https://avatars.githubusercontent.com/u/583231?v=4",
       name: "The Octocat",
+      type: "user",
     });
     expect(octokit.request).toHaveBeenCalledWith("GET /users/{username}", { username: "octocat" });
   });
@@ -489,6 +492,7 @@ function makeTrackedUser(login: string): TrackedUser {
     login,
     avatarUrl: `https://avatars.githubusercontent.com/u/99999`,
     name: login,
+    type: "user",
   };
 }
 

--- a/tests/services/api.test.ts
+++ b/tests/services/api.test.ts
@@ -1570,7 +1570,7 @@ describe("fetchIssuesAndPullRequests — monitoredRepos", () => {
       "octocat",
       undefined,
       undefined,
-      [{ fullName: "org/monitored" }]
+      [{ owner: "org", name: "monitored", fullName: "org/monitored" }]
     );
     expect(result.issues).toEqual([]);
     expect(result.pullRequests).toEqual([]);
@@ -1603,7 +1603,7 @@ describe("fetchIssuesAndPullRequests — monitoredRepos", () => {
       "octocat",
       undefined,
       undefined,
-      [{ fullName: "org/monitored" }]
+      [{ owner: "org", name: "monitored", fullName: "org/monitored" }]
     );
 
     // Unfiltered queries should not contain 'involves:'
@@ -1657,7 +1657,7 @@ describe("fetchIssuesAndPullRequests — all repos monitored (edge case)", () =>
       "octocat",
       undefined,
       undefined,
-      [{ fullName: "org/repo1" }]  // all repos monitored
+      [{ owner: "org", name: "repo1", fullName: "org/repo1" }]  // all repos monitored
     );
 
     // Items returned from unfiltered search
@@ -1754,7 +1754,7 @@ describe("fetchIssuesAndPullRequests — cross-feature: monitored repo + bot tra
       "octocat",
       undefined,
       [botUser],
-      [{ fullName: "org/monitored" }]
+      [{ owner: "org", name: "monitored", fullName: "org/monitored" }]
     );
 
     // Both issues are present (no dedup since different IDs)
@@ -1856,7 +1856,7 @@ describe("fetchIssuesAndPullRequests — unfiltered search error handling", () =
       "octocat",
       undefined,
       undefined,
-      [{ fullName: "org/monitored" }]
+      [{ owner: "org", name: "monitored", fullName: "org/monitored" }]
     );
 
     // Partial issue data recovered
@@ -1894,14 +1894,15 @@ describe("fetchIssuesAndPullRequests — unfiltered search error handling", () =
       "octocat",
       undefined,
       undefined,
-      [{ fullName: "org/monitored" }]
+      [{ owner: "org", name: "monitored", fullName: "org/monitored" }]
     );
 
     // No results recovered
     expect(result.issues).toHaveLength(0);
     expect(result.pullRequests).toHaveLength(0);
-    // Error recorded
+    // Error recorded with retryable flag (network error → statusCode null → retryable)
     expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toMatchObject({ retryable: true });
   });
 });
 
@@ -1934,7 +1935,7 @@ describe("fetchIssuesAndPullRequests — all monitored + tracked users skips inv
       "octocat",
       undefined,
       [botUser],
-      [{ fullName: "org/repo1" }]  // all repos monitored
+      [{ owner: "org", name: "repo1", fullName: "org/repo1" }]  // all repos monitored
     );
 
     // No involves: queries for tracked user (since normalRepos is empty, tracked search is skipped)
@@ -1980,7 +1981,7 @@ describe("fetchIssuesAndPullRequests — onLightData suppression when all monito
       "octocat",
       onLightData,
       undefined,
-      [{ fullName: "org/repo1" }]  // all repos monitored
+      [{ owner: "org", name: "repo1", fullName: "org/repo1" }]  // all repos monitored
     );
 
     // onLightData NOT called (main user search skipped, unfiltered results come after)

--- a/tests/services/api.test.ts
+++ b/tests/services/api.test.ts
@@ -6,6 +6,7 @@ import {
   fetchIssues,
   fetchPullRequests,
   fetchWorkflowRuns,
+  validateGitHubUser,
   type RepoRef,
 } from "../../src/app/services/api";
 import { clearCache } from "../../src/app/stores/cache";
@@ -112,7 +113,7 @@ describe("fetchRepos", () => {
   it("returns repos for an org via paginate.iterator", async () => {
     const octokit = makeBasicOctokit();
     const result = await fetchRepos(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       "acme-corp",
       "org"
     );
@@ -129,7 +130,7 @@ describe("fetchRepos", () => {
   it("passes sort=pushed and direction=desc to paginate.iterator", async () => {
     const octokit = makeBasicOctokit();
     await fetchRepos(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       "acme-corp",
       "org"
     );
@@ -142,7 +143,7 @@ describe("fetchRepos", () => {
   it("passes sort=pushed and direction=desc for user repos", async () => {
     const octokit = makeBasicOctokit();
     await fetchRepos(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       "octocat",
       "user"
     );
@@ -155,7 +156,7 @@ describe("fetchRepos", () => {
   it("returns repos for a user account via paginate.iterator", async () => {
     const octokit = makeBasicOctokit();
     const result = await fetchRepos(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       "octocat",
       "user"
     );
@@ -205,7 +206,7 @@ describe("fetchIssues", () => {
   it("returns issues from GraphQL search results", async () => {
     const octokit = makeIssueOctokit();
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -218,7 +219,7 @@ describe("fetchIssues", () => {
   it("uses GraphQL search with involves qualifier", async () => {
     const octokit = makeIssueOctokit();
     await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -236,7 +237,7 @@ describe("fetchIssues", () => {
   it("includes repo qualifiers in GraphQL search query", async () => {
     const octokit = makeIssueOctokit();
     await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -250,7 +251,7 @@ describe("fetchIssues", () => {
   it("maps GraphQL fields to camelCase issue shape", async () => {
     const octokit = makeIssueOctokit();
     const { issues } = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -269,7 +270,7 @@ describe("fetchIssues", () => {
   it("returns empty result when repos is empty", async () => {
     const octokit = makeIssueOctokit();
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [],
       "octocat"
     );
@@ -288,7 +289,7 @@ describe("fetchIssues", () => {
 
     const octokit = makeIssueOctokit();
     await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       repos,
       "octocat"
     );
@@ -307,7 +308,7 @@ describe("fetchIssues", () => {
     // Both batches return the same databaseId
     const octokit = makeIssueOctokit(async () => makeGraphqlIssueResponse([graphqlIssueNode]));
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       repos,
       "octocat"
     );
@@ -330,7 +331,7 @@ describe("fetchIssues", () => {
     });
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -347,7 +348,7 @@ describe("fetchIssues", () => {
     const octokit = makeIssueOctokit(async () => makeGraphqlIssueResponse(manyNodes, true, 1500));
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -375,7 +376,7 @@ describe("fetchIssues", () => {
     }));
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -398,7 +399,7 @@ describe("fetchIssues", () => {
     });
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -435,7 +436,7 @@ describe("fetchIssues", () => {
     });
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -458,7 +459,7 @@ describe("fetchIssues", () => {
     }));
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -472,7 +473,7 @@ describe("fetchIssues", () => {
   it("rejects invalid userLogin with error instead of injecting into query", async () => {
     const octokit = makeIssueOctokit();
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "bad user" // contains space — fails VALID_LOGIN
     );
@@ -505,7 +506,7 @@ describe("fetchIssues", () => {
     });
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       repos,
       "octocat"
     );
@@ -583,7 +584,7 @@ describe("fetchPullRequests", () => {
     });
 
     await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -597,7 +598,7 @@ describe("fetchPullRequests", () => {
     const octokit = makePROctokit();
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -638,7 +639,7 @@ describe("fetchPullRequests", () => {
       } as typeof graphqlPRNode;
       const octokit = makePROctokit(async () => makeGraphqlPRResponse([node]));
       const { pullRequests } = await fetchPullRequests(
-        octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+        octokit as never,
         [testRepo],
         "octocat"
       );
@@ -656,7 +657,7 @@ describe("fetchPullRequests", () => {
     const octokit = makePROctokit(async () => makeGraphqlPRResponse([nodeWithOverlap]));
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -672,7 +673,7 @@ describe("fetchPullRequests", () => {
       const node = { ...graphqlPRNode, databaseId: 300, reviewDecision: decision } as typeof graphqlPRNode;
       const octokit = makePROctokit(async () => makeGraphqlPRResponse([node]));
       const { pullRequests } = await fetchPullRequests(
-        octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+        octokit as never,
         [testRepo],
         "octocat"
       );
@@ -685,7 +686,7 @@ describe("fetchPullRequests", () => {
     const octokit = makePROctokit(async () => makeGraphqlPRResponse([graphqlPRNode]));
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -719,7 +720,7 @@ describe("fetchPullRequests", () => {
     });
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -744,7 +745,7 @@ describe("fetchPullRequests", () => {
     });
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -767,7 +768,7 @@ describe("fetchPullRequests", () => {
     const octokit = makePROctokit(async () => makeGraphqlPRResponse([malformedNode]));
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -793,7 +794,7 @@ describe("fetchPullRequests", () => {
     });
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -830,7 +831,7 @@ describe("fetchPullRequests", () => {
     });
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -880,7 +881,7 @@ describe("fetchPullRequests", () => {
     });
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -924,7 +925,7 @@ describe("fetchPullRequests", () => {
     });
 
     const result = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -961,7 +962,7 @@ describe("fetchPullRequests", () => {
     });
 
     const result = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -981,7 +982,7 @@ describe("fetchPullRequests", () => {
     }));
 
     const result = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -1004,7 +1005,7 @@ describe("fetchPullRequests", () => {
     });
 
     const result = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -1050,7 +1051,7 @@ describe("fetchPullRequests", () => {
     });
 
     const { pullRequests } = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "octocat"
     );
@@ -1066,7 +1067,7 @@ describe("fetchPullRequests", () => {
   it("returns empty result when repos is empty", async () => {
     const octokit = makePROctokit();
     const result = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [],
       "octocat"
     );
@@ -1105,7 +1106,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       3
@@ -1119,7 +1120,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       3
@@ -1142,7 +1143,7 @@ describe("fetchWorkflowRuns", () => {
     const maxWorkflows = 3;
     const maxRuns = 1;
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       maxWorkflows,
       maxRuns
@@ -1163,7 +1164,7 @@ describe("fetchWorkflowRuns", () => {
 
     const maxWorkflows = 1;
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       maxWorkflows,
       10
@@ -1178,7 +1179,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       10
@@ -1199,7 +1200,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       3
@@ -1227,7 +1228,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       10
@@ -1245,7 +1246,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       10
@@ -1268,7 +1269,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       10
@@ -1285,7 +1286,7 @@ describe("fetchWorkflowRuns", () => {
     const octokit = makeOctokitForRuns();
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       10
@@ -1308,7 +1309,7 @@ describe("empty userLogin short-circuit", () => {
     };
 
     const result = await fetchIssues(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "" // empty userLogin
     );
@@ -1324,7 +1325,7 @@ describe("empty userLogin short-circuit", () => {
     const octokit = { request, graphql, paginate: { iterator: vi.fn() } };
 
     const result = await fetchPullRequests(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       "" // empty userLogin
     );
@@ -1378,7 +1379,7 @@ describe("fetchWorkflowRuns pagination", () => {
     };
 
     const { workflowRuns } = await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       25
@@ -1413,7 +1414,7 @@ describe("fetchWorkflowRuns pagination", () => {
     };
 
     await fetchWorkflowRuns(
-      octokit as unknown as ReturnType<typeof import("../../src/app/services/github").getClient>,
+      octokit as never,
       [testRepo],
       5,
       3
@@ -1421,5 +1422,322 @@ describe("fetchWorkflowRuns pagination", () => {
 
     // Only 1 page request should be made
     expect(requestCount).toBe(1);
+  });
+});
+
+// ── validateGitHubUser — bot login and type detection (C1) ───────────────────
+
+function makeUserOctokit(userData: {
+  login: string;
+  avatar_url: string;
+  name: string | null;
+  type: string;
+}) {
+  return makeOctokit(async () => ({ data: userData }));
+}
+
+describe("validateGitHubUser — VALID_TRACKED_LOGIN and type detection", () => {
+  it("accepts regular user login", async () => {
+    const octokit = makeUserOctokit({
+      login: "octocat",
+      avatar_url: "https://avatars.githubusercontent.com/u/583231",
+      name: "The Octocat",
+      type: "User",
+    });
+    const result = await validateGitHubUser(
+      octokit as never,
+      "octocat"
+    );
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("user");
+  });
+
+  it("accepts bot login with [bot] suffix", async () => {
+    const octokit = makeUserOctokit({
+      login: "dependabot[bot]",
+      avatar_url: "https://avatars.githubusercontent.com/u/27347476",
+      name: null,
+      type: "Bot",
+    });
+    const result = await validateGitHubUser(
+      octokit as never,
+      "dependabot[bot]"
+    );
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("bot");
+    expect(result?.login).toBe("dependabot[bot]");
+  });
+
+  it("accepts another bot login — khepri-bot[bot]", async () => {
+    const octokit = makeUserOctokit({
+      login: "khepri-bot[bot]",
+      avatar_url: "https://avatars.githubusercontent.com/u/999",
+      name: null,
+      type: "Bot",
+    });
+    const result = await validateGitHubUser(
+      octokit as never,
+      "khepri-bot[bot]"
+    );
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("bot");
+  });
+
+  it("returns type:user when API returns type:User", async () => {
+    const octokit = makeUserOctokit({
+      login: "regular-user",
+      avatar_url: "https://avatars.githubusercontent.com/u/1",
+      name: "Regular User",
+      type: "User",
+    });
+    const result = await validateGitHubUser(
+      octokit as never,
+      "regular-user"
+    );
+    expect(result?.type).toBe("user");
+  });
+
+  it("returns null for [bot] alone (no base login)", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(
+      octokit as never,
+      "[bot]"
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for login with arbitrary bracket content", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(
+      octokit as never,
+      "user[evil]"
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for [Bot] (case-sensitive — only [bot] accepted)", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(
+      octokit as never,
+      "user[Bot]"
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for user[bot][bot] (double suffix)", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(
+      octokit as never,
+      "user[bot][bot]"
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null on 404 for bot login", async () => {
+    const octokit = makeOctokit(async () => {
+      const err = Object.assign(new Error("Not Found"), { status: 404 });
+      throw err;
+    });
+    const result = await validateGitHubUser(
+      octokit as never,
+      "nonexistent[bot]"
+    );
+    expect(result).toBeNull();
+  });
+
+  it("throws on network error", async () => {
+    const octokit = makeOctokit(async () => {
+      throw new Error("Network error");
+    });
+    await expect(
+      validateGitHubUser(
+        octokit as never,
+        "dependabot[bot]"
+      )
+    ).rejects.toThrow("Network error");
+  });
+});
+
+// ── fetchIssuesAndPullRequests — monitoredRepos partition (C5) ────────────────
+
+describe("fetchIssuesAndPullRequests — monitoredRepos", () => {
+  it("returns empty result with no repos even when monitoredRepos provided", async () => {
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    const octokit = makeOctokit(async () => ({ data: {} }), async () => ({}));
+    const result = await fetchIssuesAndPullRequests(
+      octokit as never,
+      [],
+      "octocat",
+      undefined,
+      undefined,
+      [{ fullName: "org/monitored" }]
+    );
+    expect(result.issues).toEqual([]);
+    expect(result.pullRequests).toEqual([]);
+  });
+
+  it("unfiltered search query does not contain 'involves:'", async () => {
+    const queriesUsed: string[] = [];
+    const octokit = makeOctokit(
+      async () => ({ data: {} }),
+      async (_query: string, variables: unknown) => {
+        const vars = variables as Record<string, unknown>;
+        if (vars.issueQ) queriesUsed.push(vars.issueQ as string);
+        if (vars.prQ) queriesUsed.push(vars.prQ as string);
+        return {
+          issues: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          // Also handle regular combined search format
+          prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+        };
+      }
+    );
+
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    const monitoredRepo = { owner: "org", name: "monitored", fullName: "org/monitored" };
+    await fetchIssuesAndPullRequests(
+      octokit as never,
+      [monitoredRepo],
+      "octocat",
+      undefined,
+      undefined,
+      [{ fullName: "org/monitored" }]
+    );
+
+    // Unfiltered queries should not contain 'involves:'
+    const unfilteredQueries = queriesUsed.filter(q => !q.includes("involves:") && !q.includes("review-requested:"));
+    expect(unfilteredQueries.length).toBeGreaterThan(0);
+    for (const q of unfilteredQueries) {
+      expect(q).not.toContain("involves:");
+    }
+  });
+});
+
+// ── fetchIssuesAndPullRequests — cross-feature integration (monitored + bot) ──
+
+describe("fetchIssuesAndPullRequests — cross-feature: monitored repo + bot tracked user", () => {
+  const monitoredRepo = { owner: "org", name: "monitored", fullName: "org/monitored" };
+  const normalRepo = { owner: "org", name: "normal", fullName: "org/normal" };
+
+  const monitoredIssueNode = {
+    databaseId: 2001,
+    number: 1,
+    title: "Monitored repo issue",
+    state: "open",
+    url: "https://github.com/org/monitored/issues/1",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-02T00:00:00Z",
+    author: { login: "someone", avatarUrl: "https://avatars.githubusercontent.com/u/1" },
+    labels: { nodes: [] },
+    assignees: { nodes: [] },
+    repository: { nameWithOwner: "org/monitored" },
+    comments: { totalCount: 0 },
+  };
+
+  const botIssueNode = {
+    databaseId: 2002,
+    number: 2,
+    title: "Bot-surfaced issue",
+    state: "open",
+    url: "https://github.com/org/normal/issues/2",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-02T00:00:00Z",
+    author: { login: "dependabot[bot]", avatarUrl: "https://avatars.githubusercontent.com/u/27347476" },
+    labels: { nodes: [] },
+    assignees: { nodes: [] },
+    repository: { nameWithOwner: "org/normal" },
+    comments: { totalCount: 0 },
+  };
+
+  it("deduplicates issues when same item appears in both monitored and bot searches", async () => {
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+
+    const octokit = makeOctokit(
+      async () => ({ data: {}, headers: {} }),
+      async (_query: string, variables: unknown) => {
+        const vars = variables as Record<string, unknown>;
+        // Unfiltered search for monitored repo returns monitoredIssueNode
+        if (vars.issueQ && typeof vars.issueQ === "string" && !String(vars.issueQ).includes("involves:")) {
+          return {
+            issues: { issueCount: 1, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [monitoredIssueNode] },
+            prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            rateLimit: { limit: 5000, remaining: 4990, resetAt: new Date(Date.now() + 3600000).toISOString() },
+          };
+        }
+        // Bot tracked user search on normal repos returns botIssueNode
+        if (vars.issueQ && String(vars.issueQ).includes("involves:dependabot")) {
+          return {
+            issues: { issueCount: 1, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [botIssueNode] },
+            prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            rateLimit: { limit: 5000, remaining: 4985, resetAt: new Date(Date.now() + 3600000).toISOString() },
+          };
+        }
+        // Main user search returns nothing
+        return {
+          issues: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+        };
+      }
+    );
+
+    const botUser = { login: "dependabot[bot]", avatarUrl: "https://avatars.githubusercontent.com/u/27347476", name: null, type: "bot" as const };
+    const result = await fetchIssuesAndPullRequests(
+      octokit as never,
+      [normalRepo, monitoredRepo],
+      "octocat",
+      undefined,
+      [botUser],
+      [{ fullName: "org/monitored" }]
+    );
+
+    // Both issues are present (no dedup since different IDs)
+    const ids = result.issues.map((i) => i.id);
+    expect(ids).toContain(2001); // monitored repo issue
+    expect(ids).toContain(2002); // bot-surfaced issue
+
+    // Bot issue has surfacedBy annotation
+    const botIssue = result.issues.find((i) => i.id === 2002);
+    expect(botIssue?.surfacedBy).toContain("dependabot[bot]");
+
+    // Monitored repo issue has no surfacedBy (no user qualifier)
+    const monitoredIssue = result.issues.find((i) => i.id === 2001);
+    expect(monitoredIssue?.surfacedBy).toBeUndefined();
+  });
+});
+
+// ── VALID_TRACKED_LOGIN — GraphQL injection character rejection ────────────────
+
+describe("VALID_TRACKED_LOGIN — rejects GraphQL-unsafe characters", () => {
+  it("rejects login with space", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(octokit as never, "user name");
+    expect(result).toBeNull();
+    expect(octokit.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects login with colon", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(octokit as never, "user:name");
+    expect(result).toBeNull();
+    expect(octokit.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects login with double quote", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(octokit as never, 'user"name');
+    expect(result).toBeNull();
+    expect(octokit.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects login with newline", async () => {
+    const octokit = makeOctokit(async () => ({ data: {} }));
+    const result = await validateGitHubUser(octokit as never, "user\nname");
+    expect(result).toBeNull();
+    expect(octokit.request).not.toHaveBeenCalled();
   });
 });

--- a/tests/services/api.test.ts
+++ b/tests/services/api.test.ts
@@ -1615,6 +1615,68 @@ describe("fetchIssuesAndPullRequests — monitoredRepos", () => {
   });
 });
 
+describe("fetchIssuesAndPullRequests — all repos monitored (edge case)", () => {
+  it("skips main user light search and returns items from unfiltered search only", async () => {
+    const queriesUsed: string[] = [];
+    const repo = { owner: "org", name: "repo1", fullName: "org/repo1" };
+
+    const issueNode = {
+      databaseId: 3001,
+      number: 1,
+      title: "All-monitored issue",
+      state: "open",
+      url: "https://github.com/org/repo1/issues/1",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+      author: { login: "someone", avatarUrl: "https://avatars.githubusercontent.com/u/1" },
+      labels: { nodes: [] },
+      assignees: { nodes: [] },
+      repository: { nameWithOwner: "org/repo1" },
+      comments: { totalCount: 0 },
+    };
+
+    const octokit = makeOctokit(
+      async () => ({ data: {}, headers: {} }),
+      async (_query: string, variables: unknown) => {
+        const vars = variables as Record<string, unknown>;
+        if (vars.issueQ) queriesUsed.push(vars.issueQ as string);
+        return {
+          issues: { issueCount: 1, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [issueNode] },
+          prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+        };
+      }
+    );
+
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    const result = await fetchIssuesAndPullRequests(
+      octokit as never,
+      [repo],
+      "octocat",
+      undefined,
+      undefined,
+      [{ fullName: "org/repo1" }]  // all repos monitored
+    );
+
+    // Items returned from unfiltered search
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].id).toBe(3001);
+
+    // No involves: query (main user search skipped since normalRepos is empty)
+    const involvesQueries = queriesUsed.filter(q => q.includes("involves:octocat"));
+    expect(involvesQueries).toHaveLength(0);
+
+    // Unfiltered query was issued (no involves: qualifier)
+    const unfilteredQueries = queriesUsed.filter(q => !q.includes("involves:") && !q.includes("review-requested:"));
+    expect(unfilteredQueries.length).toBeGreaterThan(0);
+
+    // Item has no surfacedBy (unfiltered search items aren't attributed to a user)
+    expect(result.issues[0].surfacedBy).toBeUndefined();
+  });
+});
+
 // ── fetchIssuesAndPullRequests — cross-feature integration (monitored + bot) ──
 
 describe("fetchIssuesAndPullRequests — cross-feature: monitored repo + bot tracked user", () => {

--- a/tests/services/api.test.ts
+++ b/tests/services/api.test.ts
@@ -475,7 +475,7 @@ describe("fetchIssues", () => {
     const result = await fetchIssues(
       octokit as never,
       [testRepo],
-      "bad user" // contains space — fails VALID_LOGIN
+      "bad user" // contains space — fails VALID_TRACKED_LOGIN
     );
 
     expect(result.issues).toEqual([]);
@@ -1903,6 +1903,71 @@ describe("fetchIssuesAndPullRequests — unfiltered search error handling", () =
     // Error recorded with retryable flag (network error → statusCode null → retryable)
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toMatchObject({ retryable: true });
+  });
+
+  it("recovers PR data when issues is null but prs has data (symmetric partial case)", async () => {
+    const monitoredRepo = { owner: "org", name: "monitored", fullName: "org/monitored" };
+    // Fixture matches GraphQLLightPRNode — no heavy fields (additions, commits, etc.)
+    const prNode = {
+      id: "PR_kwDOtest4501",
+      databaseId: 4501,
+      number: 1,
+      title: "Partial PR",
+      state: "open",
+      isDraft: false,
+      url: "https://github.com/org/monitored/pull/1",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+      author: { login: "someone", avatarUrl: "https://avatars.githubusercontent.com/u/1" },
+      repository: { nameWithOwner: "org/monitored" },
+      headRefName: "fix/thing",
+      baseRefName: "main",
+      reviewDecision: null,
+      labels: { nodes: [] },
+    };
+
+    let callCount = 0;
+    const octokit = makeOctokit(
+      async () => ({ data: {}, headers: {} }),
+      async () => {
+        callCount++;
+        if (callCount === 1) {
+          const err = Object.assign(new Error("Partial failure"), {
+            data: {
+              issues: null,
+              prs: { issueCount: 1, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [prNode] },
+              rateLimit: { limit: 5000, remaining: 4998, resetAt: new Date(Date.now() + 3600000).toISOString() },
+            },
+          });
+          throw err;
+        }
+        return {
+          issues: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+        };
+      }
+    );
+
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    const result = await fetchIssuesAndPullRequests(
+      octokit as never,
+      [monitoredRepo],
+      "octocat",
+      undefined,
+      undefined,
+      [{ owner: "org", name: "monitored", fullName: "org/monitored" }]
+    );
+
+    // PR data recovered from partial response
+    expect(result.pullRequests).toHaveLength(1);
+    expect(result.pullRequests[0].id).toBe(4501);
+    // Issues empty (null coalesced to empty)
+    expect(result.issues).toHaveLength(0);
+    // Error recorded
+    expect(result.errors.some(e => e.retryable)).toBe(true);
   });
 });
 

--- a/tests/services/api.test.ts
+++ b/tests/services/api.test.ts
@@ -1803,3 +1803,190 @@ describe("VALID_TRACKED_LOGIN — rejects GraphQL-unsafe characters", () => {
     expect(octokit.request).not.toHaveBeenCalled();
   });
 });
+
+describe("fetchIssuesAndPullRequests — unfiltered search error handling", () => {
+  it("returns partial results when unfiltered GraphQL query throws with partial data", async () => {
+    const monitoredRepo = { owner: "org", name: "monitored", fullName: "org/monitored" };
+    const issueNode = {
+      databaseId: 4001,
+      number: 1,
+      title: "Partial issue",
+      state: "open",
+      url: "https://github.com/org/monitored/issues/1",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+      author: { login: "someone", avatarUrl: "https://avatars.githubusercontent.com/u/1" },
+      labels: { nodes: [] },
+      assignees: { nodes: [] },
+      repository: { nameWithOwner: "org/monitored" },
+      comments: { totalCount: 0 },
+    };
+
+    let callCount = 0;
+    const octokit = makeOctokit(
+      async () => ({ data: {}, headers: {} }),
+      async () => {
+        callCount++;
+        // First call is for unfiltered search — throw with partial data
+        if (callCount === 1) {
+          const err = Object.assign(new Error("Partial failure"), {
+            data: {
+              issues: { issueCount: 1, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [issueNode] },
+              prs: null,
+              rateLimit: { limit: 5000, remaining: 4998, resetAt: new Date(Date.now() + 3600000).toISOString() },
+            },
+          });
+          throw err;
+        }
+        // No other searches expected (normalRepos is empty)
+        return {
+          issues: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+        };
+      }
+    );
+
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    const result = await fetchIssuesAndPullRequests(
+      octokit as never,
+      [monitoredRepo],
+      "octocat",
+      undefined,
+      undefined,
+      [{ fullName: "org/monitored" }]
+    );
+
+    // Partial issue data recovered
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].id).toBe(4001);
+    // Error recorded
+    expect(result.errors.some(e => e.retryable)).toBe(true);
+  });
+
+  it("records error when unfiltered GraphQL query throws with no data", async () => {
+    const monitoredRepo = { owner: "org", name: "monitored", fullName: "org/monitored" };
+
+    let callCount = 0;
+    const octokit = makeOctokit(
+      async () => ({ data: {}, headers: {} }),
+      async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("Total failure");
+        }
+        return {
+          issues: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+        };
+      }
+    );
+
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    const result = await fetchIssuesAndPullRequests(
+      octokit as never,
+      [monitoredRepo],
+      "octocat",
+      undefined,
+      undefined,
+      [{ fullName: "org/monitored" }]
+    );
+
+    // No results recovered
+    expect(result.issues).toHaveLength(0);
+    expect(result.pullRequests).toHaveLength(0);
+    // Error recorded
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("fetchIssuesAndPullRequests — all monitored + tracked users skips involves: search", () => {
+  it("does not fire tracked user involves: search when all repos are monitored", async () => {
+    const queriesUsed: string[] = [];
+    const repo = { owner: "org", name: "repo1", fullName: "org/repo1" };
+    const botUser = { login: "dependabot[bot]", avatarUrl: "https://avatars.githubusercontent.com/u/27347476", name: null, type: "bot" as const };
+
+    const octokit = makeOctokit(
+      async () => ({ data: {}, headers: {} }),
+      async (_query: string, variables: unknown) => {
+        const vars = variables as Record<string, unknown>;
+        if (vars.issueQ) queriesUsed.push(vars.issueQ as string);
+        if (vars.prInvQ) queriesUsed.push(vars.prInvQ as string);
+        return {
+          issues: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+        };
+      }
+    );
+
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    await fetchIssuesAndPullRequests(
+      octokit as never,
+      [repo],
+      "octocat",
+      undefined,
+      [botUser],
+      [{ fullName: "org/repo1" }]  // all repos monitored
+    );
+
+    // No involves: queries for tracked user (since normalRepos is empty, tracked search is skipped)
+    const involvesQueries = queriesUsed.filter(q => q.includes("involves:dependabot"));
+    expect(involvesQueries).toHaveLength(0);
+  });
+});
+
+describe("fetchIssuesAndPullRequests — onLightData suppression when all monitored", () => {
+  it("does not call onLightData when all repos are monitored", async () => {
+    const repo = { owner: "org", name: "repo1", fullName: "org/repo1" };
+    const issueNode = {
+      databaseId: 5001,
+      number: 1,
+      title: "Monitored issue",
+      state: "open",
+      url: "https://github.com/org/repo1/issues/1",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+      author: { login: "someone", avatarUrl: "https://avatars.githubusercontent.com/u/1" },
+      labels: { nodes: [] },
+      assignees: { nodes: [] },
+      repository: { nameWithOwner: "org/repo1" },
+      comments: { totalCount: 0 },
+    };
+
+    const octokit = makeOctokit(
+      async () => ({ data: {}, headers: {} }),
+      async () => ({
+        issues: { issueCount: 1, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [issueNode] },
+        prs: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        prInvolves: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        prReviewReq: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date(Date.now() + 3600000).toISOString() },
+      })
+    );
+
+    const onLightData = vi.fn();
+    const { fetchIssuesAndPullRequests } = await import("../../src/app/services/api");
+    const result = await fetchIssuesAndPullRequests(
+      octokit as never,
+      [repo],
+      "octocat",
+      onLightData,
+      undefined,
+      [{ fullName: "org/repo1" }]  // all repos monitored
+    );
+
+    // onLightData NOT called (main user search skipped, unfiltered results come after)
+    expect(onLightData).not.toHaveBeenCalled();
+    // But final result still has the issue
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].id).toBe(5001);
+  });
+});

--- a/tests/services/hot-poll.test.ts
+++ b/tests/services/hot-poll.test.ts
@@ -206,7 +206,7 @@ describe("resetPollState", () => {
   it("clears hot sets and resets generation", async () => {
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_x" })],
+      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_x" })],
       workflowRuns: [makeWorkflowRun({ id: 10, status: "in_progress", conclusion: null, repoFullName: "o/r" })],
     });
     expect(getHotPollGeneration()).toBe(1);
@@ -235,7 +235,7 @@ describe("rebuildHotSets", () => {
     expect(getHotPollGeneration()).toBe(2);
   });
 
-  it("populates hot PRs for pending/null checkStatus with nodeId", async () => {
+  it("populates hot PRs for enriched pending checkStatus with nodeId", async () => {
     const octokit = makeOctokit(undefined, () => Promise.resolve({
       nodes: [],
       rateLimit: { limit: 5000, remaining: 4999, resetAt: "2026-01-01T00:00:00Z" },
@@ -245,20 +245,20 @@ describe("rebuildHotSets", () => {
     rebuildHotSets({
       ...emptyData,
       pullRequests: [
-        makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_a" }),
-        makePullRequest({ id: 2, checkStatus: null, nodeId: "PR_b" }),
-        makePullRequest({ id: 3, checkStatus: "success", nodeId: "PR_c" }), // should be skipped
-        makePullRequest({ id: 4, checkStatus: "pending" }), // no nodeId, should be skipped
+        makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_a" }),
+        makePullRequest({ id: 2, checkStatus: null, enriched: true, nodeId: "PR_b" }), // null checkStatus — skipped (not pending)
+        makePullRequest({ id: 3, checkStatus: "success", enriched: true, nodeId: "PR_c" }), // resolved — skipped
+        makePullRequest({ id: 4, checkStatus: "pending", enriched: true }), // no nodeId — skipped
+        makePullRequest({ id: 5, checkStatus: "pending", enriched: false, nodeId: "PR_e" }), // not enriched — skipped
       ],
     });
 
     await fetchHotData();
-    // Verify graphql was called with only the 2 eligible node IDs
+    // Verify graphql was called with only the 1 eligible node ID
     expect(octokit.graphql).toHaveBeenCalledTimes(1);
     const calledIds = (octokit.graphql.mock.calls[0][1] as { ids: string[] }).ids;
-    expect(calledIds).toHaveLength(2);
+    expect(calledIds).toHaveLength(1);
     expect(calledIds).toContain("PR_a");
-    expect(calledIds).toContain("PR_b");
   });
 
   it("populates hot runs for queued/in_progress, skips completed", async () => {
@@ -377,7 +377,7 @@ describe("fetchHotData", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_x" })],
+      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_x" })],
     });
 
     // First fetch — PR is hot, returns success -> evicts
@@ -603,7 +603,7 @@ describe("createHotPollCoordinator", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_a" })],
+      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_a" })],
     });
 
     const { pushError } = await import("../../src/app/lib/errors");
@@ -661,7 +661,7 @@ describe("createHotPollCoordinator", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 42, nodeId: "PR_node42", repoFullName: "o/r" })],
+      pullRequests: [makePullRequest({ id: 42, checkStatus: "pending", enriched: true, nodeId: "PR_node42", repoFullName: "o/r" })],
       workflowRuns: [makeWorkflowRun({ id: 7, status: "in_progress", conclusion: null, repoFullName: "o/r" })],
     });
 
@@ -746,7 +746,7 @@ describe("createHotPollCoordinator", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 42, nodeId: "PR_node42", repoFullName: "o/r" })],
+      pullRequests: [makePullRequest({ id: 42, checkStatus: "pending", enriched: true, nodeId: "PR_node42", repoFullName: "o/r" })],
     });
 
     const { pushError } = await import("../../src/app/lib/errors");
@@ -868,7 +868,7 @@ describe("rebuildHotSets caps", () => {
 
   it("caps hot PRs at MAX_HOT_PRS (200)", async () => {
     const prs = Array.from({ length: 250 }, (_, i) =>
-      makePullRequest({ id: i + 1, checkStatus: "pending", nodeId: `PR_${i}` })
+      makePullRequest({ id: i + 1, checkStatus: "pending", enriched: true, nodeId: `PR_${i}` })
     );
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -945,8 +945,8 @@ describe("fetchHotData eviction edge cases", () => {
     rebuildHotSets({
       ...emptyData,
       pullRequests: [
-        makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_one" }),
-        makePullRequest({ id: 2, checkStatus: "pending", nodeId: "PR_two" }),
+        makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_one" }),
+        makePullRequest({ id: 2, checkStatus: "pending", enriched: true, nodeId: "PR_two" }),
       ],
     });
 
@@ -979,7 +979,7 @@ describe("fetchHotData eviction edge cases", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_merged" })],
+      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_merged" })],
     });
 
     const first = await fetchHotData();
@@ -1008,7 +1008,7 @@ describe("fetchHotData eviction edge cases", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 2, checkStatus: null, nodeId: "PR_closed" })],
+      pullRequests: [makePullRequest({ id: 2, checkStatus: "pending", enriched: true, nodeId: "PR_closed" })],
     });
 
     await fetchHotData();
@@ -1022,7 +1022,7 @@ describe("clearHotSets", () => {
   it("empties both hot maps so next fetchHotData is a no-op", async () => {
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_a" })],
+      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_a" })],
       workflowRuns: [makeWorkflowRun({ id: 10, status: "in_progress", conclusion: null, repoFullName: "o/r" })],
     });
 
@@ -1060,7 +1060,7 @@ describe("fetchHotData hadErrors", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_a" })],
+      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_a" })],
       workflowRuns: [makeWorkflowRun({ id: 10, status: "in_progress", conclusion: null, repoFullName: "o/r" })],
     });
 
@@ -1074,7 +1074,7 @@ describe("fetchHotData hadErrors", () => {
 
     rebuildHotSets({
       ...emptyData,
-      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", nodeId: "PR_a" })],
+      pullRequests: [makePullRequest({ id: 1, checkStatus: "pending", enriched: true, nodeId: "PR_a" })],
     });
 
     const { hadErrors, prUpdates } = await fetchHotData();

--- a/tests/services/poll-fetchAllData.test.ts
+++ b/tests/services/poll-fetchAllData.test.ts
@@ -136,7 +136,7 @@ describe("fetchAllData — first call", () => {
 
     await fetchAllData();
 
-    expect(fetchIssuesAndPullRequests).toHaveBeenCalledWith(mockOctokit, config.selectedRepos, "octocat", undefined, []);
+    expect(fetchIssuesAndPullRequests).toHaveBeenCalledWith(mockOctokit, config.selectedRepos, "octocat", undefined, [], []);
     expect(fetchWorkflowRuns).toHaveBeenCalledWith(
       mockOctokit,
       config.selectedRepos,
@@ -719,6 +719,7 @@ describe("fetchAllData — upstream repos and tracked users", () => {
       selectedRepos,
       "octocat",
       undefined,
+      [],
       []
     );
     expect(fetchWorkflowRuns).toHaveBeenCalledWith(

--- a/tests/services/poll-notification-effects.test.ts
+++ b/tests/services/poll-notification-effects.test.ts
@@ -59,7 +59,9 @@ vi.mock("../../src/app/lib/errors", () => ({
 import { updateConfig, resetConfig } from "../../src/app/stores/config";
 
 // Import poll.ts — triggers createRoot + createEffect registration at module scope
-import "../../src/app/services/poll";
+import { fetchAllData, resetPollState } from "../../src/app/services/poll";
+import { getClient } from "../../src/app/services/github";
+import { fetchIssuesAndPullRequests, fetchWorkflowRuns } from "../../src/app/services/api";
 
 describe("poll.ts — notification reset reactive effects", () => {
   beforeEach(() => {
@@ -122,5 +124,74 @@ describe("poll.ts — notification reset reactive effects", () => {
     });
 
     expect(mockResetNotifState).toHaveBeenCalled();
+  });
+});
+
+describe("poll.ts — notifications gate bypass on config change", () => {
+  const mockRequest = vi.fn();
+
+  beforeEach(() => {
+    resetPollState();
+    resetConfig();
+    mockRequest.mockReset();
+    mockRequest.mockResolvedValue({
+      data: [],
+      headers: { "last-modified": "Thu, 20 Mar 2026 12:00:00 GMT" },
+    });
+    vi.mocked(getClient).mockReturnValue({
+      request: mockRequest,
+      graphql: vi.fn(),
+      hook: { before: vi.fn() },
+    } as never);
+    vi.mocked(fetchIssuesAndPullRequests).mockResolvedValue({
+      issues: [], pullRequests: [], errors: [],
+    });
+    vi.mocked(fetchWorkflowRuns).mockResolvedValue({
+      workflowRuns: [], errors: [],
+    } as never);
+  });
+
+  it("bypasses notifications gate after monitoredRepos change", async () => {
+    // First call — no _lastSuccessfulFetch, gate skipped
+    await fetchAllData();
+    expect(mockRequest).not.toHaveBeenCalled();
+
+    // Second call — _lastSuccessfulFetch set, gate fires
+    await fetchAllData();
+    expect(mockRequest).toHaveBeenCalledWith("GET /notifications", expect.anything());
+    mockRequest.mockClear();
+
+    // Change monitoredRepos — should null _lastSuccessfulFetch
+    updateConfig({
+      selectedRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
+      monitoredRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
+    });
+
+    // Third call — gate bypassed because _lastSuccessfulFetch was nulled
+    await fetchAllData();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("bypasses notifications gate after trackedUsers change", async () => {
+    // First call — sets _lastSuccessfulFetch
+    await fetchAllData();
+
+    // Second call — gate fires
+    await fetchAllData();
+    mockRequest.mockClear();
+
+    // Change trackedUsers — should null _lastSuccessfulFetch
+    updateConfig({
+      trackedUsers: [{
+        login: "octocat",
+        avatarUrl: "https://avatars.githubusercontent.com/u/583231",
+        name: "Octocat",
+        type: "user" as const,
+      }],
+    });
+
+    // Next call — gate bypassed
+    await fetchAllData();
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 });

--- a/tests/services/poll-notification-effects.test.ts
+++ b/tests/services/poll-notification-effects.test.ts
@@ -95,6 +95,18 @@ describe("poll.ts — notification reset reactive effects", () => {
     expect(mockResetNotifState).not.toHaveBeenCalled();
   });
 
+  it("resets notification state when monitoredRepos cleared to empty", () => {
+    updateConfig({
+      selectedRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
+      monitoredRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
+    });
+    mockResetNotifState.mockClear();
+
+    updateConfig({ monitoredRepos: [] });
+
+    expect(mockResetNotifState).toHaveBeenCalled();
+  });
+
   it("detects swap at same array length (key-based comparison)", () => {
     updateConfig({
       selectedRepos: [

--- a/tests/services/poll-notification-effects.test.ts
+++ b/tests/services/poll-notification-effects.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the module-scope reactive effects in poll.ts that reset notification
+ * state when config.trackedUsers or config.monitoredRepos change.
+ *
+ * Uses the REAL reactive config store (not a static mock) so that updateConfig()
+ * triggers the reactive effects registered by poll.ts at module load.
+ */
+import "fake-indexeddb/auto";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockResetNotifState } = vi.hoisted(() => ({
+  mockResetNotifState: vi.fn(),
+}));
+
+// Mock github client
+vi.mock("../../src/app/services/github", () => ({
+  getClient: vi.fn(),
+}));
+
+// Mock auth store — onAuthCleared is called at poll.ts module scope
+vi.mock("../../src/app/stores/auth", () => ({
+  user: vi.fn(() => ({ login: "octocat", avatar_url: "https://github.com/images/error/octocat_happy.gif", name: "Octocat" })),
+  onAuthCleared: vi.fn(),
+}));
+
+// Mock API functions
+vi.mock("../../src/app/services/api", () => ({
+  fetchIssuesAndPullRequests: vi.fn(),
+  fetchWorkflowRuns: vi.fn(),
+  fetchHotPRStatus: vi.fn(),
+  fetchWorkflowRunById: vi.fn(),
+  pooledAllSettled: vi.fn(),
+  resetEmptyActionRepos: vi.fn(),
+}));
+
+// Mock notifications — spy on _resetNotificationState
+vi.mock("../../src/app/lib/notifications", () => ({
+  detectNewItems: vi.fn(() => []),
+  dispatchNotifications: vi.fn(),
+  _resetNotificationState: mockResetNotifState,
+}));
+
+// Mock errors store
+vi.mock("../../src/app/lib/errors", () => ({
+  pushError: vi.fn(),
+  pushNotification: vi.fn(),
+  getErrors: vi.fn().mockReturnValue([]),
+  dismissError: vi.fn(),
+  getNotifications: vi.fn().mockReturnValue([]),
+  getUnreadCount: vi.fn().mockReturnValue(0),
+  markAllAsRead: vi.fn(),
+  startCycleTracking: vi.fn(),
+  endCycleTracking: vi.fn(),
+  resetNotificationState: vi.fn(),
+  dismissNotificationBySource: vi.fn(),
+}));
+
+// Use REAL config store — the reactive effects in poll.ts subscribe to this
+import { updateConfig, resetConfig } from "../../src/app/stores/config";
+
+// Import poll.ts — triggers createRoot + createEffect registration at module scope
+import "../../src/app/services/poll";
+
+describe("poll.ts — notification reset reactive effects", () => {
+  beforeEach(() => {
+    resetConfig();
+    mockResetNotifState.mockClear();
+  });
+
+  it("resets notification state when monitoredRepos changes", () => {
+    updateConfig({
+      selectedRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
+      monitoredRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
+    });
+
+    expect(mockResetNotifState).toHaveBeenCalled();
+  });
+
+  it("resets notification state when trackedUsers changes", () => {
+    updateConfig({
+      trackedUsers: [{
+        login: "octocat",
+        avatarUrl: "https://avatars.githubusercontent.com/u/583231",
+        name: "Octocat",
+        type: "user" as const,
+      }],
+    });
+
+    expect(mockResetNotifState).toHaveBeenCalled();
+  });
+
+  it("does not reset when config update does not change the key", () => {
+    updateConfig({ theme: "dark" });
+
+    expect(mockResetNotifState).not.toHaveBeenCalled();
+  });
+
+  it("detects swap at same array length (key-based comparison)", () => {
+    updateConfig({
+      selectedRepos: [
+        { owner: "org", name: "a", fullName: "org/a" },
+        { owner: "org", name: "b", fullName: "org/b" },
+      ],
+      monitoredRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+    });
+    mockResetNotifState.mockClear();
+
+    updateConfig({
+      monitoredRepos: [{ owner: "org", name: "b", fullName: "org/b" }],
+    });
+
+    expect(mockResetNotifState).toHaveBeenCalled();
+  });
+});

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -5,6 +5,11 @@ vi.mock("../../src/app/stores/cache", () => ({
   clearCache: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockPushNotification = vi.fn();
+vi.mock("../../src/app/lib/errors", () => ({
+  pushNotification: (...args: unknown[]) => mockPushNotification(...args),
+}));
+
 // Mock localStorage with full control (same pattern as config.test.ts)
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -67,6 +72,24 @@ describe("setAuth / token signal", () => {
     vi.resetModules();
     const fresh = await import("../../src/app/stores/auth");
     expect(fresh.token()).toBe("ghs_persisted");
+  });
+
+  it("sets token in memory and warns when localStorage.setItem throws", () => {
+    const origSetItem = localStorageMock.setItem;
+    localStorageMock.setItem = () => { throw new DOMException("QuotaExceededError"); };
+    mockPushNotification.mockClear();
+
+    try {
+      mod.setAuth({ access_token: "ghs_quota" });
+      expect(mod.token()).toBe("ghs_quota");
+      expect(mockPushNotification).toHaveBeenCalledWith(
+        "localStorage:auth",
+        expect.stringContaining("storage may be full"),
+        "warning",
+      );
+    } finally {
+      localStorageMock.setItem = origSetItem;
+    }
   });
 });
 
@@ -349,6 +372,26 @@ describe("validateToken", () => {
     expect(result).toBe(false);
     // Token preserved — network error on retry doesn't confirm revocation
     expect(mod.token()).toBe("ghs_retrynet");
+  });
+
+  it("does not invalidate a new token set during the retry window (race condition guard)", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      // First GET /user returns 401
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      // Retry also returns 401 — but token was replaced mid-window
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+    );
+
+    mod.setAuth({ access_token: "ghs_old" });
+    const promise = mod.validateToken();
+    // Simulate user re-authenticating during the 1-second retry delay
+    mod.setAuth({ access_token: "ghs_new" });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+    expect(result).toBe(false);
+    // The NEW token must survive — guard prevents expireToken() from running
+    expect(mod.token()).toBe("ghs_new");
+    expect(localStorageMock.getItem("github-tracker:auth-token")).toBe("ghs_new");
   });
 
   it("preserves user config and view state when token expires (not a full logout)", async () => {

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -131,6 +131,58 @@ describe("clearAuth", () => {
   });
 });
 
+describe("expireToken", () => {
+  let mod: typeof import("../../src/app/stores/auth");
+
+  beforeEach(async () => {
+    localStorageMock.clear();
+    vi.resetModules();
+    mod = await import("../../src/app/stores/auth");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("clears token signal to null", () => {
+    mod.setAuth({ access_token: "ghs_abc" });
+    mod.expireToken();
+    expect(mod.token()).toBeNull();
+  });
+
+  it("clears user signal to null", () => {
+    // Simulate a validated session: set token + manually set user via validateToken mock
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ login: "wgordon", avatar_url: "", name: "Will" }),
+    }));
+    mod.setAuth({ access_token: "ghs_abc" });
+    // Directly test that user is cleared — validateToken would set it, but
+    // we can verify the signal reset by checking after expireToken
+    mod.expireToken();
+    expect(mod.user()).toBeNull();
+  });
+
+  it("removes only auth token from localStorage — config, view, dashboard preserved", () => {
+    localStorageMock.setItem("github-tracker:config", '{"theme":"dark"}');
+    localStorageMock.setItem("github-tracker:view", '{"lastActiveTab":"actions"}');
+    localStorageMock.setItem("github-tracker:dashboard", '{"cached":true}');
+    mod.setAuth({ access_token: "ghs_abc" });
+    mod.expireToken();
+    expect(localStorageMock.getItem("github-tracker:auth-token")).toBeNull();
+    expect(localStorageMock.getItem("github-tracker:config")).toBe('{"theme":"dark"}');
+    expect(localStorageMock.getItem("github-tracker:view")).toBe('{"lastActiveTab":"actions"}');
+    expect(localStorageMock.getItem("github-tracker:dashboard")).toBe('{"cached":true}');
+  });
+
+  it("does NOT invoke onAuthCleared callbacks", () => {
+    const cb = vi.fn();
+    mod.onAuthCleared(cb);
+    mod.expireToken();
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
 describe("onAuthCleared callbacks", () => {
   let mod: typeof import("../../src/app/stores/auth");
 
@@ -201,12 +253,14 @@ describe("validateToken", () => {
   let mod: typeof import("../../src/app/stores/auth");
 
   beforeEach(async () => {
+    vi.useFakeTimers();
     localStorageMock.clear();
     vi.resetModules();
     mod = await import("../../src/app/stores/auth");
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -231,16 +285,90 @@ describe("validateToken", () => {
     expect(mod.user()?.name).toBe("Will");
   });
 
-  it("clears auth on 401 (permanent token revoked — no refresh fallback)", async () => {
+  it("expires token after two consecutive 401s (transient retry + genuine revocation)", async () => {
     vi.stubGlobal("fetch", vi.fn()
-      // GET /user returns 401 (access token revoked)
+      // First GET /user returns 401
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      // Retry GET /user also returns 401
       .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
     );
 
     mod.setAuth({ access_token: "ghs_revoked" });
-    await mod.validateToken();
+    const promise = mod.validateToken();
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
     expect(mod.token()).toBeNull();
     expect(localStorageMock.getItem("github-tracker:auth-token")).toBeNull();
+  });
+
+  it("recovers on transient 401 when retry succeeds", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      // First GET /user returns 401 (transient)
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      // Retry succeeds
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: () => Promise.resolve({ login: "wgordon", avatar_url: "", name: "Will" }),
+      })
+    );
+
+    mod.setAuth({ access_token: "ghs_transient" });
+    const promise = mod.validateToken();
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+    expect(result).toBe(true);
+    expect(mod.token()).toBe("ghs_transient");
+    expect(mod.user()?.login).toBe("wgordon");
+  });
+
+  it("preserves token when retry returns non-401 error (e.g. 500)", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({}) })
+    );
+
+    mod.setAuth({ access_token: "ghs_retry500" });
+    const promise = mod.validateToken();
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+    expect(result).toBe(false);
+    // Token preserved — server error on retry doesn't confirm revocation
+    expect(mod.token()).toBe("ghs_retry500");
+  });
+
+  it("preserves token when retry throws network error", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+    );
+
+    mod.setAuth({ access_token: "ghs_retrynet" });
+    const promise = mod.validateToken();
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+    expect(result).toBe(false);
+    // Token preserved — network error on retry doesn't confirm revocation
+    expect(mod.token()).toBe("ghs_retrynet");
+  });
+
+  it("preserves user config and view state when token expires (not a full logout)", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+    );
+
+    localStorageMock.setItem("github-tracker:config", '{"theme":"dark"}');
+    localStorageMock.setItem("github-tracker:view", '{"lastActiveTab":"actions"}');
+    mod.setAuth({ access_token: "ghs_expired" });
+    const promise = mod.validateToken();
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    // Token cleared
+    expect(mod.token()).toBeNull();
+    expect(localStorageMock.getItem("github-tracker:auth-token")).toBeNull();
+    // Config and view preserved — expireToken() does NOT wipe user data
+    expect(localStorageMock.getItem("github-tracker:config")).toBe('{"theme":"dark"}');
+    expect(localStorageMock.getItem("github-tracker:view")).toBe('{"lastActiveTab":"actions"}');
   });
 
   it("returns false and leaves token unchanged on non-200/non-401 response (e.g., 503)", async () => {

--- a/tests/stores/config.test.ts
+++ b/tests/stores/config.test.ts
@@ -565,4 +565,41 @@ describe("setMonitoredRepo (C3)", () => {
       dispose();
     });
   });
+
+  it("enforces max 10 monitored repos", () => {
+    createRoot((dispose) => {
+      const repos = Array.from({ length: 11 }, (_, i) => ({
+        owner: "org",
+        name: `repo-${i}`,
+        fullName: `org/repo-${i}`,
+      }));
+      updateConfig({ selectedRepos: repos, monitoredRepos: repos.slice(0, 10) });
+      // 10 is the max — adding an 11th should be rejected
+      setMonitoredRepo(repos[10], true);
+      expect(config.monitoredRepos).toHaveLength(10);
+      dispose();
+    });
+  });
+});
+
+describe("ConfigSchema — monitoredRepos max constraint", () => {
+  it("rejects more than 10 monitored repos at schema level", () => {
+    const repos = Array.from({ length: 11 }, (_, i) => ({
+      owner: "org",
+      name: `repo-${i}`,
+      fullName: `org/repo-${i}`,
+    }));
+    const result = ConfigSchema.safeParse({ monitoredRepos: repos });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts exactly 10 monitored repos", () => {
+    const repos = Array.from({ length: 10 }, (_, i) => ({
+      owner: "org",
+      name: `repo-${i}`,
+      fullName: `org/repo-${i}`,
+    }));
+    const result = ConfigSchema.safeParse({ monitoredRepos: repos });
+    expect(result.success).toBe(true);
+  });
 });

--- a/tests/stores/config.test.ts
+++ b/tests/stores/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { ConfigSchema, loadConfig, config, updateConfig, resetConfig } from "../../src/app/stores/config";
+import { ConfigSchema, TrackedUserSchema, loadConfig, config, updateConfig, resetConfig, setMonitoredRepo } from "../../src/app/stores/config";
 import { createRoot } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 
@@ -159,6 +159,58 @@ describe("ConfigSchema — upstream repos and tracked users", () => {
       upstreamRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
     });
     expect(result.upstreamRepos).toHaveLength(1);
+  });
+
+  it("TrackedUserSchema defaults type to 'user' when omitted", () => {
+    const result = TrackedUserSchema.parse({
+      login: "octocat",
+      avatarUrl: "https://avatars.githubusercontent.com/u/583231",
+      name: null,
+    });
+    expect(result.type).toBe("user");
+  });
+
+  it("TrackedUserSchema accepts type:'bot'", () => {
+    const result = TrackedUserSchema.parse({
+      login: "dependabot[bot]",
+      avatarUrl: "https://avatars.githubusercontent.com/u/27347476",
+      name: null,
+      type: "bot",
+    });
+    expect(result.type).toBe("bot");
+  });
+
+  it("TrackedUserSchema accepts type:'user'", () => {
+    const result = TrackedUserSchema.parse({
+      login: "octocat",
+      avatarUrl: "https://avatars.githubusercontent.com/u/583231",
+      name: null,
+      type: "user",
+    });
+    expect(result.type).toBe("user");
+  });
+
+  it("TrackedUserSchema rejects invalid type value", () => {
+    expect(() => TrackedUserSchema.parse({
+      login: "octocat",
+      avatarUrl: "https://avatars.githubusercontent.com/u/583231",
+      name: null,
+      type: "organization",
+    })).toThrow();
+  });
+
+  it("ConfigSchema preserves tracked user type through round-trip", () => {
+    const result = ConfigSchema.parse({
+      trackedUsers: [
+        {
+          login: "dependabot[bot]",
+          avatarUrl: "https://avatars.githubusercontent.com/u/27347476",
+          name: null,
+          type: "bot",
+        },
+      ],
+    });
+    expect(result.trackedUsers[0].type).toBe("bot");
   });
 });
 
@@ -323,7 +375,7 @@ describe("updateConfig (real export)", () => {
     ["selectedOrgs", { selectedOrgs: ["new-org"] }],
     ["selectedRepos", { selectedRepos: [{ owner: "x", name: "y", fullName: "x/y" }] }],
     ["upstreamRepos", { upstreamRepos: [{ owner: "u", name: "v", fullName: "u/v" }] }],
-    ["trackedUsers", { trackedUsers: [{ login: "bob", avatarUrl: "https://avatars.githubusercontent.com/u/1", name: null }] }],
+    ["trackedUsers", { trackedUsers: [{ login: "bob", avatarUrl: "https://avatars.githubusercontent.com/u/1", name: null, type: "user" as const }] }],
     ["refreshInterval", { refreshInterval: 120 }],
     ["hotPollInterval", { hotPollInterval: 60 }],
     ["maxWorkflowsPerRepo", { maxWorkflowsPerRepo: 10 }],
@@ -343,7 +395,7 @@ describe("updateConfig (real export)", () => {
         selectedOrgs: ["seed-org"],
         selectedRepos: [{ owner: "s", name: "r", fullName: "s/r" }],
         upstreamRepos: [{ owner: "a", name: "b", fullName: "a/b" }],
-        trackedUsers: [{ login: "alice", avatarUrl: "https://avatars.githubusercontent.com/u/2", name: "Alice" }],
+        trackedUsers: [{ login: "alice", avatarUrl: "https://avatars.githubusercontent.com/u/2", name: "Alice", type: "user" as const }],
         refreshInterval: 600,
         hotPollInterval: 45,
         maxWorkflowsPerRepo: 8,
@@ -373,11 +425,143 @@ describe("updateConfig (real export)", () => {
       // Every OTHER field must be identical to the snapshot
       for (const key of Object.keys(before)) {
         if (key === fieldName) continue;
+        // monitoredRepos is pruned when selectedRepos changes — skip the cross-check for that case
+        if (fieldName === "selectedRepos" && key === "monitoredRepos") continue;
         expect(
           (config as Record<string, unknown>)[key],
           `updateConfig({ ${fieldName} }) must not change ${key}`
         ).toEqual((before as Record<string, unknown>)[key]);
       }
+      dispose();
+    });
+  });
+});
+
+// ── monitoredRepos config schema + setMonitoredRepo (C3) ─────────────────────
+
+describe("ConfigSchema — monitoredRepos", () => {
+  it("defaults monitoredRepos to empty array", () => {
+    const result = ConfigSchema.parse({});
+    expect(result.monitoredRepos).toEqual([]);
+  });
+
+  it("accepts valid monitoredRepos", () => {
+    const result = ConfigSchema.parse({
+      monitoredRepos: [{ owner: "org", name: "repo", fullName: "org/repo" }],
+    });
+    expect(result.monitoredRepos).toHaveLength(1);
+    expect(result.monitoredRepos[0].fullName).toBe("org/repo");
+  });
+});
+
+describe("updateConfig — monitoredRepos pruning on selectedRepos change", () => {
+  beforeEach(() => {
+    resetConfig();
+  });
+
+  it("prunes monitoredRepos when selectedRepos removes a repo", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [
+          { owner: "org", name: "a", fullName: "org/a" },
+          { owner: "org", name: "b", fullName: "org/b" },
+        ],
+        monitoredRepos: [
+          { owner: "org", name: "a", fullName: "org/a" },
+          { owner: "org", name: "b", fullName: "org/b" },
+        ],
+      });
+      // Remove org/b from selectedRepos
+      updateConfig({
+        selectedRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+      });
+      expect(config.monitoredRepos).toHaveLength(1);
+      expect(config.monitoredRepos[0].fullName).toBe("org/a");
+      dispose();
+    });
+  });
+
+  it("does not prune monitoredRepos when selectedRepos is not in the update", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+        monitoredRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+      });
+      // Update theme only
+      updateConfig({ theme: "dark" });
+      expect(config.monitoredRepos).toHaveLength(1);
+      dispose();
+    });
+  });
+});
+
+describe("setMonitoredRepo (C3)", () => {
+  beforeEach(() => {
+    resetConfig();
+  });
+
+  it("adds a repo to monitoredRepos when monitored=true and repo is in selectedRepos", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+      });
+      setMonitoredRepo({ owner: "org", name: "a", fullName: "org/a" }, true);
+      expect(config.monitoredRepos).toHaveLength(1);
+      expect(config.monitoredRepos[0].fullName).toBe("org/a");
+      dispose();
+    });
+  });
+
+  it("is idempotent — adding same repo twice results in one entry", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+      });
+      setMonitoredRepo({ owner: "org", name: "a", fullName: "org/a" }, true);
+      setMonitoredRepo({ owner: "org", name: "a", fullName: "org/a" }, true);
+      expect(config.monitoredRepos).toHaveLength(1);
+      dispose();
+    });
+  });
+
+  it("removes a repo from monitoredRepos when monitored=false", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [
+          { owner: "org", name: "a", fullName: "org/a" },
+          { owner: "org", name: "b", fullName: "org/b" },
+        ],
+        monitoredRepos: [
+          { owner: "org", name: "a", fullName: "org/a" },
+          { owner: "org", name: "b", fullName: "org/b" },
+        ],
+      });
+      setMonitoredRepo({ owner: "org", name: "a", fullName: "org/a" }, false);
+      expect(config.monitoredRepos).toHaveLength(1);
+      expect(config.monitoredRepos[0].fullName).toBe("org/b");
+      dispose();
+    });
+  });
+
+  it("is idempotent — removing non-monitored repo is a no-op", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+        monitoredRepos: [],
+      });
+      setMonitoredRepo({ owner: "org", name: "a", fullName: "org/a" }, false);
+      expect(config.monitoredRepos).toHaveLength(0);
+      dispose();
+    });
+  });
+
+  it("rejects repo not in selectedRepos — does not add to monitoredRepos", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [{ owner: "org", name: "a", fullName: "org/a" }],
+      });
+      setMonitoredRepo({ owner: "org", name: "notselected", fullName: "org/notselected" }, true);
+      expect(config.monitoredRepos).toHaveLength(0);
       dispose();
     });
   });


### PR DESCRIPTION
## Summary
- Adds bot account tracking (expanded login regex, type detection, bot badge) in the existing tracked users system
- Adds per-repo monitor-all mode with unfiltered GraphQL search, surfacedBy filter bypass, and eye icon toggle in RepoSelector
- Includes 50 new tests (1250 total), all passing with clean typecheck