### PR TITLE
fix(ui): corrects tab badge counts, toolbar layout, and ignore flash

### DIFF
--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -211,37 +211,41 @@ export default function ActionsTab(props: ActionsTabProps) {
   const highlightedReposActions = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.actions,
+    () => viewState.ignoredItems.length,
   );
 
   return (
     <div class="divide-y divide-base-300">
       {/* Toolbar */}
-      <div class="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
-        <label class="flex items-center gap-1.5 text-sm text-base-content/70 cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={viewState.showPrRuns}
-            onChange={(e) => setViewState("showPrRuns", e.currentTarget.checked)}
-            class="checkbox checkbox-sm checkbox-primary"
+      <div class="flex items-start gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
+        <div class="flex flex-wrap items-center gap-3 min-w-0 flex-1">
+          <label class="flex items-center gap-1.5 text-sm text-base-content/70 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={viewState.showPrRuns}
+              onChange={(e) => setViewState("showPrRuns", e.currentTarget.checked)}
+              class="checkbox checkbox-sm checkbox-primary"
+            />
+            Show PR runs
+          </label>
+          <FilterChips
+            groups={actionsFilterGroups}
+            values={viewState.tabFilters.actions}
+            onChange={(field, value) => setTabFilter("actions", field as ActionsFilterField, value)}
+            onReset={(field) => resetTabFilter("actions", field as ActionsFilterField)}
+            onResetAll={() => resetAllTabFilters("actions")}
           />
-          Show PR runs
-        </label>
-        <FilterChips
-          groups={actionsFilterGroups}
-          values={viewState.tabFilters.actions}
-          onChange={(field, value) => setTabFilter("actions", field as ActionsFilterField, value)}
-          onReset={(field) => resetTabFilter("actions", field as ActionsFilterField)}
-          onResetAll={() => resetAllTabFilters("actions")}
-        />
-        <div class="flex-1" />
-        <ExpandCollapseButtons
-          onExpandAll={() => setAllExpanded("actions", repoGroups().map((g) => g.repoFullName), true)}
-          onCollapseAll={() => setAllExpanded("actions", repoGroups().map((g) => g.repoFullName), false)}
-        />
-        <IgnoreBadge
-          items={viewState.ignoredItems.filter((i) => i.type === "workflowRun")}
-          onUnignore={unignoreItem}
-        />
+        </div>
+        <div class="shrink-0 flex items-center gap-2 py-0.5">
+          <ExpandCollapseButtons
+            onExpandAll={() => setAllExpanded("actions", repoGroups().map((g) => g.repoFullName), true)}
+            onCollapseAll={() => setAllExpanded("actions", repoGroups().map((g) => g.repoFullName), false)}
+          />
+          <IgnoreBadge
+            items={viewState.ignoredItems.filter((i) => i.type === "workflowRun")}
+            onUnignore={unignoreItem}
+          />
+        </div>
       </div>
 
       {/* Loading skeleton — only when no data exists yet */}

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -211,7 +211,7 @@ export default function ActionsTab(props: ActionsTabProps) {
   const highlightedReposActions = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.actions,
-    () => viewState.ignoredItems.length,
+    () => viewState.ignoredItems.filter(i => i.type === "workflowRun").length,
   );
 
   return (

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -323,11 +323,30 @@ export default function DashboardPage() {
 
   const refreshTick = createMemo(() => (dashboardData.lastRefreshedAt?.getTime() ?? 0) + clockTick());
 
-  const tabCounts = createMemo(() => ({
-    issues: dashboardData.issues.length,
-    pullRequests: dashboardData.pullRequests.length,
-    actions: dashboardData.workflowRuns.length,
-  }));
+  const tabCounts = createMemo(() => {
+    const ignoredByType = (type: string) =>
+      new Set(viewState.ignoredItems.filter((i) => i.type === type).map((i) => i.id));
+
+    const ignoredIssues = ignoredByType("issue");
+    const ignoredPRs = ignoredByType("pullRequest");
+    const ignoredRuns = ignoredByType("workflowRun");
+
+    return {
+      issues: dashboardData.issues.filter((i) => {
+        if (ignoredIssues.has(String(i.id))) return false;
+        if (viewState.hideDepDashboard && i.title === "Dependency Dashboard") return false;
+        return true;
+      }).length,
+      pullRequests: dashboardData.pullRequests.filter(
+        (p) => !ignoredPRs.has(String(p.id))
+      ).length,
+      actions: dashboardData.workflowRuns.filter((w) => {
+        if (ignoredRuns.has(String(w.id))) return false;
+        if (!viewState.showPrRuns && w.isPrRun) return false;
+        return true;
+      }).length,
+    };
+  });
 
   const userLogin = createMemo(() => user()?.login ?? "");
   const allUsers = createMemo(() => {

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -324,6 +324,7 @@ export default function DashboardPage() {
   const refreshTick = createMemo(() => (dashboardData.lastRefreshedAt?.getTime() ?? 0) + clockTick());
 
   const tabCounts = createMemo(() => {
+    const { org, repo } = viewState.globalFilter;
     const ignoredByType = (type: string) =>
       new Set(viewState.ignoredItems.filter((i) => i.type === type).map((i) => i.id));
 
@@ -335,14 +336,21 @@ export default function DashboardPage() {
       issues: dashboardData.issues.filter((i) => {
         if (ignoredIssues.has(String(i.id))) return false;
         if (viewState.hideDepDashboard && i.title === "Dependency Dashboard") return false;
+        if (repo && i.repoFullName !== repo) return false;
+        if (org && !i.repoFullName.startsWith(org + "/")) return false;
         return true;
       }).length,
-      pullRequests: dashboardData.pullRequests.filter(
-        (p) => !ignoredPRs.has(String(p.id))
-      ).length,
+      pullRequests: dashboardData.pullRequests.filter((p) => {
+        if (ignoredPRs.has(String(p.id))) return false;
+        if (repo && p.repoFullName !== repo) return false;
+        if (org && !p.repoFullName.startsWith(org + "/")) return false;
+        return true;
+      }).length,
       actions: dashboardData.workflowRuns.filter((w) => {
         if (ignoredRuns.has(String(w.id))) return false;
         if (!viewState.showPrRuns && w.isPrRun) return false;
+        if (repo && w.repoFullName !== repo) return false;
+        if (org && !w.repoFullName.startsWith(org + "/")) return false;
         return true;
       }).length,
     };

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -203,7 +203,7 @@ export default function IssuesTab(props: IssuesTabProps) {
   const highlightedReposIssues = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.issues,
-    () => viewState.ignoredItems.length,
+    () => viewState.ignoredItems.filter(i => i.type === "issue").length,
   );
 
   function handleSort(field: string, direction: "asc" | "desc") {

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -203,6 +203,7 @@ export default function IssuesTab(props: IssuesTabProps) {
   const highlightedReposIssues = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.issues,
+    () => viewState.ignoredItems.length,
   );
 
   function handleSort(field: string, direction: "asc" | "desc") {
@@ -223,49 +224,52 @@ export default function IssuesTab(props: IssuesTabProps) {
   return (
     <div class="flex flex-col h-full">
       {/* Sort dropdown + filter chips + ignore badge toolbar */}
-      <div class="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
-        <SortDropdown
-          options={sortOptions}
-          value={sortPref().field}
-          direction={sortPref().direction}
-          onChange={handleSort}
-        />
-        <FilterChips
-          groups={filterGroups()}
-          values={viewState.tabFilters.issues}
-          onChange={(field, value) => {
-            setTabFilter("issues", field as IssueFilterField, value);
-            setPage(0);
-          }}
-          onReset={(field) => {
-            resetTabFilter("issues", field as IssueFilterField);
-            setPage(0);
-          }}
-          onResetAll={() => {
-            resetAllTabFilters("issues");
-            setPage(0);
-          }}
-        />
-        <button
-          onClick={() => {
-            updateViewState({ hideDepDashboard: !viewState.hideDepDashboard });
-            setPage(0);
-          }}
-          class={`btn btn-xs rounded-full ${!viewState.hideDepDashboard ? "btn-primary" : "btn-ghost text-base-content/50"}`}
-          aria-pressed={!viewState.hideDepDashboard}
-          title="Toggle visibility of Dependency Dashboard issues"
-        >
-          Show Dep Dashboard
-        </button>
-        <div class="flex-1" />
-        <ExpandCollapseButtons
-          onExpandAll={() => setAllExpanded("issues", repoGroups().map((g) => g.repoFullName), true)}
-          onCollapseAll={() => setAllExpanded("issues", repoGroups().map((g) => g.repoFullName), false)}
-        />
-        <IgnoreBadge
-          items={viewState.ignoredItems.filter((i) => i.type === "issue")}
-          onUnignore={unignoreItem}
-        />
+      <div class="flex items-start gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
+        <div class="flex flex-wrap items-center gap-3 min-w-0 flex-1">
+          <SortDropdown
+            options={sortOptions}
+            value={sortPref().field}
+            direction={sortPref().direction}
+            onChange={handleSort}
+          />
+          <FilterChips
+            groups={filterGroups()}
+            values={viewState.tabFilters.issues}
+            onChange={(field, value) => {
+              setTabFilter("issues", field as IssueFilterField, value);
+              setPage(0);
+            }}
+            onReset={(field) => {
+              resetTabFilter("issues", field as IssueFilterField);
+              setPage(0);
+            }}
+            onResetAll={() => {
+              resetAllTabFilters("issues");
+              setPage(0);
+            }}
+          />
+          <button
+            onClick={() => {
+              updateViewState({ hideDepDashboard: !viewState.hideDepDashboard });
+              setPage(0);
+            }}
+            class={`btn btn-xs rounded-full ${!viewState.hideDepDashboard ? "btn-primary" : "btn-ghost text-base-content/50"}`}
+            aria-pressed={!viewState.hideDepDashboard}
+            title="Toggle visibility of Dependency Dashboard issues"
+          >
+            Show Dep Dashboard
+          </button>
+        </div>
+        <div class="shrink-0 flex items-center gap-2 py-0.5">
+          <ExpandCollapseButtons
+            onExpandAll={() => setAllExpanded("issues", repoGroups().map((g) => g.repoFullName), true)}
+            onCollapseAll={() => setAllExpanded("issues", repoGroups().map((g) => g.repoFullName), false)}
+          />
+          <IgnoreBadge
+            items={viewState.ignoredItems.filter((i) => i.type === "issue")}
+            onUnignore={unignoreItem}
+          />
+        </div>
       </div>
 
       {/* Loading skeleton — only when no data exists yet */}

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -301,7 +301,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const highlightedReposPRs = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.pullRequests,
-    () => viewState.ignoredItems.length,
+    () => viewState.ignoredItems.filter(i => i.type === "pullRequest").length,
   );
 
   function handleSort(field: string, direction: "asc" | "desc") {

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -301,6 +301,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const highlightedReposPRs = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
     () => viewState.lockedRepos.pullRequests,
+    () => viewState.ignoredItems.length,
   );
 
   function handleSort(field: string, direction: "asc" | "desc") {
@@ -321,38 +322,41 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   return (
     <div class="flex flex-col h-full">
       {/* Filter toolbar with SortDropdown */}
-      <div class="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
-        <SortDropdown
-          options={sortOptions}
-          value={sortPref().field}
-          direction={sortPref().direction}
-          onChange={handleSort}
-        />
-        <FilterChips
-          groups={filterGroups()}
-          values={viewState.tabFilters.pullRequests}
-          onChange={(field, value) => {
-            setTabFilter("pullRequests", field as PullRequestFilterField, value);
-            setPage(0);
-          }}
-          onReset={(field) => {
-            resetTabFilter("pullRequests", field as PullRequestFilterField);
-            setPage(0);
-          }}
-          onResetAll={() => {
-            resetAllTabFilters("pullRequests");
-            setPage(0);
-          }}
-        />
-        <div class="flex-1" />
-        <ExpandCollapseButtons
-          onExpandAll={() => setAllExpanded("pullRequests", repoGroups().map((g) => g.repoFullName), true)}
-          onCollapseAll={() => setAllExpanded("pullRequests", repoGroups().map((g) => g.repoFullName), false)}
-        />
-        <IgnoreBadge
-          items={viewState.ignoredItems.filter((i) => i.type === "pullRequest")}
-          onUnignore={unignoreItem}
-        />
+      <div class="flex items-start gap-3 px-4 py-2 border-b border-base-300 bg-base-100">
+        <div class="flex flex-wrap items-center gap-3 min-w-0 flex-1">
+          <SortDropdown
+            options={sortOptions}
+            value={sortPref().field}
+            direction={sortPref().direction}
+            onChange={handleSort}
+          />
+          <FilterChips
+            groups={filterGroups()}
+            values={viewState.tabFilters.pullRequests}
+            onChange={(field, value) => {
+              setTabFilter("pullRequests", field as PullRequestFilterField, value);
+              setPage(0);
+            }}
+            onReset={(field) => {
+              resetTabFilter("pullRequests", field as PullRequestFilterField);
+              setPage(0);
+            }}
+            onResetAll={() => {
+              resetAllTabFilters("pullRequests");
+              setPage(0);
+            }}
+          />
+        </div>
+        <div class="shrink-0 flex items-center gap-2 py-0.5">
+          <ExpandCollapseButtons
+            onExpandAll={() => setAllExpanded("pullRequests", repoGroups().map((g) => g.repoFullName), true)}
+            onCollapseAll={() => setAllExpanded("pullRequests", repoGroups().map((g) => g.repoFullName), false)}
+          />
+          <IgnoreBadge
+            items={viewState.ignoredItems.filter((i) => i.type === "pullRequest")}
+            onUnignore={unignoreItem}
+          />
+        </div>
       </div>
 
       {/* Loading skeleton — only when no data exists yet */}

--- a/src/app/lib/reorderHighlight.ts
+++ b/src/app/lib/reorderHighlight.ts
@@ -4,20 +4,24 @@ import { detectReorderedRepos } from "./grouping";
 export function createReorderHighlight(
   getRepoOrder: Accessor<string[]>,
   getLockedOrder: Accessor<string[]>,
+  getIgnoredCount?: Accessor<number>,
 ): Accessor<ReadonlySet<string>> {
   let prevOrder: string[] = [];
   let prevLocked: string[] = [];
+  let prevIgnoredCount = getIgnoredCount?.() ?? 0;
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const [highlighted, setHighlighted] = createSignal<ReadonlySet<string>>(new Set());
 
   createEffect(() => {
     const currentOrder = getRepoOrder();
     const currentLocked = getLockedOrder();
+    const currentIgnoredCount = getIgnoredCount?.() ?? 0;
 
     const lockedChanged = currentLocked.length !== prevLocked.length
       || currentLocked.some((r, i) => r !== prevLocked[i]);
+    const ignoredChanged = currentIgnoredCount !== prevIgnoredCount;
 
-    if (prevOrder.length > 0 && !lockedChanged) {
+    if (prevOrder.length > 0 && !lockedChanged && !ignoredChanged) {
       const moved = detectReorderedRepos(prevOrder, currentOrder);
       if (moved.size > 0) {
         setHighlighted(moved);
@@ -28,6 +32,7 @@ export function createReorderHighlight(
 
     prevOrder = currentOrder;
     prevLocked = [...currentLocked];
+    prevIgnoredCount = currentIgnoredCount;
   });
   onCleanup(() => clearTimeout(timeout));
 

--- a/src/app/lib/reorderHighlight.ts
+++ b/src/app/lib/reorderHighlight.ts
@@ -4,18 +4,18 @@ import { detectReorderedRepos } from "./grouping";
 export function createReorderHighlight(
   getRepoOrder: Accessor<string[]>,
   getLockedOrder: Accessor<string[]>,
-  getIgnoredCount?: Accessor<number>,
+  getIgnoredCount: Accessor<number>,
 ): Accessor<ReadonlySet<string>> {
   let prevOrder: string[] = [];
   let prevLocked: string[] = [];
-  let prevIgnoredCount = getIgnoredCount?.() ?? 0;
+  let prevIgnoredCount = getIgnoredCount();
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const [highlighted, setHighlighted] = createSignal<ReadonlySet<string>>(new Set());
 
   createEffect(() => {
     const currentOrder = getRepoOrder();
     const currentLocked = getLockedOrder();
-    const currentIgnoredCount = getIgnoredCount?.() ?? 0;
+    const currentIgnoredCount = getIgnoredCount();
 
     const lockedChanged = currentLocked.length !== prevLocked.length
       || currentLocked.some((r, i) => r !== prevLocked[i]);

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -277,6 +277,30 @@ describe("DashboardPage — tab badge counts", () => {
     });
   });
 
+  it("combines hideDepDashboard and ignore exclusions correctly", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [
+        makeIssue({ id: 1, title: "Issue A" }),
+        makeIssue({ id: 2, title: "Dependency Dashboard" }),
+        makeIssue({ id: 3, title: "Issue C" }),
+      ],
+      pullRequests: [],
+      workflowRuns: [],
+      errors: [],
+    });
+    // hideDepDashboard defaults true — badge starts at 2 (excludes Dep Dashboard)
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("2");
+    });
+
+    // Ignore one real issue — badge should drop to 1
+    viewStore.ignoreItem({ id: "1", type: "issue", repo: "owner/repo", title: "Issue A", ignoredAt: Date.now() });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+  });
+
   it("decrements PR badge on ignore", async () => {
     vi.mocked(pollService.fetchAllData).mockResolvedValue({
       issues: [],

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -219,8 +219,7 @@ describe("DashboardPage — tab badge counts", () => {
     render(() => <DashboardPage />);
     await waitFor(() => {
       const issuesTab = screen.getByRole("tab", { name: /Issues/ });
-      expect(issuesTab.textContent).toContain("1");
-      expect(issuesTab.textContent).not.toContain("3");
+      expect(issuesTab.textContent?.replace(/\D+/g, "")).toBe("1");
     });
   });
 
@@ -238,17 +237,17 @@ describe("DashboardPage — tab badge counts", () => {
     render(() => <DashboardPage />);
     // hideDepDashboard defaults to true — badge shows 1
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("1");
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("1");
     });
 
     // Toggle off — badge should update to 2
     viewStore.updateViewState({ hideDepDashboard: false });
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("2");
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("2");
     });
   });
 
-  it("decrements badge on ignore and increments on un-ignore", async () => {
+  it("decrements issue badge on ignore and increments on un-ignore", async () => {
     vi.mocked(pollService.fetchAllData).mockResolvedValue({
       issues: [
         makeIssue({ id: 1, title: "Issue A" }),
@@ -262,19 +261,64 @@ describe("DashboardPage — tab badge counts", () => {
 
     render(() => <DashboardPage />);
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("2");
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("2");
     });
 
     // Ignore one item — badge should decrement to 1
     viewStore.ignoreItem({ id: "1", type: "issue", repo: "owner/repo", title: "Issue A", ignoredAt: Date.now() });
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("1");
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("1");
     });
 
     // Un-ignore — badge should increment back to 2
     viewStore.unignoreItem("1");
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("2");
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("2");
+    });
+  });
+
+  it("decrements PR badge on ignore", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [
+        makePullRequest({ id: 10, title: "PR A" }),
+        makePullRequest({ id: 11, title: "PR B" }),
+        makePullRequest({ id: 12, title: "PR C" }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Pull Requests/ }).textContent?.replace(/\D+/g, "")).toBe("3");
+    });
+
+    viewStore.ignoreItem({ id: "10", type: "pullRequest", repo: "owner/repo", title: "PR A", ignoredAt: Date.now() });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Pull Requests/ }).textContent?.replace(/\D+/g, "")).toBe("2");
+    });
+  });
+
+  it("decrements Actions badge on ignore", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [],
+      workflowRuns: [
+        makeWorkflowRun({ id: 20, isPrRun: false }),
+        makeWorkflowRun({ id: 21, isPrRun: false }),
+      ],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("2");
+    });
+
+    viewStore.ignoreItem({ id: "20", type: "workflowRun", repo: "owner/repo", title: "CI", ignoredAt: Date.now() });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
     });
   });
 
@@ -292,9 +336,32 @@ describe("DashboardPage — tab badge counts", () => {
 
     render(() => <DashboardPage />);
     await waitFor(() => {
-      const actionsTab = screen.getByRole("tab", { name: /Actions/ });
-      expect(actionsTab.textContent).toContain("1");
-      expect(actionsTab.textContent).not.toContain("3");
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+  });
+
+  it("includes PR-triggered runs in badge count when showPrRuns is enabled", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [],
+      workflowRuns: [
+        makeWorkflowRun({ id: 20, isPrRun: false }),
+        makeWorkflowRun({ id: 21, isPrRun: true }),
+        makeWorkflowRun({ id: 22, isPrRun: true }),
+      ],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    // Default: showPrRuns=false — badge shows 1
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+
+    // Toggle on — badge should update to 3
+    viewStore.updateViewState({ showPrRuns: true });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("3");
     });
   });
 });

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { makeIssue, makePullRequest, makeWorkflowRun } from "../helpers/index";
-import * as viewStore from "../../src/app/stores/view";
 import type { DashboardData } from "../../src/app/services/poll";
 import type { HotPRStatusUpdate, HotWorkflowRunUpdate } from "../../src/app/services/api";
 
