### PR TITLE
fix(ui): prevents navbar jump when notification drawer opens

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -165,6 +165,36 @@ test("switching tabs changes active tab indicator", async ({ page }) => {
   await expect(actionsTab).toHaveAttribute("aria-selected", "true");
 });
 
+test("fixed elements compensate for scrollbar width when scroll is locked", async ({ page }) => {
+  await setupAuth(page);
+  await page.goto("/dashboard");
+
+  const navbar = page.locator(".navbar");
+  const footer = page.locator(".app-footer");
+  await expect(navbar).toBeVisible();
+  await expect(footer).toBeVisible();
+
+  // Baseline: navbar 0.5rem (8px) from daisyUI, footer 0px (no base padding)
+  expect(parseFloat(await navbar.evaluate((el) => getComputedStyle(el).paddingRight))).toBeCloseTo(8, 0);
+  expect(parseFloat(await footer.evaluate((el) => getComputedStyle(el).paddingRight))).toBeCloseTo(0, 0);
+
+  // Simulate solid-prevent-scroll setting --scrollbar-width on body
+  await page.evaluate(() => {
+    document.body.style.setProperty("--scrollbar-width", "15px");
+  });
+
+  // Navbar: 8px + 15px = 23px, footer: 0px + 15px = 15px
+  expect(parseFloat(await navbar.evaluate((el) => getComputedStyle(el).paddingRight))).toBeCloseTo(23, 0);
+  expect(parseFloat(await footer.evaluate((el) => getComputedStyle(el).paddingRight))).toBeCloseTo(15, 0);
+
+  // Clear — both return to baseline
+  await page.evaluate(() => {
+    document.body.style.removeProperty("--scrollbar-width");
+  });
+  expect(parseFloat(await navbar.evaluate((el) => getComputedStyle(el).paddingRight))).toBeCloseTo(8, 0);
+  expect(parseFloat(await footer.evaluate((el) => getComputedStyle(el).paddingRight))).toBeCloseTo(0, 0);
+});
+
 test("dashboard shows empty state with no data", async ({ page }) => {
   await setupAuth(page);
   await page.goto("/dashboard");

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -428,7 +428,7 @@ export default function DashboardPage() {
           </main>
         </div>
 
-        <footer class="fixed bottom-0 left-0 right-0 z-30 border-t border-base-300 bg-base-100 py-3 text-xs text-base-content/50">
+        <footer class="app-footer fixed bottom-0 left-0 right-0 z-30 border-t border-base-300 bg-base-100 py-3 text-xs text-base-content/50">
           <div class="max-w-6xl mx-auto w-full px-4 grid grid-cols-3 items-center">
             <div />
             <div class="flex items-center justify-center gap-3">

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -144,7 +144,7 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
 
   return (
     <div
-      class={`flex items-center gap-3 ${paddingClass()} hover:bg-base-200 group ${props.isFlashing ? "animate-flash" : props.isPolling ? "animate-shimmer" : ""}`}
+      class={`flex items-center gap-3 ${paddingClass()} group ${props.run.conclusion === "failure" ? "bg-error/5 hover:bg-error/10" : "hover:bg-base-200"} ${props.isFlashing ? "animate-flash" : props.isPolling ? "animate-shimmer" : ""}`}
     >
       <StatusIcon status={props.run.status} conclusion={props.run.conclusion} />
 

--- a/src/app/components/shared/NotificationDrawer.tsx
+++ b/src/app/components/shared/NotificationDrawer.tsx
@@ -25,7 +25,7 @@ export default function NotificationDrawer(props: NotificationDrawerProps) {
   }
 
   return (
-    <Dialog open={props.open} onOpenChange={(open) => !open && props.onClose()} modal>
+    <Dialog open={props.open} onOpenChange={(open) => !open && props.onClose()} modal preventScroll={false}>
       <Dialog.Portal>
         <Dialog.Overlay class="drawer-overlay fixed inset-0 bg-black/50 z-[70]" data-testid="notification-overlay" />
         <Dialog.Content class="drawer-content fixed top-0 right-0 h-full w-80 sm:w-96 bg-base-100 shadow-xl z-[71] flex flex-col">

--- a/src/app/components/shared/NotificationDrawer.tsx
+++ b/src/app/components/shared/NotificationDrawer.tsx
@@ -25,7 +25,7 @@ export default function NotificationDrawer(props: NotificationDrawerProps) {
   }
 
   return (
-    <Dialog open={props.open} onOpenChange={(open) => !open && props.onClose()} modal preventScroll={false}>
+    <Dialog open={props.open} onOpenChange={(open) => !open && props.onClose()} modal>
       <Dialog.Portal>
         <Dialog.Overlay class="drawer-overlay fixed inset-0 bg-black/50 z-[70]" data-testid="notification-overlay" />
         <Dialog.Content class="drawer-content fixed top-0 right-0 h-full w-80 sm:w-96 bg-base-100 shadow-xl z-[71] flex flex-col">

--- a/src/app/components/shared/StatusDot.tsx
+++ b/src/app/components/shared/StatusDot.tsx
@@ -17,12 +17,12 @@ const STATUS_CONFIG = {
     pulse: true,
   },
   failure: {
-    bg: "bg-error",
+    bg: "bg-error ring-2 ring-error/30",
     label: "Checks failing",
     pulse: false,
   },
   error: {
-    bg: "bg-error",
+    bg: "bg-error ring-2 ring-error/30",
     label: "Checks failing",
     pulse: false,
   },

--- a/src/app/components/shared/StatusDot.tsx
+++ b/src/app/components/shared/StatusDot.tsx
@@ -17,12 +17,12 @@ const STATUS_CONFIG = {
     pulse: true,
   },
   failure: {
-    bg: "bg-error ring-2 ring-error/30",
+    bg: "bg-red-500",
     label: "Checks failing",
     pulse: false,
   },
   error: {
-    bg: "bg-error ring-2 ring-error/30",
+    bg: "bg-red-500",
     label: "Checks failing",
     pulse: false,
   },

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -114,7 +114,7 @@
 .navbar {
   padding-right: calc(0.5rem + var(--scrollbar-width, 0px));
 }
-footer {
+.app-footer {
   padding-right: var(--scrollbar-width, 0px);
 }
 

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -111,6 +111,9 @@
 /* solid-prevent-scroll sets --scrollbar-width on body when scroll is locked;
    fixed elements don't inherit body padding-right, so compensate explicitly */
 .navbar {
+  padding-right: calc(0.5rem + var(--scrollbar-width, 0px));
+}
+footer {
   padding-right: var(--scrollbar-width, 0px);
 }
 

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -109,7 +109,8 @@
 
 /* ── Fixed-element scrollbar compensation ────────────────────────────────── */
 /* solid-prevent-scroll sets --scrollbar-width on body when scroll is locked;
-   fixed elements don't inherit body padding-right, so compensate explicitly */
+   fixed elements don't inherit body padding-right, so compensate explicitly.
+   0.5rem matches daisyUI .navbar padding (padding: .5rem) */
 .navbar {
   padding-right: calc(0.5rem + var(--scrollbar-width, 0px));
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -107,6 +107,13 @@
   animation: overlay-fade-in 0.3s ease-out forwards;
 }
 
+/* ── Fixed-element scrollbar compensation ────────────────────────────────── */
+/* solid-prevent-scroll sets --scrollbar-width on body when scroll is locked;
+   fixed elements don't inherit body padding-right, so compensate explicitly */
+.navbar {
+  padding-right: var(--scrollbar-width, 0px);
+}
+
 /* ── Kobalte → daisyUI bridges ───────────────────────────────────────────── */
 
 /* Kobalte Tabs: data-selected → daisyUI tab-active */


### PR DESCRIPTION
## Summary
- Adds CSS `padding-right` compensation using `--scrollbar-width` CSS variable to fixed navbar and footer
- Scopes footer CSS selector to `.app-footer` class (consistent with file conventions)
- Adds E2E test verifying scrollbar compensation for both navbar and footer (baseline, compensated, reset)
- Makes CI failure indicators more noticeable: vivid `red-500` status dots and `bg-error/5` tint on failed workflow rows