### PR TITLE
feat(ui): adds created and updated date display to issue and PR rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dashboard SPA tracking GitHub issues, PRs, and GHA workflow runs across multiple
 
 ## Features
 
-- **Issues Tab** — Open issues where you're the creator, assignee, or mentioned. Sortable, filterable, paginated.
+- **Issues Tab** — Open issues where you're the creator, assignee, or mentioned. Sortable, filterable, paginated. Dependency Dashboard issues hidden by default (toggleable).
 - **Pull Requests Tab** — Open PRs with CI check status indicators (green/yellow/red dots). Draft badges, reviewer names.
 - **Actions Tab** — GHA workflow runs grouped by repo and workflow. Accordion collapse, PR run toggle.
 - **Onboarding Wizard** — Two-step org/repo selection with search filtering and bulk select.

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -11,7 +11,7 @@ import type { FilterChipGroupDef } from "../shared/FilterChips";
 import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import RepoLockControls from "../shared/RepoLockControls";
-import ExternalLinkIcon from "../shared/ExternalLinkIcon";
+import RepoGitHubLink from "../shared/RepoGitHubLink";
 import { orderRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
@@ -320,16 +320,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                       </span>
                     </Show>
                   </button>
-                  <a
-                    href={`https://github.com/${repoGroup.repoFullName}/actions`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
-                    title={`Open ${repoGroup.repoFullName} actions on GitHub`}
-                    aria-label={`Open ${repoGroup.repoFullName} actions on GitHub`}
-                  >
-                    <ExternalLinkIcon />
-                  </a>
+                  <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
                   <RepoLockControls tab="actions" repoFullName={repoGroup.repoFullName} />
                 </div>
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -19,6 +19,7 @@ interface ActionsTabProps {
   workflowRuns: WorkflowRun[];
   loading?: boolean;
   hasUpstreamRepos?: boolean;
+  refreshTick?: number;
   hotPollingRunIds?: ReadonlySet<number>;
 }
 
@@ -347,6 +348,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                               onToggle={() => toggleWorkflow(wfKey)}
                               onIgnoreRun={handleIgnore}
                               density={config.viewDensity}
+                              refreshTick={props.refreshTick}
                               hotPollingRunIds={props.hotPollingRunIds}
                               flashingRunIds={flashingRunIds()}
                             />

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -296,6 +296,17 @@ export default function ActionsTab(props: ActionsTabProps) {
                   >
                     <ChevronIcon size="md" rotated={!isExpanded()} />
                     {repoGroup.repoFullName}
+                    <a
+                      href={`https://github.com/${repoGroup.repoFullName}/actions`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary"
+                      title={`Open ${repoGroup.repoFullName} actions on GitHub`}
+                      aria-label={`Open ${repoGroup.repoFullName} actions on GitHub`}
+                    >
+                      <ExternalLinkIcon />
+                    </a>
                     <Show when={!isExpanded()}>
                       <span class="ml-auto text-xs font-normal text-base-content/60">
                         {collapsedSummary().total} workflow{collapsedSummary().total !== 1 ? "s" : ""}
@@ -320,16 +331,6 @@ export default function ActionsTab(props: ActionsTabProps) {
                       </span>
                     </Show>
                   </button>
-                  <a
-                    href={`https://github.com/${repoGroup.repoFullName}/actions`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
-                    title={`Open ${repoGroup.repoFullName} actions on GitHub`}
-                    aria-label={`Open ${repoGroup.repoFullName} actions on GitHub`}
-                  >
-                    <ExternalLinkIcon />
-                  </a>
                   <RepoLockControls tab="actions" repoFullName={repoGroup.repoFullName} />
                 </div>
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -11,6 +11,7 @@ import type { FilterChipGroupDef } from "../shared/FilterChips";
 import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import RepoLockControls from "../shared/RepoLockControls";
+import ExternalLinkIcon from "../shared/ExternalLinkIcon";
 import { orderRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
@@ -319,6 +320,16 @@ export default function ActionsTab(props: ActionsTabProps) {
                       </span>
                     </Show>
                   </button>
+                  <a
+                    href={`https://github.com/${repoGroup.repoFullName}/actions`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+                    title={`Open ${repoGroup.repoFullName} actions on GitHub`}
+                    aria-label={`Open ${repoGroup.repoFullName} actions on GitHub`}
+                  >
+                    <ExternalLinkIcon />
+                  </a>
                   <RepoLockControls tab="actions" repoFullName={repoGroup.repoFullName} />
                 </div>
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -296,17 +296,6 @@ export default function ActionsTab(props: ActionsTabProps) {
                   >
                     <ChevronIcon size="md" rotated={!isExpanded()} />
                     {repoGroup.repoFullName}
-                    <a
-                      href={`https://github.com/${repoGroup.repoFullName}/actions`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary"
-                      title={`Open ${repoGroup.repoFullName} actions on GitHub`}
-                      aria-label={`Open ${repoGroup.repoFullName} actions on GitHub`}
-                    >
-                      <ExternalLinkIcon />
-                    </a>
                     <Show when={!isExpanded()}>
                       <span class="ml-auto text-xs font-normal text-base-content/60">
                         {collapsedSummary().total} workflow{collapsedSummary().total !== 1 ? "s" : ""}
@@ -331,6 +320,16 @@ export default function ActionsTab(props: ActionsTabProps) {
                       </span>
                     </Show>
                   </button>
+                  <a
+                    href={`https://github.com/${repoGroup.repoFullName}/actions`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+                    title={`Open ${repoGroup.repoFullName} actions on GitHub`}
+                    aria-label={`Open ${repoGroup.repoFullName} actions on GitHub`}
+                  >
+                    <ExternalLinkIcon />
+                  </a>
                   <RepoLockControls tab="actions" repoFullName={repoGroup.repoFullName} />
                 </div>
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -315,7 +315,12 @@ export default function DashboardPage() {
     });
   });
 
-  const refreshTick = createMemo(() => dashboardData.lastRefreshedAt?.getTime() ?? 0);
+  // Wall-clock tick keeps relative time displays fresh between full poll cycles.
+  const [clockTick, setClockTick] = createSignal(0);
+  const clockInterval = setInterval(() => setClockTick((t) => t + 1), 60_000);
+  onCleanup(() => clearInterval(clockInterval));
+
+  const refreshTick = createMemo(() => (dashboardData.lastRefreshedAt?.getTime() ?? 0) + clockTick());
 
   const tabCounts = createMemo(() => ({
     issues: dashboardData.issues.length,

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -383,6 +383,7 @@ export default function DashboardPage() {
                   workflowRuns={dashboardData.workflowRuns}
                   loading={dashboardData.loading}
                   hasUpstreamRepos={config.upstreamRepos.length > 0}
+                  refreshTick={refreshTick()}
                   hotPollingRunIds={hotPollingRunIds()}
                 />
               </Match>

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -315,6 +315,8 @@ export default function DashboardPage() {
     });
   });
 
+  const refreshTick = createMemo(() => dashboardData.lastRefreshedAt?.getTime() ?? 0);
+
   const tabCounts = createMemo(() => ({
     issues: dashboardData.issues.length,
     pullRequests: dashboardData.pullRequests.length,
@@ -361,6 +363,7 @@ export default function DashboardPage() {
                   allUsers={allUsers()}
                   trackedUsers={config.trackedUsers}
                   monitoredRepos={config.monitoredRepos}
+                  refreshTick={refreshTick()}
                 />
               </Match>
               <Match when={activeTab() === "pullRequests"}>
@@ -372,6 +375,7 @@ export default function DashboardPage() {
                   trackedUsers={config.trackedUsers}
                   hotPollingPRIds={hotPollingPRIds()}
                   monitoredRepos={config.monitoredRepos}
+                  refreshTick={refreshTick()}
                 />
               </Match>
               <Match when={activeTab() === "actions"}>

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -343,22 +343,23 @@ export default function DashboardPage() {
       <Header />
 
       {/* Offset for fixed header */}
-      <div class="pt-14 flex flex-col h-screen">
-        {/* Single constrained panel: tabs + filters + content */}
-        <div class="max-w-6xl mx-auto w-full flex flex-col flex-1 min-h-0 bg-base-100 shadow-lg border-x border-base-300">
-          <TabBar
-            activeTab={activeTab()}
-            onTabChange={handleTabChange}
-            counts={tabCounts()}
-          />
+      <div class="pt-14 min-h-[calc(100vh-3.5rem)] flex flex-col">
+        <div class="max-w-6xl mx-auto w-full bg-base-100 shadow-lg border-x border-base-300 flex-1">
+          <div class="sticky top-14 z-40 bg-base-100">
+            <TabBar
+              activeTab={activeTab()}
+              onTabChange={handleTabChange}
+              counts={tabCounts()}
+            />
 
-          <FilterBar
-            isRefreshing={_coordinator()?.isRefreshing() ?? dashboardData.loading}
-            lastRefreshedAt={_coordinator()?.lastRefreshAt() ?? dashboardData.lastRefreshedAt}
-            onRefresh={() => _coordinator()?.manualRefresh()}
-          />
+            <FilterBar
+              isRefreshing={_coordinator()?.isRefreshing() ?? dashboardData.loading}
+              lastRefreshedAt={_coordinator()?.lastRefreshAt() ?? dashboardData.lastRefreshedAt}
+              onRefresh={() => _coordinator()?.manualRefresh()}
+            />
+          </div>
 
-          <main class="flex-1 overflow-auto">
+          <main class="pb-12">
             <Switch>
               <Match when={activeTab() === "issues"}>
                 <IssuesTab
@@ -396,7 +397,7 @@ export default function DashboardPage() {
           </main>
         </div>
 
-        <footer class="border-t border-base-300 bg-base-100 py-3 text-xs text-base-content/50 shrink-0">
+        <footer class="fixed bottom-0 left-0 right-0 z-30 border-t border-base-300 bg-base-100 py-3 text-xs text-base-content/50">
           <div class="max-w-6xl mx-auto w-full px-4 grid grid-cols-3 items-center">
             <div />
             <div class="flex items-center justify-center gap-3">

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -240,6 +240,8 @@ export default function DashboardPage() {
     updateViewState({ lastActiveTab: tab });
   }
 
+  const [clockTick, setClockTick] = createSignal(0);
+
   onMount(() => {
     if (!_coordinator()) {
       _setCoordinator(createPollCoordinator(() => config.refreshInterval, pollFetch));
@@ -306,19 +308,18 @@ export default function DashboardPage() {
       });
     }
 
+    // Wall-clock tick keeps relative time displays fresh between full poll cycles.
+    const clockInterval = setInterval(() => setClockTick((t) => t + 1), 60_000);
+
     onCleanup(() => {
       _coordinator()?.destroy();
       _setCoordinator(null);
       _hotCoordinator()?.destroy();
       _setHotCoordinator(null);
       clearHotSets();
+      clearInterval(clockInterval);
     });
   });
-
-  // Wall-clock tick keeps relative time displays fresh between full poll cycles.
-  const [clockTick, setClockTick] = createSignal(0);
-  const clockInterval = setInterval(() => setClockTick((t) => t + 1), 60_000);
-  onCleanup(() => clearInterval(clockInterval));
 
   const refreshTick = createMemo(() => (dashboardData.lastRefreshedAt?.getTime() ?? 0) + clockTick());
 

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -332,6 +332,17 @@ export default function IssuesTab(props: IssuesTabProps) {
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
                         </Show>
+                        <a
+                          href={`https://github.com/${repoGroup.repoFullName}/issues`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary"
+                          title={`Open ${repoGroup.repoFullName} issues on GitHub`}
+                          aria-label={`Open ${repoGroup.repoFullName} issues on GitHub`}
+                        >
+                          <ExternalLinkIcon />
+                        </a>
                         <Show when={!isExpanded()}>
                           <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
                             <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
@@ -349,16 +360,6 @@ export default function IssuesTab(props: IssuesTabProps) {
                           </span>
                         </Show>
                       </button>
-                      <a
-                        href={`https://github.com/${repoGroup.repoFullName}/issues`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
-                        title={`Open ${repoGroup.repoFullName} issues on GitHub`}
-                        aria-label={`Open ${repoGroup.repoFullName} issues on GitHub`}
-                      >
-                        <ExternalLinkIcon />
-                      </a>
                       <RepoLockControls tab="issues" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={isExpanded()}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -332,17 +332,6 @@ export default function IssuesTab(props: IssuesTabProps) {
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
                         </Show>
-                        <a
-                          href={`https://github.com/${repoGroup.repoFullName}/issues`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                          class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary"
-                          title={`Open ${repoGroup.repoFullName} issues on GitHub`}
-                          aria-label={`Open ${repoGroup.repoFullName} issues on GitHub`}
-                        >
-                          <ExternalLinkIcon />
-                        </a>
                         <Show when={!isExpanded()}>
                           <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
                             <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
@@ -360,6 +349,16 @@ export default function IssuesTab(props: IssuesTabProps) {
                           </span>
                         </Show>
                       </button>
+                      <a
+                        href={`https://github.com/${repoGroup.repoFullName}/issues`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+                        title={`Open ${repoGroup.repoFullName} issues on GitHub`}
+                        aria-label={`Open ${repoGroup.repoFullName} issues on GitHub`}
+                      >
+                        <ExternalLinkIcon />
+                      </a>
                       <RepoLockControls tab="issues" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={isExpanded()}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
-import { viewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type IssueFilterField } from "../../stores/view";
+import { viewState, updateViewState, setSortPreference, setTabFilter, resetTabFilter, resetAllTabFilters, ignoreItem, unignoreItem, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, type IssueFilterField } from "../../stores/view";
 import type { Issue, RepoRef } from "../../services/api";
 import ItemRow from "./ItemRow";
 import UserAvatarBadge, { buildSurfacedByUsers } from "../shared/UserAvatarBadge";
@@ -18,7 +18,7 @@ import { deriveInvolvementRoles } from "../../lib/format";
 import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
-import ExternalLinkIcon from "../shared/ExternalLinkIcon";
+import RepoGitHubLink from "../shared/RepoGitHubLink";
 
 export interface IssuesTabProps {
   issues: Issue[];
@@ -120,7 +120,7 @@ export default function IssuesTab(props: IssuesTabProps) {
         if (tabFilter.comments === "none" && issue.comments > 0) return false;
       }
 
-      if (tabFilter.depDashboard === "hide" && issue.title === "Dependency Dashboard") return false;
+      if (viewState.hideDepDashboard && issue.title === "Dependency Dashboard") return false;
 
       if (tabFilter.user !== "all") {
         // Items from monitored repos bypass the surfacedBy filter (all activity is shown)
@@ -248,12 +248,11 @@ export default function IssuesTab(props: IssuesTabProps) {
         />
         <button
           onClick={() => {
-            const next = viewState.tabFilters.issues.depDashboard === "show" ? "hide" : "show";
-            setTabFilter("issues", "depDashboard", next);
+            updateViewState({ hideDepDashboard: !viewState.hideDepDashboard });
             setPage(0);
           }}
-          class={`btn btn-xs rounded-full ${viewState.tabFilters.issues.depDashboard === "show" ? "btn-primary" : "btn-ghost text-base-content/50"}`}
-          aria-pressed={viewState.tabFilters.issues.depDashboard === "show"}
+          class={`btn btn-xs rounded-full ${!viewState.hideDepDashboard ? "btn-primary" : "btn-ghost text-base-content/50"}`}
+          aria-pressed={!viewState.hideDepDashboard}
           title="Toggle visibility of Dependency Dashboard issues"
         >
           Show Dep Dashboard
@@ -349,16 +348,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                           </span>
                         </Show>
                       </button>
-                      <a
-                        href={`https://github.com/${repoGroup.repoFullName}/issues`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
-                        title={`Open ${repoGroup.repoFullName} issues on GitHub`}
-                        aria-label={`Open ${repoGroup.repoFullName} issues on GitHub`}
-                      >
-                        <ExternalLinkIcon />
-                      </a>
+                      <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
                       <RepoLockControls tab="issues" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={isExpanded()}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -26,6 +26,7 @@ export interface IssuesTabProps {
   allUsers?: { login: string; label: string }[];
   trackedUsers?: TrackedUser[];
   monitoredRepos?: RepoRef[];
+  refreshTick?: number;
 }
 
 type SortField = "repo" | "title" | "author" | "createdAt" | "updatedAt" | "comments";
@@ -347,6 +348,8 @@ export default function IssuesTab(props: IssuesTabProps) {
                                 title={issue.title}
                                 author={issue.userLogin}
                                 createdAt={issue.createdAt}
+                                updatedAt={issue.updatedAt}
+                                refreshTick={props.refreshTick}
                                 url={issue.htmlUrl}
                                 labels={issue.labels}
                                 onIgnore={() => handleIgnore(issue)}

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -18,6 +18,7 @@ import { deriveInvolvementRoles } from "../../lib/format";
 import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
+import ExternalLinkIcon from "../shared/ExternalLinkIcon";
 
 export interface IssuesTabProps {
   issues: Issue[];
@@ -118,6 +119,8 @@ export default function IssuesTab(props: IssuesTabProps) {
         if (tabFilter.comments === "has" && issue.comments === 0) return false;
         if (tabFilter.comments === "none" && issue.comments > 0) return false;
       }
+
+      if (tabFilter.depDashboard === "hide" && issue.title === "Dependency Dashboard") return false;
 
       if (tabFilter.user !== "all") {
         // Items from monitored repos bypass the surfacedBy filter (all activity is shown)
@@ -220,7 +223,7 @@ export default function IssuesTab(props: IssuesTabProps) {
   return (
     <div class="flex flex-col h-full">
       {/* Sort dropdown + filter chips + ignore badge toolbar */}
-      <div class="flex items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
+      <div class="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
         <SortDropdown
           options={sortOptions}
           value={sortPref().field}
@@ -243,6 +246,18 @@ export default function IssuesTab(props: IssuesTabProps) {
             setPage(0);
           }}
         />
+        <button
+          onClick={() => {
+            const next = viewState.tabFilters.issues.depDashboard === "show" ? "hide" : "show";
+            setTabFilter("issues", "depDashboard", next);
+            setPage(0);
+          }}
+          class={`btn btn-xs rounded-full ${viewState.tabFilters.issues.depDashboard === "show" ? "btn-primary" : "btn-ghost text-base-content/50"}`}
+          aria-pressed={viewState.tabFilters.issues.depDashboard === "show"}
+          title="Toggle visibility of Dependency Dashboard issues"
+        >
+          Show Dep Dashboard
+        </button>
         <div class="flex-1" />
         <ExpandCollapseButtons
           onExpandAll={() => setAllExpanded("issues", repoGroups().map((g) => g.repoFullName), true)}
@@ -334,6 +349,16 @@ export default function IssuesTab(props: IssuesTabProps) {
                           </span>
                         </Show>
                       </button>
+                      <a
+                        href={`https://github.com/${repoGroup.repoFullName}/issues`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+                        title={`Open ${repoGroup.repoFullName} issues on GitHub`}
+                        aria-label={`Open ${repoGroup.repoFullName} issues on GitHub`}
+                      >
+                        <ExternalLinkIcon />
+                      </a>
                       <RepoLockControls tab="issues" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={isExpanded()}>

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -27,19 +27,28 @@ export default function ItemRow(props: ItemRowProps) {
   const isCompact = () => props.density === "compact";
   const safeUrl = () => isSafeGitHubUrl(props.url) ? props.url : undefined;
 
-  const timeInfo = createMemo(() => {
+  // Static date info — recomputed only when createdAt/updatedAt change (not on tick)
+  const staticDateInfo = createMemo(() => {
+    const createdTitle = `Created: ${new Date(props.createdAt).toLocaleString()}`;
+    const updatedTitle = `Updated: ${new Date(props.updatedAt).toLocaleString()}`;
+    const diffMs = Date.parse(props.updatedAt) - Date.parse(props.createdAt);
+    return { createdTitle, updatedTitle, diffMs };
+  });
+
+  // Reactive date display — re-run on refreshTick to keep relative times current.
+  // Date.now() is not reactive in SolidJS; refreshTick is the explicit invalidation signal.
+  const dateDisplay = createMemo(() => {
     void props.refreshTick;
     const created = shortRelativeTime(props.createdAt);
     const updated = shortRelativeTime(props.updatedAt);
     const createdLabel = `Created ${relativeTime(props.createdAt)}`;
     const updatedLabel = `Updated ${relativeTime(props.updatedAt)}`;
-    const createdTitle = `Created: ${new Date(props.createdAt).toLocaleString()}`;
-    const updatedTitle = `Updated: ${new Date(props.updatedAt).toLocaleString()}`;
-    const diffMs = Date.parse(props.updatedAt) - Date.parse(props.createdAt);
-    return { created, updated, createdLabel, updatedLabel, createdTitle, updatedTitle, diffMs };
+    return { created, updated, createdLabel, updatedLabel };
   });
+
   const hasUpdate = createMemo(() => {
-    const { diffMs, created, updated } = timeInfo();
+    const { diffMs } = staticDateInfo();
+    const { created, updated } = dateDisplay();
     if (diffMs <= 60_000) return false;
     return created !== "" && updated !== "" && created !== updated;
   });
@@ -124,19 +133,19 @@ export default function ItemRow(props: ItemRowProps) {
         <span class="inline-flex items-center gap-1 whitespace-nowrap">
           <time
             datetime={props.createdAt}
-            title={timeInfo().createdTitle}
-            aria-label={timeInfo().createdLabel}
+            title={staticDateInfo().createdTitle}
+            aria-label={dateDisplay().createdLabel}
           >
-            {timeInfo().created}
+            {dateDisplay().created}
           </time>
           <Show when={hasUpdate()}>
             <span aria-hidden="true">{"\u00B7"}</span>
             <time
               datetime={props.updatedAt}
-              title={timeInfo().updatedTitle}
-              aria-label={timeInfo().updatedLabel}
+              title={staticDateInfo().updatedTitle}
+              aria-label={dateDisplay().updatedLabel}
             >
-              {timeInfo().updated}
+              {dateDisplay().updated}
             </time>
           </Show>
         </span>

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -35,7 +35,9 @@ export default function ItemRow(props: ItemRowProps) {
     return { createdTitle, updatedTitle, diffMs };
   });
 
-  // void refreshTick — Date.now() is not reactive in SolidJS
+  // Reading props.refreshTick registers it as a SolidJS reactive dependency,
+  // forcing this memo to re-evaluate when the tick changes. Date.now() alone
+  // is not tracked by SolidJS's dependency system.
   const dateDisplay = createMemo(() => {
     void props.refreshTick;
     const created = shortRelativeTime(props.createdAt);

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -122,20 +122,22 @@ export default function ItemRow(props: ItemRowProps) {
           <div class="relative z-10">{props.surfacedByBadge}</div>
         </Show>
         <span class="inline-flex items-center gap-1 whitespace-nowrap">
-          <span
+          <time
+            datetime={props.createdAt}
             title={timeInfo().createdTitle}
             aria-label={timeInfo().createdLabel}
           >
             {timeInfo().created}
-          </span>
+          </time>
           <Show when={hasUpdate()}>
             <span aria-hidden="true">{"\u00B7"}</span>
-            <span
+            <time
+              datetime={props.updatedAt}
               title={timeInfo().updatedTitle}
               aria-label={timeInfo().updatedLabel}
             >
               {timeInfo().updated}
-            </span>
+            </time>
           </Show>
         </span>
         <Show when={props.isPolling}>

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -48,8 +48,8 @@ export default function ItemRow(props: ItemRowProps) {
 
   const hasUpdate = createMemo(() => {
     const { diffMs } = staticDateInfo();
-    const { created, updated } = dateDisplay();
     if (diffMs <= 60_000) return false;
+    const { created, updated } = dateDisplay();
     return created !== "" && updated !== "" && created !== updated;
   });
 

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -1,6 +1,6 @@
-import { For, JSX, Show } from "solid-js";
+import { createMemo, For, JSX, Show } from "solid-js";
 import { isSafeGitHubUrl } from "../../lib/url";
-import { relativeTime, labelTextColor, formatCount } from "../../lib/format";
+import { relativeTime, shortRelativeTime, labelTextColor, formatCount } from "../../lib/format";
 import { expandEmoji } from "../../lib/emoji";
 
 export interface ItemRowProps {
@@ -9,6 +9,8 @@ export interface ItemRowProps {
   title: string;
   author: string;
   createdAt: string;
+  updatedAt: string;
+  refreshTick?: number;
   url: string;
   labels: { name: string; color: string }[];
   children?: JSX.Element;
@@ -24,6 +26,28 @@ export interface ItemRowProps {
 export default function ItemRow(props: ItemRowProps) {
   const isCompact = () => props.density === "compact";
   const safeUrl = () => isSafeGitHubUrl(props.url) ? props.url : undefined;
+
+  const createdDisplay = createMemo(() => {
+    void props.refreshTick;
+    return shortRelativeTime(props.createdAt);
+  });
+  const updatedDisplay = createMemo(() => {
+    void props.refreshTick;
+    return shortRelativeTime(props.updatedAt);
+  });
+  const createdAriaLabel = createMemo(() => {
+    void props.refreshTick;
+    return `Created ${relativeTime(props.createdAt)}`;
+  });
+  const updatedAriaLabel = createMemo(() => {
+    void props.refreshTick;
+    return `Updated ${relativeTime(props.updatedAt)}`;
+  });
+  const hasUpdate = createMemo(() => {
+    const diff = new Date(props.updatedAt).getTime() - new Date(props.createdAt).getTime();
+    if (diff <= 60_000) return false;
+    return createdDisplay() !== updatedDisplay();
+  });
 
   return (
     <div
@@ -102,7 +126,23 @@ export default function ItemRow(props: ItemRowProps) {
         <Show when={props.surfacedByBadge !== undefined}>
           <div class="relative z-10">{props.surfacedByBadge}</div>
         </Show>
-        <span title={props.createdAt}>{relativeTime(props.createdAt)}</span>
+        <span class="inline-flex items-center gap-1 whitespace-nowrap">
+          <span
+            title={`Created: ${props.createdAt}`}
+            aria-label={createdAriaLabel()}
+          >
+            {createdDisplay()}
+          </span>
+          <Show when={hasUpdate()}>
+            <span aria-hidden="true">{"\u00B7"}</span>
+            <span
+              title={`Updated: ${props.updatedAt}`}
+              aria-label={updatedAriaLabel()}
+            >
+              {updatedDisplay()}
+            </span>
+          </Show>
+        </span>
         <Show when={props.isPolling}>
           <span class="loading loading-spinner loading-xs text-base-content/40" />
         </Show>

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -27,26 +27,19 @@ export default function ItemRow(props: ItemRowProps) {
   const isCompact = () => props.density === "compact";
   const safeUrl = () => isSafeGitHubUrl(props.url) ? props.url : undefined;
 
-  const createdDisplay = createMemo(() => {
+  const timeInfo = createMemo(() => {
     void props.refreshTick;
-    return shortRelativeTime(props.createdAt);
-  });
-  const updatedDisplay = createMemo(() => {
-    void props.refreshTick;
-    return shortRelativeTime(props.updatedAt);
-  });
-  const createdAriaLabel = createMemo(() => {
-    void props.refreshTick;
-    return `Created ${relativeTime(props.createdAt)}`;
-  });
-  const updatedAriaLabel = createMemo(() => {
-    void props.refreshTick;
-    return `Updated ${relativeTime(props.updatedAt)}`;
+    const created = shortRelativeTime(props.createdAt);
+    const updated = shortRelativeTime(props.updatedAt);
+    const createdLabel = `Created ${relativeTime(props.createdAt)}`;
+    const updatedLabel = `Updated ${relativeTime(props.updatedAt)}`;
+    return { created, updated, createdLabel, updatedLabel };
   });
   const hasUpdate = createMemo(() => {
     const diff = new Date(props.updatedAt).getTime() - new Date(props.createdAt).getTime();
     if (diff <= 60_000) return false;
-    return createdDisplay() !== updatedDisplay();
+    if (timeInfo().created === "" || timeInfo().updated === "") return false;
+    return timeInfo().created !== timeInfo().updated;
   });
 
   return (
@@ -128,18 +121,18 @@ export default function ItemRow(props: ItemRowProps) {
         </Show>
         <span class="inline-flex items-center gap-1 whitespace-nowrap">
           <span
-            title={`Created: ${props.createdAt}`}
-            aria-label={createdAriaLabel()}
+            title={`Created: ${new Date(props.createdAt).toLocaleString()}`}
+            aria-label={timeInfo().createdLabel}
           >
-            {createdDisplay()}
+            {timeInfo().created}
           </span>
           <Show when={hasUpdate()}>
             <span aria-hidden="true">{"\u00B7"}</span>
             <span
-              title={`Updated: ${props.updatedAt}`}
-              aria-label={updatedAriaLabel()}
+              title={`Updated: ${new Date(props.updatedAt).toLocaleString()}`}
+              aria-label={timeInfo().updatedLabel}
             >
-              {updatedDisplay()}
+              {timeInfo().updated}
             </span>
           </Show>
         </span>

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -38,8 +38,8 @@ export default function ItemRow(props: ItemRowProps) {
   const hasUpdate = createMemo(() => {
     const diff = new Date(props.updatedAt).getTime() - new Date(props.createdAt).getTime();
     if (diff <= 60_000) return false;
-    if (timeInfo().created === "" || timeInfo().updated === "") return false;
-    return timeInfo().created !== timeInfo().updated;
+    const { created, updated } = timeInfo();
+    return created !== "" && updated !== "" && created !== updated;
   });
 
   return (

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -35,8 +35,7 @@ export default function ItemRow(props: ItemRowProps) {
     return { createdTitle, updatedTitle, diffMs };
   });
 
-  // Reactive date display — re-run on refreshTick to keep relative times current.
-  // Date.now() is not reactive in SolidJS; refreshTick is the explicit invalidation signal.
+  // void refreshTick — Date.now() is not reactive in SolidJS
   const dateDisplay = createMemo(() => {
     void props.refreshTick;
     const created = shortRelativeTime(props.createdAt);
@@ -46,7 +45,7 @@ export default function ItemRow(props: ItemRowProps) {
     return { created, updated, createdLabel, updatedLabel };
   });
 
-  const hasUpdate = createMemo(() => {
+  const shouldShowUpdated = createMemo(() => {
     const { diffMs } = staticDateInfo();
     if (diffMs <= 60_000) return false;
     const { created, updated } = dateDisplay();
@@ -138,7 +137,7 @@ export default function ItemRow(props: ItemRowProps) {
           >
             {dateDisplay().created}
           </time>
-          <Show when={hasUpdate()}>
+          <Show when={shouldShowUpdated()}>
             <span aria-hidden="true">{"\u00B7"}</span>
             <time
               datetime={props.updatedAt}

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -33,12 +33,14 @@ export default function ItemRow(props: ItemRowProps) {
     const updated = shortRelativeTime(props.updatedAt);
     const createdLabel = `Created ${relativeTime(props.createdAt)}`;
     const updatedLabel = `Updated ${relativeTime(props.updatedAt)}`;
-    return { created, updated, createdLabel, updatedLabel };
+    const createdTitle = `Created: ${new Date(props.createdAt).toLocaleString()}`;
+    const updatedTitle = `Updated: ${new Date(props.updatedAt).toLocaleString()}`;
+    const diffMs = Date.parse(props.updatedAt) - Date.parse(props.createdAt);
+    return { created, updated, createdLabel, updatedLabel, createdTitle, updatedTitle, diffMs };
   });
   const hasUpdate = createMemo(() => {
-    const diff = new Date(props.updatedAt).getTime() - new Date(props.createdAt).getTime();
-    if (diff <= 60_000) return false;
-    const { created, updated } = timeInfo();
+    const { diffMs, created, updated } = timeInfo();
+    if (diffMs <= 60_000) return false;
     return created !== "" && updated !== "" && created !== updated;
   });
 
@@ -121,7 +123,7 @@ export default function ItemRow(props: ItemRowProps) {
         </Show>
         <span class="inline-flex items-center gap-1 whitespace-nowrap">
           <span
-            title={`Created: ${new Date(props.createdAt).toLocaleString()}`}
+            title={timeInfo().createdTitle}
             aria-label={timeInfo().createdLabel}
           >
             {timeInfo().created}
@@ -129,7 +131,7 @@ export default function ItemRow(props: ItemRowProps) {
           <Show when={hasUpdate()}>
             <span aria-hidden="true">{"\u00B7"}</span>
             <span
-              title={`Updated: ${new Date(props.updatedAt).toLocaleString()}`}
+              title={timeInfo().updatedTitle}
               aria-label={timeInfo().updatedLabel}
             >
               {timeInfo().updated}

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -431,17 +431,6 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
                         </Show>
-                        <a
-                          href={`https://github.com/${repoGroup.repoFullName}/pulls`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                          class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary"
-                          title={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
-                          aria-label={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
-                        >
-                          <ExternalLinkIcon />
-                        </a>
                         <Show when={!isExpanded()}>
                           <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
                             <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
@@ -501,6 +490,16 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                           </span>
                         </Show>
                       </button>
+                      <a
+                        href={`https://github.com/${repoGroup.repoFullName}/pulls`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+                        title={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
+                        aria-label={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
+                      >
+                        <ExternalLinkIcon />
+                      </a>
                       <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -22,6 +22,7 @@ import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups } from
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
 import RepoLockControls from "../shared/RepoLockControls";
+import ExternalLinkIcon from "../shared/ExternalLinkIcon";
 
 export interface PullRequestsTabProps {
   pullRequests: PullRequest[];
@@ -489,6 +490,16 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                           </span>
                         </Show>
                       </button>
+                      <a
+                        href={`https://github.com/${repoGroup.repoFullName}/pulls`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+                        title={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
+                        aria-label={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
+                      >
+                        <ExternalLinkIcon />
+                      </a>
                       <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -321,7 +321,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   return (
     <div class="flex flex-col h-full">
       {/* Filter toolbar with SortDropdown */}
-      <div class="flex items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
+      <div class="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
         <SortDropdown
           options={sortOptions}
           value={sortPref().field}

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -431,6 +431,17 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
                         </Show>
+                        <a
+                          href={`https://github.com/${repoGroup.repoFullName}/pulls`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary"
+                          title={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
+                          aria-label={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
+                        >
+                          <ExternalLinkIcon />
+                        </a>
                         <Show when={!isExpanded()}>
                           <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
                             <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
@@ -490,16 +501,6 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                           </span>
                         </Show>
                       </button>
-                      <a
-                        href={`https://github.com/${repoGroup.repoFullName}/pulls`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
-                        title={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
-                        aria-label={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
-                      >
-                        <ExternalLinkIcon />
-                      </a>
                       <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -31,6 +31,7 @@ export interface PullRequestsTabProps {
   trackedUsers?: TrackedUser[];
   hotPollingPRIds?: ReadonlySet<number>;
   monitoredRepos?: RepoRef[];
+  refreshTick?: number;
 }
 
 type SortField = "repo" | "title" | "author" | "createdAt" | "updatedAt" | "checkStatus" | "reviewDecision" | "size";
@@ -511,6 +512,8 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                                 title={pr.title}
                                 author={pr.userLogin}
                                 createdAt={pr.createdAt}
+                                updatedAt={pr.updatedAt}
+                                refreshTick={props.refreshTick}
                                 url={pr.htmlUrl}
                                 labels={pr.labels}
                                 commentCount={pr.enriched !== false ? pr.comments + pr.reviewThreads : undefined}

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -22,7 +22,7 @@ import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups } from
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
 import RepoLockControls from "../shared/RepoLockControls";
-import ExternalLinkIcon from "../shared/ExternalLinkIcon";
+import RepoGitHubLink from "../shared/RepoGitHubLink";
 
 export interface PullRequestsTabProps {
   pullRequests: PullRequest[];
@@ -490,16 +490,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                           </span>
                         </Show>
                       </button>
-                      <a
-                        href={`https://github.com/${repoGroup.repoFullName}/pulls`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
-                        title={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
-                        aria-label={`Open ${repoGroup.repoFullName} pull requests on GitHub`}
-                      >
-                        <ExternalLinkIcon />
-                      </a>
+                      <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
                       <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -132,8 +132,9 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
   const paddingClass = () =>
     props.density === "compact" ? "py-1.5 px-3" : "py-2.5 px-4";
 
-  // Re-run on refreshTick to keep relative time current.
-  // Date.now() is not reactive in SolidJS; refreshTick is the explicit invalidation signal.
+  const createdTitle = createMemo(() => `Created: ${new Date(props.run.createdAt).toLocaleString()}`);
+
+  // void refreshTick — Date.now() is not reactive in SolidJS
   const timeLabel = createMemo(() => {
     void props.refreshTick;
     return relativeTime(props.run.createdAt);
@@ -182,7 +183,7 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
       <time
         class="text-xs text-base-content/40 shrink-0"
         datetime={props.run.createdAt}
-        title={new Date(props.run.createdAt).toLocaleString()}
+        title={createdTitle()}
       >
         {timeLabel()}
       </time>

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -134,7 +134,9 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
 
   const createdTitle = createMemo(() => `Created: ${new Date(props.run.createdAt).toLocaleString()}`);
 
-  // void refreshTick — Date.now() is not reactive in SolidJS
+  // Reading props.refreshTick registers it as a SolidJS reactive dependency,
+  // forcing this memo to re-evaluate when the tick changes. Date.now() alone
+  // is not tracked by SolidJS's dependency system.
   const timeLabel = createMemo(() => {
     void props.refreshTick;
     return relativeTime(props.run.createdAt);

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -1,4 +1,4 @@
-import { Show } from "solid-js";
+import { createMemo, Show } from "solid-js";
 import type { WorkflowRun } from "../../services/api";
 import type { Config } from "../../stores/config";
 import { isSafeGitHubUrl } from "../../lib/url";
@@ -8,6 +8,7 @@ interface WorkflowRunRowProps {
   run: WorkflowRun;
   onIgnore: (run: WorkflowRun) => void;
   density: Config["viewDensity"];
+  refreshTick?: number;
   isPolling?: boolean;
   isFlashing?: boolean;
 }
@@ -131,6 +132,13 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
   const paddingClass = () =>
     props.density === "compact" ? "py-1.5 px-3" : "py-2.5 px-4";
 
+  // Re-run on refreshTick to keep relative time current.
+  // Date.now() is not reactive in SolidJS; refreshTick is the explicit invalidation signal.
+  const timeLabel = createMemo(() => {
+    void props.refreshTick;
+    return relativeTime(props.run.createdAt);
+  });
+
   return (
     <div
       class={`flex items-center gap-3 ${paddingClass()} hover:bg-base-200 group ${props.isFlashing ? "animate-flash" : props.isPolling ? "animate-shimmer" : ""}`}
@@ -171,9 +179,13 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
         {durationLabel(props.run)}
       </span>
 
-      <span class="text-xs text-base-content/40 shrink-0">
-        {relativeTime(props.run.createdAt)}
-      </span>
+      <time
+        class="text-xs text-base-content/40 shrink-0"
+        datetime={props.run.createdAt}
+        title={new Date(props.run.createdAt).toLocaleString()}
+      >
+        {timeLabel()}
+      </time>
 
       <Show when={props.isPolling}>
         <span class="loading loading-spinner loading-xs text-base-content/40" />

--- a/src/app/components/dashboard/WorkflowSummaryCard.tsx
+++ b/src/app/components/dashboard/WorkflowSummaryCard.tsx
@@ -9,6 +9,7 @@ interface WorkflowSummaryCardProps {
   onToggle: () => void;
   onIgnoreRun: (run: WorkflowRun) => void;
   density: "compact" | "comfortable";
+  refreshTick?: number;
   hotPollingRunIds?: ReadonlySet<number>;
   flashingRunIds?: ReadonlySet<number>;
 }
@@ -109,6 +110,7 @@ export default function WorkflowSummaryCard(props: WorkflowSummaryCardProps) {
                 run={run}
                 onIgnore={props.onIgnoreRun}
                 density={props.density}
+                refreshTick={props.refreshTick}
                 isPolling={props.hotPollingRunIds?.has(run.id)}
                 isFlashing={props.flashingRunIds?.has(run.id)}
               />

--- a/src/app/components/shared/ExternalLinkIcon.tsx
+++ b/src/app/components/shared/ExternalLinkIcon.tsx
@@ -1,0 +1,22 @@
+export default function ExternalLinkIcon(props: { class?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      class={props.class ?? "h-3.5 w-3.5"}
+      aria-hidden="true"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M4.25 5.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 17h-8.5A2.25 2.25 0 0 1 2 14.75v-8.5A2.25 2.25 0 0 1 4.25 4h5a.75.75 0 0 1 0 1.5h-5Z"
+        clip-rule="evenodd"
+      />
+      <path
+        fill-rule="evenodd"
+        d="M6.194 12.753a.75.75 0 0 0 1.06.053L16.5 4.44v2.81a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75h-4.5a.75.75 0 0 0 0 1.5h2.553l-9.056 8.194a.75.75 0 0 0-.053 1.06Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/src/app/components/shared/RepoGitHubLink.tsx
+++ b/src/app/components/shared/RepoGitHubLink.tsx
@@ -1,0 +1,27 @@
+import ExternalLinkIcon from "./ExternalLinkIcon";
+
+const sectionLabels = {
+  issues: "issues",
+  pulls: "pull requests",
+  actions: "actions",
+} as const;
+
+export default function RepoGitHubLink(props: {
+  repoFullName: string;
+  section: "issues" | "pulls" | "actions";
+}) {
+  const label = () => sectionLabels[props.section];
+
+  return (
+    <a
+      href={`https://github.com/${props.repoFullName}/${props.section}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+      title={`Open ${props.repoFullName} ${label()} on GitHub`}
+      aria-label={`Open ${props.repoFullName} ${label()} on GitHub`}
+    >
+      <ExternalLinkIcon />
+    </a>
+  );
+}

--- a/src/app/lib/format.ts
+++ b/src/app/lib/format.ts
@@ -64,7 +64,7 @@ export function formatDuration(startedAt: string, completedAt: string | null): s
   if (!startedAt) return "--";
   if (!completedAt) return "--";
   const diffMs = Date.parse(completedAt) - Date.parse(startedAt);
-  if (diffMs <= 0) return "--";
+  if (isNaN(diffMs) || diffMs <= 0) return "--";
   const totalSec = Math.floor(diffMs / 1000);
   const h = Math.floor(totalSec / 3600);
   const m = Math.floor((totalSec % 3600) / 60);

--- a/src/app/lib/format.ts
+++ b/src/app/lib/format.ts
@@ -5,8 +5,9 @@ const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
  * Uses Intl.RelativeTimeFormat for natural language output.
  */
 export function relativeTime(isoString: string): string {
-  const diffMs = Date.now() - new Date(isoString).getTime();
+  const diffMs = Date.now() - Date.parse(isoString);
   if (isNaN(diffMs)) return "";
+  if (diffMs < 0) return rtf.format(0, "second");
   const diffSec = Math.floor(diffMs / 1000);
 
   if (diffSec < 60) return rtf.format(-diffSec, "second");
@@ -23,7 +24,8 @@ export function relativeTime(isoString: string): string {
 
 /**
  * Formats an ISO date string as a compact relative time string (e.g., "3h", "7d", "2mo").
- * Returns "now" for differences under 60 seconds, "" for invalid input.
+ * Returns "now" for differences under 60 seconds or future timestamps (clock skew).
+ * Returns "" for invalid input.
  */
 export function shortRelativeTime(isoString: string): string {
   const diffMs = Date.now() - Date.parse(isoString);

--- a/src/app/lib/format.ts
+++ b/src/app/lib/format.ts
@@ -26,8 +26,9 @@ export function relativeTime(isoString: string): string {
  * Returns "now" for differences under 60 seconds, "" for invalid input.
  */
 export function shortRelativeTime(isoString: string): string {
-  const diffMs = Date.now() - new Date(isoString).getTime();
+  const diffMs = Date.now() - Date.parse(isoString);
   if (isNaN(diffMs)) return "";
+  if (diffMs < 0) return "now";
   const diffSec = Math.floor(diffMs / 1000);
   if (diffSec < 60) return "now";
   const diffMin = Math.floor(diffSec / 60);

--- a/src/app/lib/format.ts
+++ b/src/app/lib/format.ts
@@ -63,7 +63,7 @@ export function labelTextColor(hexColor: string): string {
 export function formatDuration(startedAt: string, completedAt: string | null): string {
   if (!startedAt) return "--";
   if (!completedAt) return "--";
-  const diffMs = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  const diffMs = Date.parse(completedAt) - Date.parse(startedAt);
   if (diffMs <= 0) return "--";
   const totalSec = Math.floor(diffMs / 1000);
   const h = Math.floor(totalSec / 3600);

--- a/src/app/lib/format.ts
+++ b/src/app/lib/format.ts
@@ -22,6 +22,26 @@ export function relativeTime(isoString: string): string {
 }
 
 /**
+ * Formats an ISO date string as a compact relative time string (e.g., "3h", "7d", "2mo").
+ * Returns "now" for differences under 60 seconds, "" for invalid input.
+ */
+export function shortRelativeTime(isoString: string): string {
+  const diffMs = Date.now() - new Date(isoString).getTime();
+  if (isNaN(diffMs)) return "";
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return "now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d`;
+  const diffMonth = Math.floor(diffDay / 30);
+  if (diffMonth < 12) return `${diffMonth}mo`;
+  return `${Math.floor(diffMonth / 12)}y`;
+}
+
+/**
  * Computes text color (black or white) for a GitHub label hex color.
  * Based on perceived luminance.
  */

--- a/src/app/lib/grouping.ts
+++ b/src/app/lib/grouping.ts
@@ -76,12 +76,19 @@ export function detectReorderedRepos(
   previousOrder: string[],
   currentOrder: string[]
 ): Set<string> {
+  // Filter both lists to only repos present in both — ignoring additions/removals
+  // so that inserting or removing a repo doesn't flag everything below it as "moved".
+  const currentSet = new Set(currentOrder);
+  const prevCommon = previousOrder.filter((r) => currentSet.has(r));
+  const prevSet = new Set(previousOrder);
+  const curCommon = currentOrder.filter((r) => prevSet.has(r));
+
   const moved = new Set<string>();
-  const prevIndex = new Map(previousOrder.map((name, i) => [name, i]));
-  for (let i = 0; i < currentOrder.length; i++) {
-    const prev = prevIndex.get(currentOrder[i]);
+  const prevIndex = new Map(prevCommon.map((name, i) => [name, i]));
+  for (let i = 0; i < curCommon.length; i++) {
+    const prev = prevIndex.get(curCommon[i]);
     if (prev !== undefined && prev !== i) {
-      moved.add(currentOrder[i]);
+      moved.add(curCommon[i]);
     }
   }
   return moved;

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -9,7 +9,6 @@ const IssueFiltersSchema = z.object({
   role: z.enum(["all", "author", "assignee"]).default("all"),
   comments: z.enum(["all", "has", "none"]).default("all"),
   user: z.enum(["all"]).or(z.string()).default("all"),
-  depDashboard: z.enum(["hide", "show"]).default("hide"),
 });
 
 const PullRequestFiltersSchema = z.object({
@@ -64,15 +63,16 @@ export const ViewStateSchema = z.object({
     })
     .default({ org: null, repo: null }),
   tabFilters: z.object({
-    issues: IssueFiltersSchema.default({ role: "all", comments: "all", user: "all", depDashboard: "hide" }),
+    issues: IssueFiltersSchema.default({ role: "all", comments: "all", user: "all" }),
     pullRequests: PullRequestFiltersSchema.default({ role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all", user: "all" }),
     actions: ActionsFiltersSchema.default({ conclusion: "all", event: "all" }),
   }).default({
-    issues: { role: "all", comments: "all", user: "all", depDashboard: "hide" },
+    issues: { role: "all", comments: "all", user: "all" },
     pullRequests: { role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all", user: "all" },
     actions: { conclusion: "all", event: "all" },
   }),
   showPrRuns: z.boolean().default(false),
+  hideDepDashboard: z.boolean().default(true),
   expandedRepos: z.object({
     issues: z.record(z.string(), z.boolean()).default({}),
     pullRequests: z.record(z.string(), z.boolean()).default({}),
@@ -122,11 +122,12 @@ export function resetViewState(): void {
     ignoredItems: [],
     globalFilter: { org: null, repo: null },
     tabFilters: {
-      issues: { role: "all", comments: "all", user: "all", depDashboard: "hide" },
+      issues: { role: "all", comments: "all", user: "all" },
       pullRequests: { role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all", user: "all" },
       actions: { conclusion: "all", event: "all" },
     },
     showPrRuns: false,
+    hideDepDashboard: true,
     expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
     lockedRepos: { issues: [], pullRequests: [], actions: [] },
   });
@@ -224,9 +225,7 @@ export function resetAllTabFilters(
   setViewState(
     produce((draft) => {
       if (tab === "issues") {
-        const depDashboard = draft.tabFilters.issues.depDashboard;
         draft.tabFilters.issues = IssueFiltersSchema.parse({});
-        draft.tabFilters.issues.depDashboard = depDashboard;
       } else if (tab === "pullRequests") {
         draft.tabFilters.pullRequests = PullRequestFiltersSchema.parse({});
       } else {

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -9,6 +9,7 @@ const IssueFiltersSchema = z.object({
   role: z.enum(["all", "author", "assignee"]).default("all"),
   comments: z.enum(["all", "has", "none"]).default("all"),
   user: z.enum(["all"]).or(z.string()).default("all"),
+  depDashboard: z.enum(["hide", "show"]).default("hide"),
 });
 
 const PullRequestFiltersSchema = z.object({
@@ -63,11 +64,11 @@ export const ViewStateSchema = z.object({
     })
     .default({ org: null, repo: null }),
   tabFilters: z.object({
-    issues: IssueFiltersSchema.default({ role: "all", comments: "all", user: "all" }),
+    issues: IssueFiltersSchema.default({ role: "all", comments: "all", user: "all", depDashboard: "hide" }),
     pullRequests: PullRequestFiltersSchema.default({ role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all", user: "all" }),
     actions: ActionsFiltersSchema.default({ conclusion: "all", event: "all" }),
   }).default({
-    issues: { role: "all", comments: "all", user: "all" },
+    issues: { role: "all", comments: "all", user: "all", depDashboard: "hide" },
     pullRequests: { role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all", user: "all" },
     actions: { conclusion: "all", event: "all" },
   }),
@@ -121,7 +122,7 @@ export function resetViewState(): void {
     ignoredItems: [],
     globalFilter: { org: null, repo: null },
     tabFilters: {
-      issues: { role: "all", comments: "all", user: "all" },
+      issues: { role: "all", comments: "all", user: "all", depDashboard: "hide" },
       pullRequests: { role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all", user: "all" },
       actions: { conclusion: "all", event: "all" },
     },
@@ -199,13 +200,20 @@ export function setTabFilter<T extends keyof TabFilterField>(
   );
 }
 
+const tabFilterDefaults: Record<string, Record<string, string>> = {
+  issues: IssueFiltersSchema.parse({}) as Record<string, string>,
+  pullRequests: PullRequestFiltersSchema.parse({}) as Record<string, string>,
+  actions: ActionsFiltersSchema.parse({}) as Record<string, string>,
+};
+
 export function resetTabFilter<T extends keyof TabFilterField>(
   tab: T,
   field: TabFilterField[T]
 ): void {
+  const defaultValue = tabFilterDefaults[tab]?.[field as string] ?? "all";
   setViewState(
     produce((draft) => {
-      (draft.tabFilters[tab] as Record<string, string>)[field as string] = "all";
+      (draft.tabFilters[tab] as Record<string, string>)[field as string] = defaultValue;
     })
   );
 }
@@ -216,7 +224,9 @@ export function resetAllTabFilters(
   setViewState(
     produce((draft) => {
       if (tab === "issues") {
+        const depDashboard = draft.tabFilters.issues.depDashboard;
         draft.tabFilters.issues = IssueFiltersSchema.parse({});
+        draft.tabFilters.issues.depDashboard = depDashboard;
       } else if (tab === "pullRequests") {
         draft.tabFilters.pullRequests = PullRequestFiltersSchema.parse({});
       } else {

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -180,6 +180,27 @@ describe("DashboardPage — tab switching", () => {
   });
 });
 
+describe("DashboardPage — clock tick", () => {
+  it("creates a 60s interval to keep relative time displays fresh", () => {
+    const spy = vi.spyOn(globalThis, "setInterval");
+    render(() => <DashboardPage />);
+    expect(spy.mock.calls.some(([, ms]) => ms === 60_000)).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("clears the interval on unmount", () => {
+    const setSpy = vi.spyOn(globalThis, "setInterval");
+    const clearSpy = vi.spyOn(globalThis, "clearInterval");
+    const { unmount } = render(() => <DashboardPage />);
+    const clockCall = setSpy.mock.calls.find(([, ms]) => ms === 60_000);
+    expect(clockCall).toBeDefined();
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+    setSpy.mockRestore();
+    clearSpy.mockRestore();
+  });
+});
+
 describe("DashboardPage — data flow", () => {
   it("passes fetched issues to IssuesTab", async () => {
     const issues = [

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -188,14 +188,15 @@ describe("DashboardPage — clock tick", () => {
     spy.mockRestore();
   });
 
-  it("clears the interval on unmount", () => {
+  it("clears the clock interval on unmount", () => {
     const setSpy = vi.spyOn(globalThis, "setInterval");
     const clearSpy = vi.spyOn(globalThis, "clearInterval");
     const { unmount } = render(() => <DashboardPage />);
-    const clockCall = setSpy.mock.calls.find(([, ms]) => ms === 60_000);
-    expect(clockCall).toBeDefined();
+    const clockCallIdx = setSpy.mock.calls.findIndex(([, ms]) => ms === 60_000);
+    expect(clockCallIdx).not.toBe(-1);
+    const clockIntervalId = setSpy.mock.results[clockCallIdx].value;
     unmount();
-    expect(clearSpy).toHaveBeenCalled();
+    expect(clearSpy).toHaveBeenCalledWith(clockIntervalId);
     setSpy.mockRestore();
     clearSpy.mockRestore();
   });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -590,4 +590,48 @@ describe("IssuesTab", () => {
     screen.getByText("org/repo-b");
     screen.getByText("Repo B issue 0");
   });
+
+  it("hides Dependency Dashboard issues by default", () => {
+    const issues = [
+      makeIssue({ id: 1, title: "Dependency Dashboard" }),
+      makeIssue({ id: 2, title: "Normal issue" }),
+    ];
+    setAllExpanded("issues", ["owner/repo"], true);
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    expect(screen.queryByText("Dependency Dashboard")).toBeNull();
+    screen.getByText("Normal issue");
+  });
+
+  it("shows Dependency Dashboard issues when toggle is active", () => {
+    const issues = [
+      makeIssue({ id: 1, title: "Dependency Dashboard" }),
+      makeIssue({ id: 2, title: "Normal issue" }),
+    ];
+    viewStore.setTabFilter("issues", "depDashboard", "show");
+    setAllExpanded("issues", ["owner/repo"], true);
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    screen.getByText("Dependency Dashboard");
+    screen.getByText("Normal issue");
+  });
+
+  it("toggles Dependency Dashboard visibility via pill button", async () => {
+    const user = userEvent.setup();
+    const issues = [
+      makeIssue({ id: 1, title: "Dependency Dashboard" }),
+      makeIssue({ id: 2, title: "Normal issue" }),
+    ];
+    setAllExpanded("issues", ["owner/repo"], true);
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+
+    // Hidden by default
+    expect(screen.queryByText("Dependency Dashboard")).toBeNull();
+
+    // Click toggle pill to show
+    await user.click(screen.getByText("Show Dep Dashboard"));
+    screen.getByText("Dependency Dashboard");
+
+    // Click again to hide
+    await user.click(screen.getByText("Show Dep Dashboard"));
+    expect(screen.queryByText("Dependency Dashboard")).toBeNull();
+  });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -602,12 +602,12 @@ describe("IssuesTab", () => {
     screen.getByText("Normal issue");
   });
 
-  it("shows Dependency Dashboard issues when toggle is active", () => {
+  it("shows Dependency Dashboard issues when hideDepDashboard is false", () => {
     const issues = [
       makeIssue({ id: 1, title: "Dependency Dashboard" }),
       makeIssue({ id: 2, title: "Normal issue" }),
     ];
-    viewStore.setTabFilter("issues", "depDashboard", "show");
+    viewStore.updateViewState({ hideDepDashboard: false });
     setAllExpanded("issues", ["owner/repo"], true);
     render(() => <IssuesTab issues={issues} userLogin="" />);
     screen.getByText("Dependency Dashboard");
@@ -633,5 +633,15 @@ describe("IssuesTab", () => {
     // Click again to hide
     await user.click(screen.getByText("Show Dep Dashboard"));
     expect(screen.queryByText("Dependency Dashboard")).toBeNull();
+  });
+
+  it("renders repo header link to GitHub issues", () => {
+    const issues = [makeIssue({ id: 1 })];
+    setAllExpanded("issues", ["owner/repo"], true);
+    render(() => <IssuesTab issues={issues} userLogin="" />);
+    const link = screen.getByLabelText("Open owner/repo issues on GitHub");
+    expect(link.getAttribute("href")).toBe("https://github.com/owner/repo/issues");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
   });
 });

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -224,19 +224,22 @@ describe("ItemRow", () => {
     vi.spyOn(Date, "now").mockImplementation(() => mockNow);
 
     // createdAt is 2h before MOCK_NOW → displays "2h"
+    // updatedAt is 30m before MOCK_NOW → displays "30m"
     render(() => (
       <ItemRow
         {...defaultProps}
-        updatedAt={defaultProps.createdAt}
         refreshTick={tick()}
       />
     ));
     expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("2h");
+    expect(screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`).textContent).toBe("30m");
 
     // Advance mock time by 3 hours and bump refreshTick
     mockNow = MOCK_NOW + 3 * 60 * 60 * 1000;
     setTick(1);
 
     expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("5h");
+    // updatedAt was 30m before MOCK_NOW; after +3h it is 3h30m ago → Math.floor(210/60) = 3 → "3h"
+    expect(screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`).textContent).toBe("3h");
   });
 });

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -47,7 +47,7 @@ describe("ItemRow", () => {
   it("renders relative time for createdAt", () => {
     render(() => <ItemRow {...defaultProps} />);
     // Should show compact format like "2h"
-    const timeEl = screen.getByTitle(`Created: ${defaultProps.createdAt}`);
+    const timeEl = screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`);
     expect(timeEl).toBeDefined();
     expect(timeEl.textContent).toMatch(/^\d+h$/);
   });
@@ -177,8 +177,8 @@ describe("ItemRow", () => {
   it("shows both dates when updatedAt meaningfully differs from createdAt", () => {
     const { container } = render(() => <ItemRow {...defaultProps} />);
     // createdAt=2h ago → "2h", updatedAt=30m ago → "30m"
-    expect(screen.getByTitle(`Created: ${defaultProps.createdAt}`).textContent).toBe("2h");
-    expect(screen.getByTitle(`Updated: ${defaultProps.updatedAt}`).textContent).toBe("30m");
+    expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("2h");
+    expect(screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`).textContent).toBe("30m");
     // Middle dot separator is a <span> with aria-hidden
     const dot = container.querySelector('span[aria-hidden="true"]');
     expect(dot).not.toBeNull();
@@ -195,7 +195,7 @@ describe("ItemRow", () => {
     ));
     // Only one time span — no dot separator span
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
-    expect(screen.queryByTitle(`Updated: 2026-03-30T11:59:30Z`)).toBeNull();
+    expect(screen.queryByTitle(`Updated: ${new Date("2026-03-30T11:59:30Z").toLocaleString()}`)).toBeNull();
   });
 
   it("shows single date when both compact values are identical (display-equality guard)", () => {
@@ -207,13 +207,13 @@ describe("ItemRow", () => {
     ));
     // diff > 60s but both show "3d" — no dot separator span
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
-    expect(screen.getByTitle(`Created: ${createdAt}`).textContent).toBe("3d");
+    expect(screen.getByTitle(`Created: ${new Date(createdAt).toLocaleString()}`).textContent).toBe("3d");
   });
 
   it("shows verbose aria-label for created and updated spans", () => {
     render(() => <ItemRow {...defaultProps} />);
-    const createdSpan = screen.getByTitle(`Created: ${defaultProps.createdAt}`);
-    const updatedSpan = screen.getByTitle(`Updated: ${defaultProps.updatedAt}`);
+    const createdSpan = screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`);
+    const updatedSpan = screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`);
     expect(createdSpan.getAttribute("aria-label")).toMatch(/^Created 2 hours? ago$/);
     expect(updatedSpan.getAttribute("aria-label")).toMatch(/^Updated 30 minutes? ago$/);
   });
@@ -231,12 +231,12 @@ describe("ItemRow", () => {
         refreshTick={tick()}
       />
     ));
-    expect(screen.getByTitle(`Created: ${defaultProps.createdAt}`).textContent).toBe("2h");
+    expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("2h");
 
     // Advance mock time by 3 hours and bump refreshTick
     mockNow = MOCK_NOW + 3 * 60 * 60 * 1000;
     setTick(1);
 
-    expect(screen.getByTitle(`Created: ${defaultProps.createdAt}`).textContent).toBe("5h");
+    expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("5h");
   });
 });

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -235,13 +235,29 @@ describe("ItemRow", () => {
     expect(container.querySelector(`time[datetime="${createdAt}"]`)!.textContent).toBe("3d");
   });
 
-  it("suppresses update display when dates are invalid", () => {
+  it("suppresses update display when both dates are invalid", () => {
     const { container } = render(() => (
       <ItemRow {...defaultProps} createdAt="not-a-date" updatedAt="also-invalid" />
     ));
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
     expect(container.querySelectorAll("time").length).toBe(1);
     expect(container.querySelector("time")!.textContent).toBe("");
+  });
+
+  it("suppresses update display when createdAt is valid but updatedAt is invalid", () => {
+    const { container } = render(() => (
+      <ItemRow {...defaultProps} createdAt="2026-03-30T10:00:00Z" updatedAt="not-a-date" />
+    ));
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    expect(container.querySelectorAll("time").length).toBe(1);
+  });
+
+  it("suppresses update display when updatedAt is valid but createdAt is invalid", () => {
+    const { container } = render(() => (
+      <ItemRow {...defaultProps} createdAt="not-a-date" updatedAt="2026-03-30T11:30:00Z" />
+    ));
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    expect(container.querySelectorAll("time").length).toBe(1);
   });
 
   it("renders correct datetime attributes on time elements", () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -49,7 +49,7 @@ describe("ItemRow", () => {
     // Should show compact format like "2h"
     const timeEl = screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`);
     expect(timeEl).toBeDefined();
-    expect(timeEl.textContent).toMatch(/^\d+h$/);
+    expect(timeEl.textContent).toBe("2h");
   });
 
   it("renders children slot when provided", () => {
@@ -196,6 +196,18 @@ describe("ItemRow", () => {
     // Only one time span — no dot separator span
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
     expect(screen.queryByTitle(`Updated: ${new Date("2026-03-30T11:59:30Z").toLocaleString()}`)).toBeNull();
+  });
+
+  it("shows single date when updatedAt is exactly 60s after createdAt", () => {
+    const { container } = render(() => (
+      <ItemRow
+        {...defaultProps}
+        createdAt="2026-03-30T11:59:00Z"
+        updatedAt="2026-03-30T12:00:00Z"
+      />
+    ));
+    // diff === 60_000ms, condition is <=, so still suppressed
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
   });
 
   it("shows single date when both compact values are identical (display-equality guard)", () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -45,11 +45,11 @@ describe("ItemRow", () => {
   });
 
   it("renders relative time for createdAt", () => {
-    render(() => <ItemRow {...defaultProps} />);
+    const { container } = render(() => <ItemRow {...defaultProps} />);
     // Should show compact format like "2h"
-    const timeEl = screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`);
-    expect(timeEl).toBeDefined();
-    expect(timeEl.textContent).toBe("2h");
+    const timeEl = container.querySelector(`time[datetime="${defaultProps.createdAt}"]`);
+    expect(timeEl).not.toBeNull();
+    expect(timeEl!.textContent).toBe("2h");
   });
 
   it("renders children slot when provided", () => {
@@ -177,8 +177,12 @@ describe("ItemRow", () => {
   it("shows both dates when updatedAt meaningfully differs from createdAt", () => {
     const { container } = render(() => <ItemRow {...defaultProps} />);
     // createdAt=2h ago → "2h", updatedAt=30m ago → "30m"
-    expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("2h");
-    expect(screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`).textContent).toBe("30m");
+    const created = container.querySelector(`time[datetime="${defaultProps.createdAt}"]`);
+    const updated = container.querySelector(`time[datetime="${defaultProps.updatedAt}"]`);
+    expect(created!.textContent).toBe("2h");
+    expect(created!.getAttribute("title")).toBe(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`);
+    expect(updated!.textContent).toBe("30m");
+    expect(updated!.getAttribute("title")).toBe(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`);
     // Middle dot separator is a <span> with aria-hidden
     const dot = container.querySelector('span[aria-hidden="true"]');
     expect(dot).not.toBeNull();
@@ -191,7 +195,7 @@ describe("ItemRow", () => {
       <ItemRow {...defaultProps} createdAt={sameDate} updatedAt={sameDate} />
     ));
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
-    expect(screen.queryByTitle(`Updated: ${new Date(sameDate).toLocaleString()}`)).toBeNull();
+    expect(container.querySelectorAll("time").length).toBe(1);
   });
 
   it("shows single date when updatedAt is within 60s of createdAt", () => {
@@ -202,9 +206,9 @@ describe("ItemRow", () => {
         updatedAt="2026-03-30T11:59:30Z"
       />
     ));
-    // Only one time span — no dot separator span
+    // Only one time element — no dot separator
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
-    expect(screen.queryByTitle(`Updated: ${new Date("2026-03-30T11:59:30Z").toLocaleString()}`)).toBeNull();
+    expect(container.querySelectorAll("time").length).toBe(1);
   });
 
   it("shows single date when updatedAt is exactly 60s after createdAt", () => {
@@ -226,9 +230,18 @@ describe("ItemRow", () => {
     const { container } = render(() => (
       <ItemRow {...defaultProps} createdAt={createdAt} updatedAt={updatedAt} />
     ));
-    // diff > 60s but both show "3d" — no dot separator span
+    // diff > 60s but both show "3d" — no dot separator
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
-    expect(screen.getByTitle(`Created: ${new Date(createdAt).toLocaleString()}`).textContent).toBe("3d");
+    expect(container.querySelector(`time[datetime="${createdAt}"]`)!.textContent).toBe("3d");
+  });
+
+  it("suppresses update display when dates are invalid", () => {
+    const { container } = render(() => (
+      <ItemRow {...defaultProps} createdAt="not-a-date" updatedAt="also-invalid" />
+    ));
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    expect(container.querySelectorAll("time").length).toBe(1);
+    expect(container.querySelector("time")!.textContent).toBe("");
   });
 
   it("renders correct datetime attributes on time elements", () => {
@@ -240,35 +253,32 @@ describe("ItemRow", () => {
   });
 
   it("shows verbose aria-label for created and updated spans", () => {
-    render(() => <ItemRow {...defaultProps} />);
-    const createdSpan = screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`);
-    const updatedSpan = screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`);
-    expect(createdSpan.getAttribute("aria-label")).toMatch(/^Created 2 hours? ago$/);
-    expect(updatedSpan.getAttribute("aria-label")).toMatch(/^Updated 30 minutes? ago$/);
+    const { container } = render(() => <ItemRow {...defaultProps} />);
+    const created = container.querySelector(`time[datetime="${defaultProps.createdAt}"]`);
+    const updated = container.querySelector(`time[datetime="${defaultProps.updatedAt}"]`);
+    expect(created!.getAttribute("aria-label")).toMatch(/^Created 2 hours? ago$/);
+    expect(updated!.getAttribute("aria-label")).toMatch(/^Updated 30 minutes? ago$/);
   });
 
   it("refreshTick forces time display update", () => {
     const [tick, setTick] = createSignal(0);
     let mockNow = MOCK_NOW;
-    vi.spyOn(Date, "now").mockImplementation(() => mockNow);
+    vi.mocked(Date.now).mockImplementation(() => mockNow);
 
-    // createdAt is 2h before MOCK_NOW → displays "2h"
-    // updatedAt is 30m before MOCK_NOW → displays "30m"
-    render(() => (
-      <ItemRow
-        {...defaultProps}
-        refreshTick={tick()}
-      />
+    const { container } = render(() => (
+      <ItemRow {...defaultProps} refreshTick={tick()} />
     ));
-    expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("2h");
-    expect(screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`).textContent).toBe("30m");
+    const created = container.querySelector(`time[datetime="${defaultProps.createdAt}"]`);
+    const updated = container.querySelector(`time[datetime="${defaultProps.updatedAt}"]`);
+    expect(created!.textContent).toBe("2h");
+    expect(updated!.textContent).toBe("30m");
 
     // Advance mock time by 3 hours and bump refreshTick
     mockNow = MOCK_NOW + 3 * 60 * 60 * 1000;
     setTick(1);
 
-    expect(screen.getByTitle(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`).textContent).toBe("5h");
+    expect(created!.textContent).toBe("5h");
     // updatedAt was 30m before MOCK_NOW; after +3h it is 3h30m ago → Math.floor(210/60) = 3 → "3h"
-    expect(screen.getByTitle(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`).textContent).toBe("3h");
+    expect(updated!.textContent).toBe("3h");
   });
 });

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -185,6 +185,15 @@ describe("ItemRow", () => {
     expect(dot!.textContent).toBe("\u00B7");
   });
 
+  it("shows single date when createdAt equals updatedAt (zero diff)", () => {
+    const sameDate = "2026-03-30T11:00:00Z";
+    const { container } = render(() => (
+      <ItemRow {...defaultProps} createdAt={sameDate} updatedAt={sameDate} />
+    ));
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    expect(screen.queryByTitle(`Updated: ${new Date(sameDate).toLocaleString()}`)).toBeNull();
+  });
+
   it("shows single date when updatedAt is within 60s of createdAt", () => {
     const { container } = render(() => (
       <ItemRow
@@ -220,6 +229,14 @@ describe("ItemRow", () => {
     // diff > 60s but both show "3d" — no dot separator span
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
     expect(screen.getByTitle(`Created: ${new Date(createdAt).toLocaleString()}`).textContent).toBe("3d");
+  });
+
+  it("renders correct datetime attributes on time elements", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} />);
+    const timeEls = container.querySelectorAll("time");
+    expect(timeEls.length).toBe(2);
+    expect(timeEls[0].getAttribute("datetime")).toBe(defaultProps.createdAt);
+    expect(timeEls[1].getAttribute("datetime")).toBe(defaultProps.updatedAt);
   });
 
   it("shows verbose aria-label for created and updated spans", () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
 import ItemRow from "../../src/app/components/dashboard/ItemRow";
 
 const MOCK_NOW = new Date("2026-03-30T12:00:00Z").getTime();
@@ -171,5 +172,71 @@ describe("ItemRow", () => {
     const { container } = render(() => <ItemRow {...defaultProps} isFlashing={true} isPolling={true} />);
     expect(container.firstElementChild?.classList.contains("animate-flash")).toBe(true);
     expect(container.firstElementChild?.classList.contains("animate-shimmer")).toBe(false);
+  });
+
+  it("shows both dates when updatedAt meaningfully differs from createdAt", () => {
+    const { container } = render(() => <ItemRow {...defaultProps} />);
+    // createdAt=2h ago → "2h", updatedAt=30m ago → "30m"
+    expect(screen.getByTitle(`Created: ${defaultProps.createdAt}`).textContent).toBe("2h");
+    expect(screen.getByTitle(`Updated: ${defaultProps.updatedAt}`).textContent).toBe("30m");
+    // Middle dot separator is a <span> with aria-hidden
+    const dot = container.querySelector('span[aria-hidden="true"]');
+    expect(dot).not.toBeNull();
+    expect(dot!.textContent).toBe("\u00B7");
+  });
+
+  it("shows single date when updatedAt is within 60s of createdAt", () => {
+    const { container } = render(() => (
+      <ItemRow
+        {...defaultProps}
+        createdAt="2026-03-30T11:59:00Z"
+        updatedAt="2026-03-30T11:59:30Z"
+      />
+    ));
+    // Only one time span — no dot separator span
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    expect(screen.queryByTitle(`Updated: 2026-03-30T11:59:30Z`)).toBeNull();
+  });
+
+  it("shows single date when both compact values are identical (display-equality guard)", () => {
+    // Both 3 days ago — createdAt 3d+2min ago, updatedAt exactly 3d ago, both display "3d"
+    const createdAt = new Date(MOCK_NOW - (3 * 24 * 60 * 60 + 2 * 60) * 1000).toISOString();
+    const updatedAt = new Date(MOCK_NOW - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const { container } = render(() => (
+      <ItemRow {...defaultProps} createdAt={createdAt} updatedAt={updatedAt} />
+    ));
+    // diff > 60s but both show "3d" — no dot separator span
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    expect(screen.getByTitle(`Created: ${createdAt}`).textContent).toBe("3d");
+  });
+
+  it("shows verbose aria-label for created and updated spans", () => {
+    render(() => <ItemRow {...defaultProps} />);
+    const createdSpan = screen.getByTitle(`Created: ${defaultProps.createdAt}`);
+    const updatedSpan = screen.getByTitle(`Updated: ${defaultProps.updatedAt}`);
+    expect(createdSpan.getAttribute("aria-label")).toMatch(/^Created 2 hours? ago$/);
+    expect(updatedSpan.getAttribute("aria-label")).toMatch(/^Updated 30 minutes? ago$/);
+  });
+
+  it("refreshTick forces time display update", () => {
+    const [tick, setTick] = createSignal(0);
+    let mockNow = MOCK_NOW;
+    vi.spyOn(Date, "now").mockImplementation(() => mockNow);
+
+    // createdAt is 2h before MOCK_NOW → displays "2h"
+    render(() => (
+      <ItemRow
+        {...defaultProps}
+        updatedAt={defaultProps.createdAt}
+        refreshTick={tick()}
+      />
+    ));
+    expect(screen.getByTitle(`Created: ${defaultProps.createdAt}`).textContent).toBe("2h");
+
+    // Advance mock time by 3 hours and bump refreshTick
+    mockNow = MOCK_NOW + 3 * 60 * 60 * 1000;
+    setTick(1);
+
+    expect(screen.getByTitle(`Created: ${defaultProps.createdAt}`).textContent).toBe("5h");
   });
 });

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -1,14 +1,17 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import ItemRow from "../../src/app/components/dashboard/ItemRow";
+
+const MOCK_NOW = new Date("2026-03-30T12:00:00Z").getTime();
 
 const defaultProps = {
   repo: "octocat/Hello-World",
   number: 42,
   title: "Fix a bug",
   author: "octocat",
-  createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2h ago
+  createdAt: "2026-03-30T10:00:00Z", // 2h before MOCK_NOW
+  updatedAt: "2026-03-30T11:30:00Z", // 30m before MOCK_NOW (differs from createdAt by >60s)
   url: "https://github.com/octocat/Hello-World/issues/42",
   labels: [{ name: "bug", color: "d73a4a" }],
   onIgnore: vi.fn(),
@@ -16,6 +19,9 @@ const defaultProps = {
 };
 
 describe("ItemRow", () => {
+  beforeEach(() => { vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
   it("renders repo badge", () => {
     render(() => <ItemRow {...defaultProps} />);
     screen.getByText("octocat/Hello-World");
@@ -39,10 +45,10 @@ describe("ItemRow", () => {
 
   it("renders relative time for createdAt", () => {
     render(() => <ItemRow {...defaultProps} />);
-    // Should show something like "2 hours ago"
-    const timeEl = screen.getByTitle(defaultProps.createdAt);
+    // Should show compact format like "2h"
+    const timeEl = screen.getByTitle(`Created: ${defaultProps.createdAt}`);
     expect(timeEl).toBeDefined();
-    expect(timeEl.textContent).toMatch(/hour/i);
+    expect(timeEl.textContent).toMatch(/^\d+h$/);
   });
 
   it("renders children slot when provided", () => {

--- a/tests/components/RepoGitHubLink.test.tsx
+++ b/tests/components/RepoGitHubLink.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@solidjs/testing-library";
+import RepoGitHubLink from "../../src/app/components/shared/RepoGitHubLink";
+
+describe("RepoGitHubLink", () => {
+  it("renders issues link with correct href and label", () => {
+    const { container } = render(() => (
+      <RepoGitHubLink repoFullName="owner/repo" section="issues" />
+    ));
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("https://github.com/owner/repo/issues");
+    expect(link.getAttribute("aria-label")).toBe("Open owner/repo issues on GitHub");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("renders pulls link with correct href and label", () => {
+    const { container } = render(() => (
+      <RepoGitHubLink repoFullName="owner/repo" section="pulls" />
+    ));
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("https://github.com/owner/repo/pulls");
+    expect(link.getAttribute("aria-label")).toBe("Open owner/repo pull requests on GitHub");
+  });
+
+  it("renders actions link with correct href and label", () => {
+    const { container } = render(() => (
+      <RepoGitHubLink repoFullName="owner/repo" section="actions" />
+    ));
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("https://github.com/owner/repo/actions");
+    expect(link.getAttribute("aria-label")).toBe("Open owner/repo actions on GitHub");
+  });
+
+  it("renders ExternalLinkIcon SVG with aria-hidden", () => {
+    const { container } = render(() => (
+      <RepoGitHubLink repoFullName="owner/repo" section="issues" />
+    ));
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/tests/components/WorkflowRunRow.test.tsx
+++ b/tests/components/WorkflowRunRow.test.tsx
@@ -36,12 +36,13 @@ describe("WorkflowRunRow", () => {
     const timeEl = container.querySelector("time");
     expect(timeEl).not.toBeNull();
     expect(timeEl!.getAttribute("datetime")).toBe(createdAt);
+    expect(timeEl!.getAttribute("title")).toBe(`Created: ${new Date(createdAt).toLocaleString()}`);
     expect(timeEl!.textContent).toMatch(/2 hours? ago/);
   });
 
   it("updates time display when refreshTick changes", () => {
     let mockNow = MOCK_NOW;
-    vi.spyOn(Date, "now").mockImplementation(() => mockNow);
+    vi.mocked(Date.now).mockImplementation(() => mockNow);
     const createdAt = new Date(MOCK_NOW - 2 * 60 * 60 * 1000).toISOString();
     const run = makeWorkflowRun({ createdAt });
     const [tick, setTick] = createSignal(0);

--- a/tests/components/WorkflowRunRow.test.tsx
+++ b/tests/components/WorkflowRunRow.test.tsx
@@ -1,10 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
 import WorkflowRunRow from "../../src/app/components/dashboard/WorkflowRunRow";
 import { makeWorkflowRun } from "../helpers/index";
 
+const MOCK_NOW = new Date("2026-03-30T12:00:00Z").getTime();
+
 describe("WorkflowRunRow", () => {
+  beforeEach(() => { vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
   it("renders run name", () => {
     const run = makeWorkflowRun({ name: "CI Build" });
     render(() => (
@@ -21,15 +27,32 @@ describe("WorkflowRunRow", () => {
     screen.getByText("feat: my cool feature");
   });
 
-  it("shows relative time", () => {
-    const run = makeWorkflowRun({ createdAt: "2024-01-10T08:00:00Z" });
-    render(() => (
+  it("shows relative time in a semantic <time> element", () => {
+    const createdAt = new Date(MOCK_NOW - 2 * 60 * 60 * 1000).toISOString();
+    const run = makeWorkflowRun({ createdAt });
+    const { container } = render(() => (
       <WorkflowRunRow run={run} onIgnore={() => {}} density="comfortable" />
     ));
-    // relativeTime returns a human-readable string; just verify something renders
-    // We can't assert exact text as it depends on current date, but the element should exist
-    const container = screen.getByText("CI").closest("div");
-    expect(container).toBeDefined();
+    const timeEl = container.querySelector("time");
+    expect(timeEl).not.toBeNull();
+    expect(timeEl!.getAttribute("datetime")).toBe(createdAt);
+    expect(timeEl!.textContent).toMatch(/2 hours? ago/);
+  });
+
+  it("updates time display when refreshTick changes", () => {
+    let mockNow = MOCK_NOW;
+    vi.spyOn(Date, "now").mockImplementation(() => mockNow);
+    const createdAt = new Date(MOCK_NOW - 2 * 60 * 60 * 1000).toISOString();
+    const run = makeWorkflowRun({ createdAt });
+    const [tick, setTick] = createSignal(0);
+    const { container } = render(() => (
+      <WorkflowRunRow run={run} onIgnore={() => {}} density="comfortable" refreshTick={tick()} />
+    ));
+    const timeEl = container.querySelector("time");
+    expect(timeEl!.textContent).toMatch(/2 hours? ago/);
+    mockNow = MOCK_NOW + 3 * 60 * 60 * 1000;
+    setTick(1);
+    expect(timeEl!.textContent).toMatch(/5 hours? ago/);
   });
 
   it("renders status indicator for success conclusion", () => {

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -121,6 +121,11 @@ describe("shortRelativeTime", () => {
     expect(shortRelativeTime(isoString)).toBe("1mo");
   });
 
+  it("returns '2mo' for 2 months ago", () => {
+    const isoString = new Date(MOCK_NOW - 2 * 30 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("2mo");
+  });
+
   it("returns '11mo' for 11 months ago", () => {
     const isoString = new Date(MOCK_NOW - 11 * 30 * 24 * 60 * 60 * 1000).toISOString();
     expect(shortRelativeTime(isoString)).toBe("11mo");

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -106,6 +106,11 @@ describe("shortRelativeTime", () => {
     expect(shortRelativeTime(isoString)).toBe("now");
   });
 
+  it("returns 'now' for future timestamps beyond 60s", () => {
+    const future = new Date(MOCK_NOW + 5 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(future)).toBe("now");
+  });
+
   it("returns empty string for invalid input", () => {
     expect(shortRelativeTime("not-a-date")).toBe("");
     expect(shortRelativeTime("")).toBe("");

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -136,6 +136,16 @@ describe("shortRelativeTime", () => {
     expect(shortRelativeTime(isoString)).toBe("1y");
   });
 
+  it("returns '11mo' for 359 days ago (just before year boundary)", () => {
+    const isoString = new Date(MOCK_NOW - 359 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("11mo");
+  });
+
+  it("returns '1y' for 360 days ago (exact year boundary at 12×30)", () => {
+    const isoString = new Date(MOCK_NOW - 360 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("1y");
+  });
+
   it("returns compact years for 400 days ago", () => {
     const isoString = new Date(MOCK_NOW - 400 * 24 * 60 * 60 * 1000).toISOString();
     expect(shortRelativeTime(isoString)).toBe("1y");

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -58,6 +58,11 @@ describe("relativeTime", () => {
     expect(relativeTime("")).toBe("");
     expect(relativeTime("garbage-2026-13-99")).toBe("");
   });
+
+  it("clamps future timestamps to 'now' (clock skew)", () => {
+    const future = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    expect(relativeTime(future)).toMatch(/now/i);
+  });
 });
 
 describe("shortRelativeTime", () => {
@@ -91,9 +96,39 @@ describe("shortRelativeTime", () => {
     expect(shortRelativeTime(isoString)).toBe("7d");
   });
 
+  it("returns 'now' for exactly 59 seconds ago", () => {
+    const isoString = new Date(MOCK_NOW - 59 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("now");
+  });
+
+  it("returns '1m' for exactly 60 seconds ago", () => {
+    const isoString = new Date(MOCK_NOW - 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("1m");
+  });
+
+  it("returns '29d' for 29 days ago", () => {
+    const isoString = new Date(MOCK_NOW - 29 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("29d");
+  });
+
+  it("returns '1mo' for 30 days ago", () => {
+    const isoString = new Date(MOCK_NOW - 30 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("1mo");
+  });
+
   it("returns compact months for 45 days ago", () => {
     const isoString = new Date(MOCK_NOW - 45 * 24 * 60 * 60 * 1000).toISOString();
     expect(shortRelativeTime(isoString)).toBe("1mo");
+  });
+
+  it("returns '11mo' for 11 months ago", () => {
+    const isoString = new Date(MOCK_NOW - 11 * 30 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("11mo");
+  });
+
+  it("returns '1y' for 12 months ago", () => {
+    const isoString = new Date(MOCK_NOW - 12 * 30 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("1y");
   });
 
   it("returns compact years for 400 days ago", () => {

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { relativeTime, labelTextColor, formatDuration, prSizeCategory, deriveInvolvementRoles, formatCount } from "../../src/app/lib/format";
+import { relativeTime, shortRelativeTime, labelTextColor, formatDuration, prSizeCategory, deriveInvolvementRoles, formatCount } from "../../src/app/lib/format";
 
 describe("relativeTime", () => {
   beforeEach(() => {
@@ -57,6 +57,58 @@ describe("relativeTime", () => {
     expect(relativeTime("not-a-date")).toBe("");
     expect(relativeTime("")).toBe("");
     expect(relativeTime("garbage-2026-13-99")).toBe("");
+  });
+});
+
+describe("shortRelativeTime", () => {
+  const MOCK_NOW = new Date("2026-03-21T12:00:00.000Z").getTime();
+
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 'now' for under 60 seconds ago", () => {
+    const isoString = new Date(MOCK_NOW - 30 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("now");
+  });
+
+  it("returns compact minutes for 5 minutes ago", () => {
+    const isoString = new Date(MOCK_NOW - 5 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("5m");
+  });
+
+  it("returns compact hours for 3 hours ago", () => {
+    const isoString = new Date(MOCK_NOW - 3 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("3h");
+  });
+
+  it("returns compact days for 7 days ago", () => {
+    const isoString = new Date(MOCK_NOW - 7 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("7d");
+  });
+
+  it("returns compact months for 45 days ago", () => {
+    const isoString = new Date(MOCK_NOW - 45 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("1mo");
+  });
+
+  it("returns compact years for 400 days ago", () => {
+    const isoString = new Date(MOCK_NOW - 400 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("1y");
+  });
+
+  it("returns 'now' for future timestamps (clock skew)", () => {
+    const isoString = new Date(MOCK_NOW + 60 * 1000).toISOString();
+    expect(shortRelativeTime(isoString)).toBe("now");
+  });
+
+  it("returns empty string for invalid input", () => {
+    expect(shortRelativeTime("not-a-date")).toBe("");
+    expect(shortRelativeTime("")).toBe("");
   });
 });
 

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -226,6 +226,11 @@ describe("formatDuration", () => {
   it("returns '<1s' for sub-second duration", () => {
     expect(formatDuration("2026-03-21T10:00:00.000Z", "2026-03-21T10:00:00.500Z")).toBe("<1s");
   });
+
+  it("returns '--' for invalid date strings", () => {
+    expect(formatDuration("not-a-date", "2026-03-21T10:00:00Z")).toBe("--");
+    expect(formatDuration("2026-03-21T10:00:00Z", "not-a-date")).toBe("--");
+  });
 });
 
 describe("prSizeCategory", () => {

--- a/tests/lib/grouping-lock.test.ts
+++ b/tests/lib/grouping-lock.test.ts
@@ -60,10 +60,17 @@ describe("detectReorderedRepos", () => {
     expect(detectReorderedRepos(prev, curr)).toEqual(new Set());
   });
 
-  it("ignores removed repos", () => {
-    const prev = ["org/a", "org/b"];
-    const curr = ["org/b"];
-    // org/b was at index 1, now at index 0 -> moved
-    expect(detectReorderedRepos(prev, curr)).toEqual(new Set(["org/b"]));
+  it("does not flash remaining repos when a repo is removed", () => {
+    const prev = ["org/a", "org/b", "org/c"];
+    const curr = ["org/b", "org/c"];
+    // org/a removed — org/b and org/c kept same relative order
+    expect(detectReorderedRepos(prev, curr)).toEqual(new Set());
+  });
+
+  it("detects reorder even when a repo is simultaneously removed", () => {
+    const prev = ["org/a", "org/b", "org/c"];
+    const curr = ["org/c", "org/b"];
+    // org/a removed, and org/b + org/c swapped relative order
+    expect(detectReorderedRepos(prev, curr)).toEqual(new Set(["org/b", "org/c"]));
   });
 });

--- a/tests/stores/view.test.ts
+++ b/tests/stores/view.test.ts
@@ -190,6 +190,7 @@ describe("ViewStateSchema", () => {
     expect(result.sortPreferences).toEqual({});
     expect(result.ignoredItems).toEqual([]);
     expect(result.globalFilter).toEqual({ org: null, repo: null });
+    expect(result.hideDepDashboard).toBe(true);
   });
 
   it("handles missing fields with defaults", () => {

--- a/tests/stores/view.test.ts
+++ b/tests/stores/view.test.ts
@@ -8,8 +8,6 @@ import {
   unignoreItem,
   setSortPreference,
   setGlobalFilter,
-  setTabFilter,
-  resetTabFilter,
   resetAllTabFilters,
   initViewPersistence,
   ViewStateSchema,
@@ -310,21 +308,29 @@ describe("resetViewState", () => {
   });
 });
 
-describe("depDashboard filter reset", () => {
+describe("hideDepDashboard", () => {
   beforeEach(() => resetViewState());
 
-  it("resetTabFilter resets depDashboard to 'hide' (not 'all')", () => {
-    setTabFilter("issues", "depDashboard", "show");
-    expect(viewState.tabFilters.issues.depDashboard).toBe("show");
-    resetTabFilter("issues", "depDashboard");
-    expect(viewState.tabFilters.issues.depDashboard).toBe("hide");
+  it("defaults to true", () => {
+    expect(viewState.hideDepDashboard).toBe(true);
   });
 
-  it("resetAllTabFilters preserves depDashboard value", () => {
-    setTabFilter("issues", "depDashboard", "show");
-    setTabFilter("issues", "role", "author");
+  it("can be toggled via updateViewState", () => {
+    updateViewState({ hideDepDashboard: false });
+    expect(viewState.hideDepDashboard).toBe(false);
+    updateViewState({ hideDepDashboard: true });
+    expect(viewState.hideDepDashboard).toBe(true);
+  });
+
+  it("is not affected by resetAllTabFilters", () => {
+    updateViewState({ hideDepDashboard: false });
     resetAllTabFilters("issues");
-    expect(viewState.tabFilters.issues.role).toBe("all");
-    expect(viewState.tabFilters.issues.depDashboard).toBe("show");
+    expect(viewState.hideDepDashboard).toBe(false);
+  });
+
+  it("is reset by resetViewState", () => {
+    updateViewState({ hideDepDashboard: false });
+    resetViewState();
+    expect(viewState.hideDepDashboard).toBe(true);
   });
 });

--- a/tests/stores/view.test.ts
+++ b/tests/stores/view.test.ts
@@ -8,6 +8,9 @@ import {
   unignoreItem,
   setSortPreference,
   setGlobalFilter,
+  setTabFilter,
+  resetTabFilter,
+  resetAllTabFilters,
   initViewPersistence,
   ViewStateSchema,
   toggleExpandedRepo,
@@ -304,5 +307,24 @@ describe("resetViewState", () => {
     expect("org/repo-b" in viewState.expandedRepos.issues).toBe(false);
     expect("org/repo-c" in viewState.expandedRepos.pullRequests).toBe(false);
     expect("org/repo-d" in viewState.expandedRepos.actions).toBe(false);
+  });
+});
+
+describe("depDashboard filter reset", () => {
+  beforeEach(() => resetViewState());
+
+  it("resetTabFilter resets depDashboard to 'hide' (not 'all')", () => {
+    setTabFilter("issues", "depDashboard", "show");
+    expect(viewState.tabFilters.issues.depDashboard).toBe("show");
+    resetTabFilter("issues", "depDashboard");
+    expect(viewState.tabFilters.issues.depDashboard).toBe("hide");
+  });
+
+  it("resetAllTabFilters preserves depDashboard value", () => {
+    setTabFilter("issues", "depDashboard", "show");
+    setTabFilter("issues", "role", "author");
+    resetAllTabFilters("issues");
+    expect(viewState.tabFilters.issues.role).toBe("all");
+    expect(viewState.tabFilters.issues.depDashboard).toBe("show");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `shortRelativeTime()` compact formatter (`now`, `5m`, `3h`, `7d`, `2mo`, `1y`) and dual inline date display on ItemRow showing both created and updated times
- Wires `refreshTick` from DashboardPage through tabs for reactive time display with 60s threshold and display-equality guard to suppress redundant updates
- Uses semantic `<time>` elements with `datetime` attributes, `aria-label` for screen readers, and human-readable tooltips via `toLocaleString()`