@@ -73,6 +72,7 @@ let capturedOnHotData: ((
 let DashboardPage: typeof import("../../src/app/components/dashboard/DashboardPage").default;
 let pollService: typeof import("../../src/app/services/poll");
 let authStore: typeof import("../../src/app/stores/auth");
+let viewStore: typeof import("../../src/app/stores/view");
 
 beforeEach(async () => {
   // Clear localStorage so loadCachedDashboard doesn't pick up stale data from prior tests
@@ -123,6 +123,7 @@ beforeEach(async () => {
   DashboardPage = dashboardModule.default;
   pollService = await import("../../src/app/services/poll");
   authStore = await import("../../src/app/stores/auth");
+  viewStore = await import("../../src/app/stores/view");
 
   mockLocationReplace.mockClear();
   capturedFetchAll = null;
@@ -199,6 +200,102 @@ describe("DashboardPage — clock tick", () => {
     expect(clearSpy).toHaveBeenCalledWith(clockIntervalId);
     setSpy.mockRestore();
     clearSpy.mockRestore();
+  });
+});
+
+describe("DashboardPage — tab badge counts", () => {
+  it("excludes Dependency Dashboard issues from badge count by default", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [
+        makeIssue({ id: 1, title: "Real issue" }),
+        makeIssue({ id: 2, title: "Dependency Dashboard" }),
+        makeIssue({ id: 3, title: "Dependency Dashboard" }),
+      ],
+      pullRequests: [],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      const issuesTab = screen.getByRole("tab", { name: /Issues/ });
+      expect(issuesTab.textContent).toContain("1");
+      expect(issuesTab.textContent).not.toContain("3");
+    });
+  });
+
+  it("updates badge dynamically when hideDepDashboard is toggled off", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [
+        makeIssue({ id: 1, title: "Real issue" }),
+        makeIssue({ id: 2, title: "Dependency Dashboard" }),
+      ],
+      pullRequests: [],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    // hideDepDashboard defaults to true — badge shows 1
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("1");
+    });
+
+    // Toggle off — badge should update to 2
+    viewStore.updateViewState({ hideDepDashboard: false });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("2");
+    });
+  });
+
+  it("decrements badge on ignore and increments on un-ignore", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [
+        makeIssue({ id: 1, title: "Issue A" }),
+        makeIssue({ id: 2, title: "Issue B" }),
+      ],
+      pullRequests: [],
+      workflowRuns: [],
+      errors: [],
+    });
+    viewStore.updateViewState({ hideDepDashboard: false });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("2");
+    });
+
+    // Ignore one item — badge should decrement to 1
+    viewStore.ignoreItem({ id: "1", type: "issue", repo: "owner/repo", title: "Issue A", ignoredAt: Date.now() });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("1");
+    });
+
+    // Un-ignore — badge should increment back to 2
+    viewStore.unignoreItem("1");
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent).toContain("2");
+    });
+  });
+
+  it("excludes PR-triggered runs from badge count by default", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [],
+      workflowRuns: [
+        makeWorkflowRun({ id: 20, isPrRun: false }),
+        makeWorkflowRun({ id: 21, isPrRun: true }),
+        makeWorkflowRun({ id: 22, isPrRun: true }),
+      ],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      const actionsTab = screen.getByRole("tab", { name: /Actions/ });
+      expect(actionsTab.textContent).toContain("1");
+      expect(actionsTab.textContent).not.toContain("3");
+    });
   });
 });
 

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -396,6 +396,36 @@ describe("DashboardPage — tab badge counts", () => {
       expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
     });
   });
