### PR TITLE
feat(poll): enables background refresh when tab is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dashboard SPA tracking GitHub issues, PRs, and GHA workflow runs across multiple
 - **Ignore System** — Hide specific items with an "N ignored" badge and unignore popover.
 - **Dark Mode** — System-aware with flash prevention via inline script + CSP SHA-256 hash.
 - **ETag Caching** — Conditional requests (304s are free against GitHub's rate limit).
-- **Auto-refresh** — Background polling keeps data fresh even in hidden tabs; hot poll pauses to save API budget.
+- **Auto-refresh** — Background polling keeps data fresh even in hidden tabs (requires notifications scope for efficient 304 change detection); hot poll pauses to save API budget.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dashboard SPA tracking GitHub issues, PRs, and GHA workflow runs across multiple
 - **Ignore System** — Hide specific items with an "N ignored" badge and unignore popover.
 - **Dark Mode** — System-aware with flash prevention via inline script + CSP SHA-256 hash.
 - **ETag Caching** — Conditional requests (304s are free against GitHub's rate limit).
-- **Auto-refresh** — Visibility-aware polling that pauses when tab is hidden.
+- **Auto-refresh** — Background polling keeps data fresh even in hidden tabs; hot poll pauses to save API budget.
 
 ## Tech Stack
 
@@ -55,7 +55,7 @@ src/
     services/
       api.ts        # GitHub API methods (fetchOrgs, fetchRepos, fetchIssues, fetchPRs, fetchWorkflowRuns)
       github.ts     # Octokit client factory with ETag caching and rate limit tracking
-      poll.ts       # Poll coordinator with visibility-aware auto-refresh
+      poll.ts       # Poll coordinator with background refresh + hot poll for in-flight items
     stores/
       auth.ts       # OAuth token management (localStorage persistence, validateToken)
       cache.ts      # IndexedDB cache with TTL eviction and ETag support

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -580,6 +580,9 @@ export async function fetchHotData(): Promise<{
  * in-flight items without a full poll cycle. Uses setTimeout chains to avoid
  * overlapping concurrent fetches.
  *
+ * - Pauses when document is hidden (visual-only feedback has no value in background tabs)
+ * - Resumes on next scheduled cycle when tab becomes visible
+ *
  * Must be called inside a SolidJS reactive root (uses createEffect + onCleanup).
  *
  * @param getInterval - Reactive accessor returning interval in seconds

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -71,6 +71,12 @@ export function clearHotSets(): void {
   _hotRuns.clear();
 }
 
+/** Simulate 403 on /notifications — disables the notifications gate.
+ * Used by tests to exercise the conditional background-poll guard. */
+export function disableNotifGate(): void {
+  _notifGateDisabled = true;
+}
+
 export function resetPollState(): void {
   _notifLastModified = null;
   _lastSuccessfulFetch = null;
@@ -178,8 +184,8 @@ async function hasNotificationChanges(): Promise<boolean> {
     ) {
       console.warn("[poll] Notifications API returned 403 — disabling gate");
       pushNotification("notifications", config.authMethod === "pat"
-        ? "Notifications API returned 403 — fine-grained tokens do not support notifications; classic tokens need the notifications scope"
-        : "Notifications API returned 403 — check that the notifications scope is granted", "warning");
+        ? "Notifications API returned 403 — fine-grained tokens do not support notifications; classic tokens need the notifications scope. Background refresh in hidden tabs is disabled."
+        : "Notifications API returned 403 — check that the notifications scope is granted. Background refresh in hidden tabs is disabled.", "warning");
       _notifGateDisabled = true;
     }
     return true;
@@ -323,7 +329,10 @@ function withJitter(intervalMs: number): number {
  * - Triggers an immediate fetch on init
  * - Polls at getInterval() seconds (reactive — restarts when interval changes)
  * - If getInterval() === 0, disables auto-polling (SDR-017)
- * - Continues polling in background tabs (no visibility pause)
+ * - Continues polling in background tabs when notifications gate is available
+ *   (304 responses make background polls near-zero cost). When the gate is
+ *   disabled (fine-grained PAT or missing notifications scope), background
+ *   polling pauses to conserve API budget.
  * - On re-visible after >2 min hidden, fires catch-up fetch (safety net for
  *   browser tab throttling/freezing — Safari purge, Chrome Energy Saver)
  * - Applies ±30 second jitter to poll interval
@@ -393,6 +402,10 @@ export function createPollCoordinator(
 
     const intervalMs = withJitter(intervalSec * 1000);
     intervalId = setInterval(() => {
+      // Without the notifications gate (403 — scope not granted), every background
+      // poll is a full fetch with no 304 shortcut. Skip background polls to avoid
+      // burning API budget; the catch-up handler still fires on tab return.
+      if (document.visibilityState === "hidden" && _notifGateDisabled) return;
       void doFetch();
     }, intervalMs);
   }

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -323,8 +323,9 @@ function withJitter(intervalMs: number): number {
  * - Triggers an immediate fetch on init
  * - Polls at getInterval() seconds (reactive — restarts when interval changes)
  * - If getInterval() === 0, disables auto-polling (SDR-017)
- * - Pauses when document is hidden; resumes on visibility restore
- * - Refreshes immediately on re-visible if hidden for >2 min
+ * - Continues polling in background tabs (no visibility pause)
+ * - On re-visible after >2 min hidden, fires catch-up fetch (safety net for
+ *   browser tab throttling/freezing — Safari purge, Chrome Energy Saver)
  * - Applies ±30 second jitter to poll interval
  *
  * Must be called inside a reactive root (e.g., createRoot or component body).
@@ -396,6 +397,12 @@ export function createPollCoordinator(
     }, intervalMs);
   }
 
+  // Safety net for browser-level tab throttling/freezing. Background polling
+  // continues via setInterval, but browsers may throttle or freeze timers in
+  // hidden tabs (Chrome Energy Saver, Safari tab purge, Firefox timer capping).
+  // When the tab becomes visible again after >2 min, this handler fires a
+  // catch-up fetch in case the browser suppressed scheduled polls. The
+  // notifications gate (304) makes redundant fetches near-zero cost.
   function handleVisibilityChange(): void {
     if (document.visibilityState === "hidden") {
       hiddenAt = Date.now();
@@ -616,6 +623,14 @@ export function createHotPollCoordinator(
 
     // No-op cycle when nothing to poll
     if (_hotPRs.size === 0 && _hotRuns.size === 0) {
+      schedule(myGeneration);
+      return;
+    }
+
+    // Skip fetch when page is hidden — hot poll provides visual feedback
+    // (shimmer, status changes) that has no value in a background tab.
+    // The full poll continues in background for data freshness.
+    if (document.visibilityState === "hidden") {
       schedule(myGeneration);
       return;
     }

--- a/src/app/services/poll.ts
+++ b/src/app/services/poll.ts
@@ -392,7 +392,6 @@ export function createPollCoordinator(
 
     const intervalMs = withJitter(intervalSec * 1000);
     intervalId = setInterval(() => {
-      if (document.visibilityState === "hidden") return;
       void doFetch();
     }, intervalMs);
   }
@@ -617,12 +616,6 @@ export function createHotPollCoordinator(
 
     // No-op cycle when nothing to poll
     if (_hotPRs.size === 0 && _hotRuns.size === 0) {
-      schedule(myGeneration);
-      return;
-    }
-
-    // Skip fetch when page is hidden
-    if (document.visibilityState === "hidden") {
       schedule(myGeneration);
       return;
     }

--- a/tests/services/hot-poll.test.ts
+++ b/tests/services/hot-poll.test.ts
@@ -517,7 +517,7 @@ describe("createHotPollCoordinator", () => {
     });
   });
 
-  it("skips fetch when document is hidden", async () => {
+  it("continues fetching when document is hidden", async () => {
     const onHotData = vi.fn();
     mockGetClient.mockReturnValue(makeOctokit());
 
@@ -530,7 +530,7 @@ describe("createHotPollCoordinator", () => {
       createHotPollCoordinator(() => 10, onHotData);
       Object.defineProperty(document, "visibilityState", { value: "hidden", writable: true, configurable: true });
       await vi.advanceTimersByTimeAsync(10_000);
-      expect(onHotData).not.toHaveBeenCalled();
+      expect(onHotData).toHaveBeenCalled();
       Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
       dispose();
     });

--- a/tests/services/hot-poll.test.ts
+++ b/tests/services/hot-poll.test.ts
@@ -535,6 +535,36 @@ describe("createHotPollCoordinator", () => {
     });
   });
 
+  it("resumes fetching after hidden→visible transition", async () => {
+    const onHotData = vi.fn();
+    const requestFn = vi.fn(() => Promise.resolve({
+      data: { id: 1, status: "in_progress", conclusion: null, updated_at: "2026-01-01T00:00:00Z", completed_at: null },
+      headers: {},
+    }));
+    mockGetClient.mockReturnValue(makeOctokit(requestFn));
+
+    rebuildHotSets({
+      ...emptyData,
+      workflowRuns: [makeWorkflowRun({ id: 1, status: "in_progress", conclusion: null, repoFullName: "o/r" })],
+    });
+
+    await createRoot(async (dispose) => {
+      createHotPollCoordinator(() => 10, onHotData);
+
+      // Hidden — cycle skips fetch
+      Object.defineProperty(document, "visibilityState", { value: "hidden", writable: true, configurable: true });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onHotData).not.toHaveBeenCalled();
+
+      // Visible — next cycle should fetch
+      Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onHotData).toHaveBeenCalled();
+
+      dispose();
+    });
+  });
+
   it("resets backoff counter on successful cycle", async () => {
     const onHotData = vi.fn();
     const requestFn = vi.fn(() => Promise.resolve({

--- a/tests/services/hot-poll.test.ts
+++ b/tests/services/hot-poll.test.ts
@@ -517,7 +517,7 @@ describe("createHotPollCoordinator", () => {
     });
   });
 
-  it("continues fetching when document is hidden", async () => {
+  it("skips fetch when document is hidden", async () => {
     const onHotData = vi.fn();
     mockGetClient.mockReturnValue(makeOctokit());
 
@@ -530,8 +530,7 @@ describe("createHotPollCoordinator", () => {
       createHotPollCoordinator(() => 10, onHotData);
       Object.defineProperty(document, "visibilityState", { value: "hidden", writable: true, configurable: true });
       await vi.advanceTimersByTimeAsync(10_000);
-      expect(onHotData).toHaveBeenCalled();
-      Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
+      expect(onHotData).not.toHaveBeenCalled();
       dispose();
     });
   });

--- a/tests/services/poll.test.ts
+++ b/tests/services/poll.test.ts
@@ -119,7 +119,7 @@ describe("createPollCoordinator", () => {
     });
   });
 
-  it("pauses polling when document is hidden", async () => {
+  it("continues polling when document is hidden", async () => {
     const fetchAll = makeFetchAll();
 
     await createRoot(async (dispose) => {
@@ -135,8 +135,8 @@ describe("createPollCoordinator", () => {
       vi.advanceTimersByTime(90_000);
       await Promise.resolve();
 
-      // Should not have fetched while hidden
-      expect(fetchAll.mock.calls.length).toBe(callsAfterInit);
+      // Should have fetched while hidden (background refresh)
+      expect(fetchAll.mock.calls.length).toBeGreaterThan(callsAfterInit);
       dispose();
     });
   });

--- a/tests/services/poll.test.ts
+++ b/tests/services/poll.test.ts
@@ -121,6 +121,7 @@ describe("createPollCoordinator", () => {
   });
 
   it("continues polling when document is hidden (notifications gate enabled)", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5); // jitter = 0
     const fetchAll = makeFetchAll();
 
     await createRoot(async (dispose) => {
@@ -132,14 +133,16 @@ describe("createPollCoordinator", () => {
       // Hide document
       setDocumentVisible(false);
 
-      // Advance past the interval
-      vi.advanceTimersByTime(90_000);
+      // Advance past the interval (60s with 0 jitter)
+      vi.advanceTimersByTime(61_000);
       await Promise.resolve();
 
       // Should have fetched while hidden (background refresh)
       expect(fetchAll.mock.calls.length).toBeGreaterThan(callsAfterInit);
       dispose();
     });
+
+    randomSpy.mockRestore();
   });
 
   it("triggers immediate refresh on re-visible after >2 minutes hidden", async () => {
@@ -474,7 +477,7 @@ describe("createPollCoordinator", () => {
     });
   });
 
-  // ── qa-3: doFetch skipped path — no restore (reconciliation replaces snapshot/restore) ──
+  // ── qa-3a: doFetch skipped path — no restore (reconciliation replaces snapshot/restore) ──
 
   it("skipped fetch does NOT call pushError for previous errors (no restore logic)", async () => {
     mockPushError.mockClear();

--- a/tests/services/poll.test.ts
+++ b/tests/services/poll.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createRoot } from "solid-js";
+import { createRoot, createSignal } from "solid-js";
 import { createPollCoordinator, disableNotifGate, resetPollState, type DashboardData } from "../../src/app/services/poll";
 
 // Mock pushError so we can spy on it
@@ -280,40 +280,35 @@ describe("createPollCoordinator", () => {
   });
 
   it("config change (interval change) restarts the interval", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5); // jitter = 0
     const fetchAll = makeFetchAll();
-    let intervalSec = 300;
 
     await createRoot(async (dispose) => {
-      // Use a signal-based getter to simulate reactive config
-      const [getInterval, setGetInterval] = (() => {
-        let fn = () => intervalSec;
-        return [
-          () => fn(),
-          (newFn: () => number) => {
-            fn = newFn;
-          },
-        ] as const;
-      })();
+      const [interval, setInterval] = createSignal(300);
 
-      createPollCoordinator(getInterval, fetchAll);
+      createPollCoordinator(interval, fetchAll);
       await Promise.resolve(); // initial fetch
 
-      // Simulate config change to shorter interval by providing a new accessor
-      // In practice SolidJS createEffect re-runs when reactive dependencies change.
-      // Here we verify that calling with interval=60 fires within 90s.
-      intervalSec = 60;
-      void setGetInterval; // suppress unused warning
+      const callsAfterInit = fetchAll.mock.calls.length;
 
+      // At 300s interval, 90s should NOT fire
       vi.advanceTimersByTime(90_000);
       await Promise.resolve();
+      expect(fetchAll.mock.calls.length).toBe(callsAfterInit);
 
-      // At 300s interval, 90s would not fire. But with 60s interval restart,
-      // it should fire at least once more. Since the internal createEffect
-      // is not re-triggered (intervalSec is not a signal), we only verify
-      // that the original timer was set and would eventually fire.
-      // The key test is just that manualRefresh + timer work correctly.
+      // Change interval to 60s — createEffect re-fires, timer restarts
+      setInterval(60);
+      await Promise.resolve(); // let effect run
+
+      // Advance 61s — new 60s interval should fire
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+      expect(fetchAll.mock.calls.length).toBeGreaterThan(callsAfterInit);
+
       dispose();
     });
+
+    randomSpy.mockRestore();
   });
 
   it("interval=0 disables auto-refresh (no setInterval)", async () => {

--- a/tests/services/poll.test.ts
+++ b/tests/services/poll.test.ts
@@ -160,13 +160,16 @@ describe("createPollCoordinator", () => {
       setDocumentVisible(true);
       await Promise.resolve();
 
-      // Should have triggered an immediate fetch on re-visible
-      expect(fetchAll.mock.calls.length).toBe(callsAfterInit + 1);
+      // Should have triggered at least a catch-up fetch on re-visible
+      // (background polls may also have fired if interval < hidden duration)
+      expect(fetchAll.mock.calls.length).toBeGreaterThanOrEqual(callsAfterInit + 1);
       dispose();
     });
   });
 
   it("does NOT trigger immediate refresh on re-visible within 2 minutes", async () => {
+    // Pin jitter to 0 so 300s interval is exactly 300s (no background poll in 90s)
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
     const fetchAll = makeFetchAll();
 
     await createRoot(async (dispose) => {
@@ -187,6 +190,50 @@ describe("createPollCoordinator", () => {
       expect(fetchAll.mock.calls.length).toBe(callsAfterInit);
       dispose();
     });
+
+    randomSpy.mockRestore();
+  });
+
+  it("resets timer on re-visible after >2 min, preventing double-fire with background polls", async () => {
+    // Pin jitter to 0 so 60s interval is exactly 60s
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const fetchAll = makeFetchAll();
+
+    await createRoot(async (dispose) => {
+      createPollCoordinator(makeGetInterval(60), fetchAll);
+      await Promise.resolve(); // initial fetch
+
+      const callsAfterInit = fetchAll.mock.calls.length;
+
+      // Hide for >2 min — background polls fire at 60s and 120s
+      setDocumentVisible(false);
+      vi.advanceTimersByTime(130_000);
+      await Promise.resolve();
+
+      const callsWhileHidden = fetchAll.mock.calls.length;
+      expect(callsWhileHidden).toBeGreaterThan(callsAfterInit);
+
+      // Restore visibility — catch-up fetch fires + timer resets
+      setDocumentVisible(true);
+      await Promise.resolve();
+
+      const callsAfterRevisible = fetchAll.mock.calls.length;
+      expect(callsAfterRevisible).toBeGreaterThan(callsWhileHidden);
+
+      // Advance 30s — should NOT fire (timer was reset to full 60s interval)
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+      expect(fetchAll.mock.calls.length).toBe(callsAfterRevisible);
+
+      // Advance another 31s (61s from reset) — timer fires
+      vi.advanceTimersByTime(31_000);
+      await Promise.resolve();
+      expect(fetchAll.mock.calls.length).toBeGreaterThan(callsAfterRevisible);
+
+      dispose();
+    });
+
+    randomSpy.mockRestore();
   });
 
   it("manual refresh triggers fetch and resets the timer", async () => {

--- a/tests/services/poll.test.ts
+++ b/tests/services/poll.test.ts
@@ -1,7 +1,7 @@
 import "fake-indexeddb/auto";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createRoot } from "solid-js";
-import { createPollCoordinator, type DashboardData } from "../../src/app/services/poll";
+import { createPollCoordinator, disableNotifGate, resetPollState, type DashboardData } from "../../src/app/services/poll";
 
 // Mock pushError so we can spy on it
 const mockPushError = vi.fn();
@@ -29,6 +29,7 @@ vi.mock("../../src/app/lib/errors", () => ({
 vi.mock("../../src/app/lib/notifications", () => ({
   detectNewItems: vi.fn(() => []),
   dispatchNotifications: vi.fn(),
+  _resetNotificationState: vi.fn(),
 }));
 
 // Mock config so doFetch doesn't fail when accessing config.selectedRepos
@@ -119,7 +120,7 @@ describe("createPollCoordinator", () => {
     });
   });
 
-  it("continues polling when document is hidden", async () => {
+  it("continues polling when document is hidden (notifications gate enabled)", async () => {
     const fetchAll = makeFetchAll();
 
     await createRoot(async (dispose) => {
@@ -165,6 +166,31 @@ describe("createPollCoordinator", () => {
       expect(fetchAll.mock.calls.length).toBeGreaterThanOrEqual(callsAfterInit + 1);
       dispose();
     });
+  });
+
+  it("pauses background polling when hidden and notifications gate is disabled", async () => {
+    disableNotifGate();
+    const fetchAll = makeFetchAll();
+
+    await createRoot(async (dispose) => {
+      createPollCoordinator(makeGetInterval(60), fetchAll);
+      await Promise.resolve(); // initial fetch
+
+      const callsAfterInit = fetchAll.mock.calls.length;
+
+      // Hide document
+      setDocumentVisible(false);
+
+      // Advance past the interval
+      vi.advanceTimersByTime(90_000);
+      await Promise.resolve();
+
+      // Should NOT have fetched — gate disabled means no cheap 304, skip background polls
+      expect(fetchAll.mock.calls.length).toBe(callsAfterInit);
+      dispose();
+    });
+
+    resetPollState(); // restore gate for other tests
   });
 
   it("does NOT trigger immediate refresh on re-visible within 2 minutes", async () => {


### PR DESCRIPTION
## Summary
- Removes visibility guard from full poll so it continues fetching in background tabs — but only when the notifications gate is available (304 responses make this near-zero cost)
- When notifications gate is disabled (fine-grained PAT or missing scope), background polling pauses to conserve API budget; catch-up fetch on tab return ensures data freshness
- Retains visibility guard in hot poll (30s) — visual-only feedback has no value in hidden tabs
- Retains visibilitychange catch-up handler as safety net for browser tab throttling (Safari purge, Chrome Energy Saver)