+
+  it("filters badge counts by globalFilter org only", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [
+        makeIssue({ id: 1, repoFullName: "alpha/one" }),
+        makeIssue({ id: 2, repoFullName: "beta/two" }),
+        makeIssue({ id: 3, repoFullName: "alpha/three" }),
+      ],
+      pullRequests: [
+        makePullRequest({ id: 10, repoFullName: "alpha/one" }),
+        makePullRequest({ id: 11, repoFullName: "beta/two" }),
+      ],
+      workflowRuns: [
+        makeWorkflowRun({ id: 20, repoFullName: "beta/two" }),
+        makeWorkflowRun({ id: 21, repoFullName: "alpha/one" }),
+      ],
+      errors: [],
+    });
+    viewStore.updateViewState({
+      hideDepDashboard: false,
+      globalFilter: { org: "alpha", repo: null },
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("2");
+      expect(screen.getByRole("tab", { name: /Pull Requests/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+  });
 });
 
 describe("DashboardPage — data flow", () => {

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -322,9 +322,15 @@ describe("DashboardPage — tab badge counts", () => {
     await waitFor(() => {
       expect(screen.getByRole("tab", { name: /Pull Requests/ }).textContent?.replace(/\D+/g, "")).toBe("2");
     });
+
+    // Un-ignore — badge should increment back to 3
+    viewStore.unignoreItem("10");
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Pull Requests/ }).textContent?.replace(/\D+/g, "")).toBe("3");
+    });
   });
 
-  it("decrements Actions badge on ignore", async () => {
+  it("decrements Actions badge on ignore and increments on un-ignore", async () => {
     vi.mocked(pollService.fetchAllData).mockResolvedValue({
       issues: [],
       pullRequests: [],
@@ -343,6 +349,12 @@ describe("DashboardPage — tab badge counts", () => {
     viewStore.ignoreItem({ id: "20", type: "workflowRun", repo: "owner/repo", title: "CI", ignoredAt: Date.now() });
     await waitFor(() => {
       expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+
+    // Un-ignore — badge should increment back to 2
+    viewStore.unignoreItem("20");
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("2");
     });
   });
 
@@ -386,6 +398,31 @@ describe("DashboardPage — tab badge counts", () => {
     viewStore.updateViewState({ showPrRuns: true });
     await waitFor(() => {
       expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("3");
+    });
+  });
+
+  it("combines showPrRuns and ignore exclusions for Actions badge", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [],
+      workflowRuns: [
+        makeWorkflowRun({ id: 20, isPrRun: false }),
+        makeWorkflowRun({ id: 21, isPrRun: true }),
+        makeWorkflowRun({ id: 22, isPrRun: true }),
+      ],
+      errors: [],
+    });
+    viewStore.updateViewState({ showPrRuns: true });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("3");
+    });
+
+    // Ignore one PR-triggered run — badge should drop to 2
+    viewStore.ignoreItem({ id: "21", type: "workflowRun", repo: "owner/repo", title: "CI", ignoredAt: Date.now() });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("2");
     });
   });
 

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -364,6 +364,38 @@ describe("DashboardPage — tab badge counts", () => {
       expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("3");
     });
   });
+
+  it("filters badge counts by globalFilter repo", async () => {
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [
+        makeIssue({ id: 1, title: "Issue A", repoFullName: "org/alpha" }),
+        makeIssue({ id: 2, title: "Issue B", repoFullName: "org/beta" }),
+        makeIssue({ id: 3, title: "Issue C", repoFullName: "org/alpha" }),
+      ],
+      pullRequests: [
+        makePullRequest({ id: 10, repoFullName: "org/alpha" }),
+        makePullRequest({ id: 11, repoFullName: "org/beta" }),
+      ],
+      workflowRuns: [
+        makeWorkflowRun({ id: 20, repoFullName: "org/alpha" }),
+        makeWorkflowRun({ id: 21, repoFullName: "org/beta" }),
+        makeWorkflowRun({ id: 22, repoFullName: "org/beta" }),
+      ],
+      errors: [],
+    });
+    // Set filter BEFORE render to avoid Kobalte Select onChange cascade in happy-dom
+    viewStore.updateViewState({
+      hideDepDashboard: false,
+      globalFilter: { org: null, repo: "org/alpha" },
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("2");
+      expect(screen.getByRole("tab", { name: /Pull Requests/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+      expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+  });
 });
 
 describe("DashboardPage — data flow", () => {

--- a/tests/lib/reorderHighlight.test.ts
+++ b/tests/lib/reorderHighlight.test.ts
@@ -153,4 +153,34 @@ describe("createReorderHighlight", () => {
 
     disposeRoot();
   });
+
+  it("suppresses highlight when locked repos change simultaneously with reorder", () => {
+    let highlighted!: Accessor<ReadonlySet<string>>;
+    let setOrder!: (v: string[]) => void;
+    let setLocked!: (v: string[]) => void;
+    let disposeRoot!: () => void;
+
+    createRoot((dispose) => {
+      const [order, _setOrder] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked, _setLocked] = createSignal<string[]>([]);
+      const [ignored] = createSignal(0);
+      setOrder = _setOrder;
+      setLocked = _setLocked;
+      highlighted = createReorderHighlight(order, locked, ignored);
+      disposeRoot = dispose;
+    });
+
+    // Reorder AND add a lock in single batch — should suppress
+    batch(() => {
+      setLocked(["c"]);
+      setOrder(["c", "a", "b"]);
+    });
+    expect(highlighted().size).toBe(0);
+
+    // Next reorder without lock change — should highlight
+    setOrder(["b", "c", "a"]);
+    expect(highlighted().size).toBeGreaterThan(0);
+
+    disposeRoot();
+  });
 });

--- a/tests/lib/reorderHighlight.test.ts
+++ b/tests/lib/reorderHighlight.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createRoot, createSignal } from "solid-js";
+import { createRoot, createSignal, batch, type Accessor } from "solid-js";
 import { createReorderHighlight } from "../../src/app/lib/reorderHighlight";
 
 describe("createReorderHighlight", () => {
@@ -7,7 +7,8 @@ describe("createReorderHighlight", () => {
     createRoot((dispose) => {
       const [order] = createSignal<string[]>(["a", "b"]);
       const [locked] = createSignal<string[]>([]);
-      const highlighted = createReorderHighlight(order, locked);
+      const [ignored] = createSignal(0);
+      const highlighted = createReorderHighlight(order, locked, ignored);
 
       expect(highlighted()).toBeInstanceOf(Set);
       expect(highlighted().size).toBe(0);
@@ -20,7 +21,8 @@ describe("createReorderHighlight", () => {
     createRoot((dispose) => {
       const [order] = createSignal<string[]>(["a", "b", "c"]);
       const [locked] = createSignal<string[]>([]);
-      const highlighted = createReorderHighlight(order, locked);
+      const [ignored] = createSignal(0);
+      const highlighted = createReorderHighlight(order, locked, ignored);
 
       // First render seeds prevOrder — no detection
       expect(highlighted().size).toBe(0);
@@ -28,4 +30,127 @@ describe("createReorderHighlight", () => {
     });
   });
 
+  it("highlights reordered repos when ignored count is unchanged", () => {
+    let highlighted!: Accessor<ReadonlySet<string>>;
+    let setOrder!: (v: string[]) => void;
+    let disposeRoot!: () => void;
+
+    createRoot((dispose) => {
+      const [order, _setOrder] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked] = createSignal<string[]>([]);
+      const [ignored] = createSignal(0);
+      setOrder = _setOrder;
+      highlighted = createReorderHighlight(order, locked, ignored);
+      disposeRoot = dispose;
+    });
+
+    // Seed complete — reorder outside batch to trigger effect synchronously
+    setOrder(["c", "a", "b"]);
+    expect(highlighted().size).toBeGreaterThan(0);
+
+    disposeRoot();
+  });
+
+  it("suppresses highlight when ignored count changes simultaneously with reorder", () => {
+    let highlighted!: Accessor<ReadonlySet<string>>;
+    let setOrder!: (v: string[]) => void;
+    let setIgnored!: (v: number) => void;
+    let disposeRoot!: () => void;
+
+    createRoot((dispose) => {
+      const [order, _setOrder] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked] = createSignal<string[]>([]);
+      const [ignored, _setIgnored] = createSignal(0);
+      setOrder = _setOrder;
+      setIgnored = _setIgnored;
+      highlighted = createReorderHighlight(order, locked, ignored);
+      disposeRoot = dispose;
+    });
+
+    // Reorder AND increment ignored count in single batch — should suppress
+    batch(() => {
+      setIgnored(1);
+      setOrder(["c", "a", "b"]);
+    });
+    expect(highlighted().size).toBe(0);
+
+    disposeRoot();
+  });
+
+  it("resumes highlighting after an ignored-count-change cycle", () => {
+    let highlighted!: Accessor<ReadonlySet<string>>;
+    let setOrder!: (v: string[]) => void;
+    let setIgnored!: (v: number) => void;
+    let disposeRoot!: () => void;
+
+    createRoot((dispose) => {
+      const [order, _setOrder] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked] = createSignal<string[]>([]);
+      const [ignored, _setIgnored] = createSignal(0);
+      setOrder = _setOrder;
+      setIgnored = _setIgnored;
+      highlighted = createReorderHighlight(order, locked, ignored);
+      disposeRoot = dispose;
+    });
+
+    // Suppress via batched ignored count change + reorder
+    batch(() => {
+      setIgnored(1);
+      setOrder(["c", "a", "b"]);
+    });
+    expect(highlighted().size).toBe(0);
+
+    // Next reorder without ignore change — should highlight again
+    setOrder(["b", "c", "a"]);
+    expect(highlighted().size).toBeGreaterThan(0);
+
+    disposeRoot();
+  });
+
+  it("seeds prevIgnoredCount correctly with non-zero initial value", () => {
+    let highlighted!: Accessor<ReadonlySet<string>>;
+    let setOrder!: (v: string[]) => void;
+    let disposeRoot!: () => void;
+
+    createRoot((dispose) => {
+      const [order, _setOrder] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked] = createSignal<string[]>([]);
+      const [ignored] = createSignal(3);
+      setOrder = _setOrder;
+      highlighted = createReorderHighlight(order, locked, ignored);
+      disposeRoot = dispose;
+    });
+
+    // Reorder without changing ignored count (still 3) — should highlight
+    setOrder(["c", "a", "b"]);
+    expect(highlighted().size).toBeGreaterThan(0);
+
+    disposeRoot();
+  });
+
+  it("suppresses highlight when ignored count decrements (un-ignore)", () => {
+    let highlighted!: Accessor<ReadonlySet<string>>;
+    let setOrder!: (v: string[]) => void;
+    let setIgnored!: (v: number) => void;
+    let disposeRoot!: () => void;
+
+    createRoot((dispose) => {
+      const [order, _setOrder] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked] = createSignal<string[]>([]);
+      const [ignored, _setIgnored] = createSignal(2);
+      setOrder = _setOrder;
+      setIgnored = _setIgnored;
+      highlighted = createReorderHighlight(order, locked, ignored);
+      disposeRoot = dispose;
+    });
+
+    // Reorder AND decrement ignored count in single batch — should suppress
+    batch(() => {
+      setIgnored(1);
+      setOrder(["c", "a", "b"]);
+    });
+    expect(highlighted().size).toBe(0);
+
+    disposeRoot();
+  });
 });

--- a/tests/lib/reorderHighlight.test.ts
+++ b/tests/lib/reorderHighlight.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createRoot, createSignal, batch, type Accessor } from "solid-js";
 import { createReorderHighlight } from "../../src/app/lib/reorderHighlight";
 
@@ -182,5 +182,32 @@ describe("createReorderHighlight", () => {
     expect(highlighted().size).toBeGreaterThan(0);
 
     disposeRoot();
+  });
+
+  it("clears highlight after 1500ms timeout", () => {
+    vi.useFakeTimers();
+
+    let highlighted!: Accessor<ReadonlySet<string>>;
+    let setOrder!: (v: string[]) => void;
+    let disposeRoot!: () => void;
+
+    createRoot((dispose) => {
+      const [order, _setOrder] = createSignal<string[]>(["a", "b", "c"]);
+      const [locked] = createSignal<string[]>([]);
+      const [ignored] = createSignal(0);
+      setOrder = _setOrder;
+      highlighted = createReorderHighlight(order, locked, ignored);
+      disposeRoot = dispose;
+    });
+
+    setOrder(["c", "a", "b"]);
+    expect(highlighted().size).toBeGreaterThan(0);
+
+    // Advance past the 1500ms clear timeout
+    vi.advanceTimersByTime(1500);
+    expect(highlighted().size).toBe(0);
+
+    disposeRoot();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Tab badges now exclude permanently hidden items (Dependency Dashboard, ignored items, PR-triggered runs) to match what each tab actually displays
- Toolbar layout pins expand/collapse and ignore badge to top-right instead of wrapping to their own row on narrow viewports
- Reorder highlight no longer flashes when ignoring/un-ignoring items