### PR TITLE
feat(ui): add accessible tooltips and user documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,3 +81,5 @@ Scope is optional. Use imperative mood: "add feature", not "adds feature" or "ad
 All PRs target `main` on `gordon-code/github-tracker`. Keep PRs focused — one feature or fix per PR makes review faster and reverts cleaner.
 
 In the PR body, describe what changed and why. CI runs typecheck, unit tests, and E2E tests automatically. PRs need a passing CI run before merge.
+
+When adding or changing user-facing features, update [docs/USER_GUIDE.md](docs/USER_GUIDE.md) to reflect the changes.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ src/
       view.ts       # View state (tabs, sorting, filters, ignored items, locked repos)
   worker/
     index.ts        # OAuth token exchange endpoint, CORS, security headers
-tests/              # 1535 unit/component tests across 70 test files
+tests/              # unit/component tests across 70 test files
 e2e/                # 15 E2E tests across 3 spec files
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Open issues where you're the creator, assignee, or mentioned. A scope filter let
 
 ### Pull Requests
 
-Open PRs with CI status dots (green/yellow/red), review decision badges, size badges (XS–XXL by lines changed), and draft indicators. A "blocked" filter catches PRs where checks are failing or a review requested changes. The scope filter works here too. Reviewer avatars stack for multiple reviewers.
+Open PRs with CI status dots (green/yellow/red), review decision badges, size badges (XS–XL by lines changed), and draft indicators. A "blocked" filter catches PRs where checks are failing or a review requested changes. The scope filter works here too. Reviewer avatars stack for multiple reviewers.
 
 ### Actions
 
@@ -100,11 +100,11 @@ src/
       layout/       # Header, TabBar, FilterBar
       onboarding/   # OnboardingWizard, OrgSelector, RepoSelector
       settings/     # SettingsPage, TrackedUsersSection, ThemePicker, Section, SettingRow
-      shared/       # 18 shared components: FilterInput, FilterChips, StatusDot,
+      shared/       # 19 shared components: FilterInput, FilterChips, StatusDot,
                     # ReviewBadge, SizeBadge, RoleBadge, SortDropdown, PaginationControls,
                     # LoadingSpinner, SkeletonRows, ToastContainer, NotificationDrawer,
                     # RepoLockControls, UserAvatarBadge, ExpandCollapseButtons,
-                    # RepoGitHubLink, ChevronIcon, ExternalLinkIcon
+                    # RepoGitHubLink, ChevronIcon, ExternalLinkIcon, Tooltip/InfoTooltip
     lib/            # 14 modules: format, errors, notifications, oauth, pat, url,
                     # flashDetection, grouping, reorderHighlight, collections,
                     # emoji, label-colors, sentry, github-emoji-map.json

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A dashboard for tracking GitHub issues, PRs, and Actions workflow runs across ma
 
 ![Dashboard](docs/dashboard-screenshot.png)
 
+## Documentation
+
+For detailed feature documentation, see the [User Guide](docs/USER_GUIDE.md).
+
 ## Features
 
 ### Issues

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ src/
       view.ts       # View state (tabs, sorting, filters, ignored items, locked repos)
   worker/
     index.ts        # OAuth token exchange endpoint, CORS, security headers
-tests/              # 1522 unit/component tests across 69 test files
-e2e/                # 14 E2E tests across 2 spec files
+tests/              # 1534 unit/component tests across 70 test files
+e2e/                # 15 E2E tests across 3 spec files
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ src/
       view.ts       # View state (tabs, sorting, filters, ignored items, locked repos)
   worker/
     index.ts        # OAuth token exchange endpoint, CORS, security headers
-tests/              # 1534 unit/component tests across 70 test files
+tests/              # 1535 unit/component tests across 70 test files
 e2e/                # 15 E2E tests across 3 spec files
 ```
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -129,7 +129,7 @@ Filters can be combined. Click **Reset all** to clear all active filters at once
 
 ### Dependency Dashboard Toggle
 
-The **Show Dep Dashboard** button controls whether the Renovate "Dependency Dashboard" issue appears in the list. It is hidden by default. This setting applies across all repos.
+The **Show Dep Dashboard** button controls whether the Renovate "Dependency Dashboard" issue appears in the list. The Dependency Dashboard issue is hidden by default. This setting applies across all repos.
 
 ### Issues Sorting
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,409 @@
+# GitHub Tracker User Guide
+
+GitHub Tracker is a dashboard that aggregates open issues, pull requests, and GitHub Actions workflow runs across your repositories into a single view at [gh.gordoncode.dev](https://gh.gordoncode.dev).
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+  - [OAuth Sign-In](#oauth-sign-in)
+  - [Personal Access Token Sign-In](#personal-access-token-sign-in)
+  - [Repository Selection](#repository-selection)
+  - [Organization Access](#organization-access)
+- [Dashboard Overview](#dashboard-overview)
+  - [Tab Structure](#tab-structure)
+  - [Personal Summary Strip](#personal-summary-strip)
+  - [Repo Grouping and Expand/Collapse](#repo-grouping-and-expandcollapse)
+  - [Scope Filter](#scope-filter)
+- [Issues Tab](#issues-tab)
+  - [Filters](#issues-filters)
+  - [Dependency Dashboard Toggle](#dependency-dashboard-toggle)
+  - [Sorting](#issues-sorting)
+  - [Ignored Items](#ignored-items)
+- [Pull Requests Tab](#pull-requests-tab)
+  - [Status Indicators](#status-indicators)
+  - [Filters](#pull-requests-filters)
+  - [Sorting](#pull-requests-sorting)
+- [Actions Tab](#actions-tab)
+  - [Workflow Grouping](#workflow-grouping)
+  - [Show PR Runs](#show-pr-runs)
+  - [Filters](#actions-filters)
+- [Multi-User Tracking](#multi-user-tracking)
+- [Monitor-All Mode](#monitor-all-mode)
+- [Upstream Repos](#upstream-repos)
+- [Refresh and Polling](#refresh-and-polling)
+- [Notifications](#notifications)
+- [Repo Pinning](#repo-pinning)
+- [Settings Reference](#settings-reference)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Getting Started
+
+### OAuth Sign-In
+
+OAuth is the recommended sign-in method. Click **Sign in with GitHub** on the login page and authorize the application. GitHub will redirect you back with a token that grants access to `repo`, `read:org`, and `notifications` scopes.
+
+OAuth tokens work across all organizations you belong to and support the notifications optimization that reduces API usage in background tabs.
+
+### Personal Access Token Sign-In
+
+If you prefer not to use OAuth, you can sign in with a GitHub Personal Access Token (PAT). Click **Use a Personal Access Token** on the login page and paste your token.
+
+Two token formats are accepted:
+
+- **Classic tokens** (starts with `ghp_`) — recommended. Works across all organizations you belong to. Required scopes: `repo`, `read:org` (under admin:org), `notifications`.
+- **Fine-grained tokens** (starts with `github_pat_`) — also work, but have limitations: they only access one organization at a time, do not support the `notifications` scope, and therefore cannot use the background-poll optimization. Required permissions: Actions (read), Contents (read), Issues (read), Pull requests (read).
+
+The token is validated against the GitHub API before being stored. It is saved permanently in your browser's `localStorage` — you will not need to re-enter it on revisit.
+
+### Repository Selection
+
+After signing in, the onboarding wizard asks you to select repositories to track. Search by name or browse by organization. You can change your selection at any time in **Settings > Repositories**.
+
+### Organization Access
+
+OAuth sign-in uses your existing GitHub org memberships. If a private organization does not appear in the repo selector, click **Manage org access** in Settings to open GitHub's OAuth application settings and grant access to that organization. When you return to the tracker, it automatically syncs your updated org list.
+
+---
+
+## Dashboard Overview
+
+### Tab Structure
+
+The dashboard has three tabs:
+
+| Tab | Contents |
+|-----|----------|
+| **Issues** | Open issues across your selected repos where you are the author, assignee, or mentioned |
+| **Pull Requests** | Open PRs where you are the author, reviewer, or assignee |
+| **Actions** | Recent workflow runs for your selected repos |
+
+The active tab is remembered across page loads by default. You can set a fixed default tab in Settings.
+
+### Personal Summary Strip
+
+A summary strip appears directly below the tab bar whenever there is actionable activity. It shows counts for:
+
+- **Issues assigned** to you
+- **PRs awaiting your review** (you are a requested reviewer and the PR needs review)
+- **PRs ready to merge** (you are the author, checks pass, PR is approved or has no review requirement, not a draft)
+- **PRs blocked** (you are the author, PR is not a draft, checks are failing or there is a merge conflict)
+- **Actions running** (in-progress workflow runs, excluding ignored items)
+
+Clicking any count switches to the relevant tab and applies filters that match what was counted. This lets you jump directly to the most important items.
+
+Counts are computed across all repos regardless of any org or repo filter you have active on the tab.
+
+### Repo Grouping and Expand/Collapse
+
+Items are grouped by repository. Each repo group has a header row showing the repo name, item count, and a summary of statuses (check results, review decisions, role counts). Click a repo header to expand or collapse that group.
+
+Use the **Expand all** / **Collapse all** buttons in the toolbar to expand or collapse all groups at once.
+
+When a group is collapsed, a brief preview of any status change detected by the hot poll appears under the header for a few seconds before fading.
+
+### Scope Filter
+
+The **Scope** filter chip appears on the Issues and Pull Requests tabs when you have tracked users configured or monitor-all repos enabled. It has two options:
+
+- **Involves me** (default) — shows only items where you (the signed-in user) are the author, assignee, reviewer, or mentioned. For monitored repos, all activity in that repo is always shown regardless of scope.
+- **All activity** — shows every open item across your selected repos. Items that involve you are highlighted with a blue left border.
+
+The scope filter is hidden (and always set to "Involves me") when you have no tracked users and no monitor-all repos, because in that configuration all fetched data already involves you.
+
+---
+
+## Issues Tab
+
+### Issues Filters
+
+| Filter | Options | Default |
+|--------|---------|---------|
+| Scope | Involves me / All activity | Involves me |
+| Role | All / Author / Assignee | All |
+| Comments | All / Has comments / No comments | All |
+| User | All / (tracked user logins) | All (shown when tracked users are configured) |
+
+Filters can be combined. Click **Reset all** to clear all active filters at once.
+
+### Dependency Dashboard Toggle
+
+The **Show Dep Dashboard** button controls whether the Renovate "Dependency Dashboard" issue appears in the list. It is hidden by default. This setting applies across all repos.
+
+### Issues Sorting
+
+Sort by: Repo, Title, Author, Comments, Created, Updated (default: Updated, descending).
+
+### Ignored Items
+
+Each issue row has an ignore button (visible on hover). Ignored items are hidden from the list. To restore ignored items, click the **Ignored** badge in the toolbar, which lists all currently ignored items with an option to unignore each one. Ignored items are automatically pruned after 30 days.
+
+---
+
+## Pull Requests Tab
+
+### Status Indicators
+
+Each PR row displays several indicators:
+
+#### Check Status Dot
+
+A small colored dot shows the aggregate CI status for the PR's latest commit:
+
+| Color | Meaning |
+|-------|---------|
+| Green (solid) | All checks passed |
+| Yellow (pulsing) | Checks in progress |
+| Red (solid) | Checks failing |
+| Yellow/faded (solid) | Checks blocked by merge conflict |
+| Gray (solid) | No checks configured |
+
+The dot links to the PR's checks page on GitHub.
+
+#### Review Badges
+
+| Badge | Meaning |
+|-------|---------|
+| Approved | At least one approving review, no blocking reviews |
+| Changes requested | At least one reviewer requested changes |
+| Needs review | Review has been requested but not yet submitted |
+| Dismissed | Previously submitted review was dismissed |
+
+#### Size Badges
+
+PR size is computed from total lines changed (additions + deletions):
+
+| Badge | Total lines changed |
+|-------|---------------------|
+| XS | Less than 10 |
+| S | 10 to 99 |
+| M | 100 to 499 |
+| L | 500 to 999 |
+| XL | 1,000 or more |
+
+The size badge links to the PR's file diff on GitHub.
+
+#### Role Badges
+
+Shows your involvement in the PR: **Author**, **Reviewer**, **Assignee**, or **Involved** (for items in upstream repos where you have no direct role).
+
+### Pull Requests Filters
+
+| Filter | Options | Default |
+|--------|---------|---------|
+| Scope | Involves me / All activity | Involves me |
+| Role | All / Author / Reviewer / Assignee | All |
+| Review | All / Approved / Changes / Needs review / Mergeable | All |
+| Status | All / Draft / Ready | All |
+| Checks | All / Passing / Failing / Pending / Conflict / Blocked / No CI | All |
+| Size | All / XS / S / M / L / XL | All |
+| User | All / (tracked user logins) | All (shown when tracked users are configured) |
+
+**Mergeable** in the Review filter matches PRs that are approved or have no review requirement (equivalent to "safe to merge from review standpoint").
+
+**Blocked** in the Checks filter matches PRs with failing checks or a merge conflict.
+
+### Pull Requests Sorting
+
+Sort by: Repo, Title, Author, Checks, Review, Size, Created, Updated (default: Updated, descending).
+
+---
+
+## Actions Tab
+
+### Workflow Grouping
+
+Workflow runs are grouped first by repository, then by workflow name. Each workflow group shows its most recent runs up to the configured limit (default: 3 runs per workflow, up to 5 workflows per repo).
+
+### Show PR Runs
+
+By default, runs triggered by pull request events are hidden to reduce noise. Toggle **Show PR runs** to include them. This preference is saved across sessions.
+
+### Actions Filters
+
+| Filter | Options | Default |
+|--------|---------|---------|
+| Conclusion | All / Success / Failure / Cancelled / Running / Other | All |
+| Event | All / Push / Pull request / Schedule / Workflow dispatch / Other | All |
+
+---
+
+## Multi-User Tracking
+
+You can track another GitHub user's issues and PRs alongside your own. Go to **Settings > Tracked Users**, enter a GitHub username, and click **Add**. The app validates the username against the GitHub API before saving.
+
+- Tracked user items appear in the same Issues and Pull Requests tabs, mixed with your own items.
+- Each item shows small avatar badges indicating which tracked users it was surfaced by.
+- When multiple users are tracked, a **User** filter chip appears on the Issues and Pull Requests tabs, letting you view activity for one user at a time.
+- Both regular GitHub users and bot accounts (e.g., `renovate[bot]`) can be tracked. Bot accounts are labeled with a "Bot" badge in the Tracked Users section.
+
+**API usage note:** Each tracked user adds one additional GraphQL search query per poll cycle. At 3 or more tracked users, a warning appears in Settings. The hard cap is 10 tracked users.
+
+---
+
+## Monitor-All Mode
+
+Normally, the dashboard shows only issues and PRs that involve you (or a tracked user). Monitor-all mode shows every open issue and PR in a specific repo — regardless of whether anyone you track is involved.
+
+**How to enable:** In **Settings > Repositories**, expand the repo panel. Each repo has an eye icon toggle. Enabling it adds the repo to the monitored list (maximum 10 monitored repos).
+
+**Effect on display:** Repo groups for monitored repos show a **Monitoring all** badge in their header. Items from monitored repos are always visible even when the Scope filter is set to "Involves me", and they bypass the User filter.
+
+Upstream repos cannot be monitored (only selected repos are eligible).
+
+---
+
+## Upstream Repos
+
+Upstream repos are repositories that you contribute to but do not own — for example, open-source projects you have pull requests in.
+
+**Auto-discovery:** The app discovers upstream repos automatically by searching for issues and PRs involving you across GitHub (not limited to your selected repos). Discovered repos appear in **Settings > Repositories** under "Upstream repos" and are added to issue and PR fetches.
+
+**Manual management:** You can add or remove upstream repos manually in the Settings repo panel.
+
+Upstream repos are included in Issues and Pull Requests fetches but excluded from the Actions tab, since workflow run access requires explicit repo permissions.
+
+---
+
+## Refresh and Polling
+
+### Full Refresh
+
+The dashboard polls GitHub at a configurable interval (default: **5 minutes**). Each full refresh fetches all issues, PRs, and workflow runs. You can trigger a manual refresh by clicking the refresh button in the header.
+
+Setting the interval to **Off** disables automatic polling; manual refresh still works.
+
+A ±30 second jitter is applied to the refresh interval to avoid synchronized API spikes from multiple browser tabs.
+
+### Hot Poll
+
+A second, faster poll loop runs alongside the full refresh specifically for in-flight items. It targets:
+
+- **PRs with pending CI checks** — re-checks status until checks resolve
+- **In-progress workflow runs** — re-checks until the run completes
+
+Default interval: **30 seconds** (configurable from 10 to 120 seconds in Settings).
+
+While the hot poll is active, a subtle shimmer animation appears on affected PR rows. When a status changes, the row flashes briefly to draw attention.
+
+The hot poll pauses automatically when the browser tab is hidden (since visual feedback has no value in a background tab).
+
+### Tab Visibility Behavior
+
+When the tab is hidden:
+
+- The **hot poll always pauses** (it provides only visual feedback).
+- The **full poll continues in background** when the notifications gate is available (OAuth or classic PAT with `notifications` scope). The gate uses `If-Modified-Since` headers for near-zero-cost 304 checks that do not count against your rate limit.
+- When the notifications gate is **unavailable** (fine-grained PAT or classic PAT missing the `notifications` scope), the full poll also pauses in background tabs to conserve API budget.
+
+When you return to a tab that has been hidden for more than 2 minutes, a catch-up fetch fires immediately regardless of where the timer is in its cycle.
+
+---
+
+## Notifications
+
+### Notification Drawer
+
+The bell icon in the header opens the notification drawer, which shows API errors, rate limit warnings, and other system messages. Notifications are dismissed automatically when the underlying condition clears on the next poll cycle.
+
+### Browser Push Notifications
+
+Browser push notifications are disabled by default. To enable them:
+
+1. Go to **Settings > Notifications**.
+2. Click **Grant permission** and allow notifications in the browser prompt.
+3. Toggle **Enable notifications** on.
+
+Per-type toggles (all default to on when notifications are enabled):
+
+| Toggle | What triggers a notification |
+|--------|------------------------------|
+| Issues | New issues are opened in your tracked repos |
+| Pull Requests | New PRs are opened or updated |
+| Workflow Runs | Workflow runs complete |
+
+---
+
+## Repo Pinning
+
+Each repo group header has a pin (lock) control, visible on hover on desktop and always visible on mobile. Pinning a repo keeps it at the top of the list within its tab regardless of sort order or how recently it was updated.
+
+- Click the pin icon to pin a repo to the top.
+- Click it again to unpin.
+- Use the up/down arrows (visible when pinned) to reorder pinned repos relative to each other.
+
+Pin state is per-tab — a repo can be pinned on the Issues tab but not the Pull Requests tab.
+
+---
+
+## Settings Reference
+
+Settings are saved automatically to `localStorage` and persist across sessions. All settings can be exported as a JSON file via **Settings > Data > Export**.
+
+### Config Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Refresh interval | 5 minutes | How often to poll GitHub for new data. Options: 1, 2, 5, 10, 15, 30 minutes, or Off. |
+| CI status refresh (hot poll interval) | 30 seconds | How often to re-check in-flight CI checks and workflow runs. Range: 10–120 seconds. |
+| Max workflows per repo | 5 | Number of active workflows to track per repository. Range: 1–20. |
+| Max runs per workflow | 3 | Number of recent runs to show per workflow. Range: 1–10. |
+| Notifications enabled | Off | Master toggle for browser push notifications. |
+| Notify: Issues | On | Notify when new issues open (requires notifications enabled). |
+| Notify: Pull Requests | On | Notify when PRs are opened or updated (requires notifications enabled). |
+| Notify: Workflow Runs | On | Notify when workflow runs complete (requires notifications enabled). |
+| Theme | Auto | UI color theme. Auto follows system dark/light preference (Corporate for light, Dim for dark). |
+| View density | Comfortable | Spacing between list items. Options: Comfortable, Compact. |
+| Items per page | 25 | Number of items per page in each tab. Options: 10, 25, 50, 100. |
+| Default tab | Issues | Tab shown when opening the dashboard fresh (without remembered last tab). |
+| Remember last tab | On | Return to the last active tab on revisit. |
+
+### View State Settings
+
+These are UI preferences that persist across sessions but are not included in the exported config file.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Scope filter (Issues) | Involves me | Whether to show only items involving you or all activity. |
+| Scope filter (Pull Requests) | Involves me | Whether to show only items involving you or all activity. |
+| Show PR runs (Actions) | Off | Whether to show workflow runs triggered by pull request events. |
+| Hide Dependency Dashboard | On | Whether to hide the Renovate Dependency Dashboard issue. |
+| Sort preferences | Updated (desc) | Sort field and direction per tab, remembered across sessions. |
+| Pinned repos | (none) | Repos pinned to the top of each tab's list. |
+
+---
+
+## Troubleshooting
+
+**Items I expect to see are not showing up.**
+
+- Check that the Scope filter is set correctly. "Involves me" hides items where you have no direct involvement. Switch to "All activity" to see everything.
+- Verify the repo is in your selected repo list (Settings > Repositories).
+- Check if the item was accidentally ignored (toolbar Ignored badge).
+- If you recently added the repo, wait for the next full refresh or click the manual refresh button.
+
+**I see a rate limit warning.**
+
+The tracker uses GitHub's GraphQL and REST APIs. Each poll cycle consumes some of your 5,000 request hourly budget. Tracking many repos, tracked users, or having a short refresh interval increases consumption. Increasing the refresh interval or reducing the number of tracked repos will reduce API usage.
+
+OAuth tokens and classic PATs use the notifications gate (304 shortcut), which significantly reduces per-cycle cost when nothing has changed. Fine-grained PATs do not support this optimization.
+
+**PAT vs OAuth: what is the difference?**
+
+OAuth tokens (from "Sign in with GitHub") work across all your organizations and support all features including the notifications background-poll optimization. Classic PATs with the correct scopes (`repo`, `read:org`, `notifications`) behave identically to OAuth.
+
+Fine-grained PATs are limited to one organization at a time, do not support the `notifications` scope, and therefore cannot use the background-poll optimization — the full poll pauses in hidden tabs, and a warning appears in the notification drawer.
+
+**Data looks stale after switching back to the tab.**
+
+When a tab has been hidden for more than 2 minutes, a catch-up fetch fires automatically on return. If the notifications gate is unavailable (fine-grained PAT), polling was paused while the tab was hidden — the catch-up fetch provides a single refresh on return. To ensure continuous background updates, use OAuth or a classic PAT with the `notifications` scope.
+
+**I want to stop tracking a repository.**
+
+Go to **Settings > Repositories > Manage Repositories**, find the repo, and deselect it. If it was in the monitored list, it will be removed from monitoring automatically.
+
+**How do I sign out or reset everything?**
+
+- **Sign out**: Settings > Data > Sign out. This clears your auth token and returns you to the login page. Your config is preserved.
+- **Reset all**: Settings > Data > Reset all. This clears all settings, cache, auth tokens, and reloads the page. All configuration is lost.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -157,7 +157,7 @@ A small colored dot shows the aggregate CI status for the PR's latest commit:
 | Yellow (pulsing) | Checks in progress |
 | Red (solid) | Checks failing |
 | Yellow/faded (solid) | Checks blocked by merge conflict |
-| Gray (solid) | No checks configured |
+| Gray (solid) | No checks |
 
 The dot links to the PR's checks page on GitHub.
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -6,6 +6,7 @@ import { setupAuth } from "./helpers";
 test("settings page renders section headings", async ({ page }) => {
   await setupAuth(page);
   await page.goto("/settings");
+  await page.waitForLoadState("networkidle");
 
   await expect(
     page.getByRole("heading", { name: /organizations & repositories/i })

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -470,7 +470,7 @@ export default function DashboardPage() {
             <div class="flex justify-end">
               <Show when={getGraphqlRateLimit()}>
                 {(rl) => (
-                  <Tooltip content={`GraphQL API Rate Limits — resets at ${rl().resetAt.toLocaleTimeString()}`} placement="left">
+                  <Tooltip content={`GraphQL API Rate Limits — resets at ${rl().resetAt.toLocaleTimeString()}`} placement="left" focusable>
                     <span class={`tabular-nums ${rl().remaining < rl().limit * 0.1 ? "text-warning" : ""}`}>
                       API RL: {rl().remaining.toLocaleString()}/{formatCount(rl().limit)}/hr
                     </span>

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -25,6 +25,7 @@ import { pushNotification } from "../../lib/errors";
 import { getClient, getGraphqlRateLimit } from "../../services/github";
 import { formatCount } from "../../lib/format";
 import { setsEqual } from "../../lib/collections";
+import { Tooltip } from "../shared/Tooltip";
 
 // ── Shared dashboard store (module-level to survive navigation) ─────────────
 
@@ -451,6 +452,15 @@ export default function DashboardPage() {
               </a>
               <span aria-hidden="true">&middot;</span>
               <a
+                href="https://github.com/gordon-code/github-tracker/blob/main/docs/USER_GUIDE.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="link link-hover"
+              >
+                Guide
+              </a>
+              <span aria-hidden="true">&middot;</span>
+              <a
                 href="/privacy"
                 class="link link-hover"
               >
@@ -460,11 +470,11 @@ export default function DashboardPage() {
             <div class="flex justify-end">
               <Show when={getGraphqlRateLimit()}>
                 {(rl) => (
-                  <div class="tooltip tooltip-left" data-tip={`GraphQL API Rate Limits — resets at ${rl().resetAt.toLocaleTimeString()}`}>
+                  <Tooltip content={`GraphQL API Rate Limits — resets at ${rl().resetAt.toLocaleTimeString()}`} placement="left">
                     <span class={`tabular-nums ${rl().remaining < rl().limit * 0.1 ? "text-warning" : ""}`}>
                       API RL: {rl().remaining.toLocaleString()}/{formatCount(rl().limit)}/hr
                     </span>
-                  </div>
+                  </Tooltip>
                 )}
               </Show>
             </div>

--- a/src/app/components/dashboard/IgnoreBadge.tsx
+++ b/src/app/components/dashboard/IgnoreBadge.tsx
@@ -85,7 +85,7 @@ export default function IgnoreBadge(props: IgnoreBadgeProps) {
                       <p class="text-xs text-base-content/60 truncate">
                         {item.repo}
                       </p>
-                      <Tooltip content={item.title}>
+                      <Tooltip content={item.title} class="min-w-0 w-full">
                         <p class="text-sm text-base-content truncate">
                           {item.title}
                         </p>

--- a/src/app/components/dashboard/IgnoreBadge.tsx
+++ b/src/app/components/dashboard/IgnoreBadge.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show } from "solid-js";
 import type { IgnoredItem } from "../../stores/view";
+import { Tooltip } from "../shared/Tooltip";
 
 interface IgnoreBadgeProps {
   items: IgnoredItem[];
@@ -84,9 +85,11 @@ export default function IgnoreBadge(props: IgnoreBadgeProps) {
                       <p class="text-xs text-base-content/60 truncate">
                         {item.repo}
                       </p>
-                      <p class="text-sm text-base-content truncate" title={item.title}>
-                        {item.title}
-                      </p>
+                      <Tooltip content={item.title}>
+                        <p class="text-sm text-base-content truncate">
+                          {item.title}
+                        </p>
+                      </Tooltip>
                       <p class="text-xs text-base-content/40">
                         Ignored {formatDate(item.ignoredAt)}
                       </p>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -18,6 +18,7 @@ import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, isUse
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
+import { Tooltip } from "../shared/Tooltip";
 
 export interface IssuesTabProps {
   issues: Issue[];
@@ -271,17 +272,18 @@ export default function IssuesTab(props: IssuesTabProps) {
               setPage(0);
             }}
           />
-          <button
-            onClick={() => {
-              updateViewState({ hideDepDashboard: !viewState.hideDepDashboard });
-              setPage(0);
-            }}
-            class={`btn btn-xs rounded-full ${!viewState.hideDepDashboard ? "btn-primary" : "btn-ghost text-base-content/50"}`}
-            aria-pressed={!viewState.hideDepDashboard}
-            title="Toggle visibility of Dependency Dashboard issues"
-          >
-            Show Dep Dashboard
-          </button>
+          <Tooltip content="Toggle Dependency Dashboard issues">
+            <button
+              onClick={() => {
+                updateViewState({ hideDepDashboard: !viewState.hideDepDashboard });
+                setPage(0);
+              }}
+              class={`btn btn-xs rounded-full ${!viewState.hideDepDashboard ? "btn-primary" : "btn-ghost text-base-content/50"}`}
+              aria-pressed={!viewState.hideDepDashboard}
+            >
+              Show Dep Dashboard
+            </button>
+          </Tooltip>
         </div>
         <div class="shrink-0 flex items-center gap-2 py-0.5">
           <ExpandCollapseButtons
@@ -360,7 +362,9 @@ export default function IssuesTab(props: IssuesTabProps) {
                         <ChevronIcon size="md" rotated={!isExpanded()} />
                         {repoGroup.repoFullName}
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
-                          <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                          <Tooltip content="Showing all activity, not just yours" focusable>
+                            <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                          </Tooltip>
                         </Show>
                         <Show when={repoGroup.starCount != null && repoGroup.starCount > 0}>
                           <span class="text-xs text-base-content/50 font-normal" aria-label={`${repoGroup.starCount} stars`}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -272,7 +272,7 @@ export default function IssuesTab(props: IssuesTabProps) {
               setPage(0);
             }}
           />
-          <Tooltip content="Toggle Dependency Dashboard issues">
+          <Tooltip content="Show or hide Renovate Dependency Dashboard issues">
             <button
               onClick={() => {
                 updateViewState({ hideDepDashboard: !viewState.hideDepDashboard });

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -3,7 +3,6 @@ import { isSafeGitHubUrl } from "../../lib/url";
 import { relativeTime, shortRelativeTime, formatCount } from "../../lib/format";
 import { expandEmoji } from "../../lib/emoji";
 import { labelColorClass } from "../../lib/label-colors";
-import { Tooltip } from "../shared/Tooltip";
 
 export interface ItemRowProps {
   repo: string;
@@ -170,7 +169,6 @@ export default function ItemRow(props: ItemRowProps) {
       </div>
 
       {/* Ignore button — visible on hover */}
-      <Tooltip content="Ignore">
       <button
         data-ignore-btn
         onClick={() => props.onIgnore()}
@@ -179,6 +177,7 @@ export default function ItemRow(props: ItemRowProps) {
           hover:text-error
           opacity-0 group-hover:opacity-100 focus:opacity-100
           transition-opacity focus:outline-none focus:ring-2 focus:ring-error`}
+        title="Ignore this item"
         aria-label={`Ignore #${props.number} ${props.title}`}
       >
         {/* Eye-slash icon */}
@@ -197,7 +196,6 @@ export default function ItemRow(props: ItemRowProps) {
           <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
         </svg>
       </button>
-      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -3,6 +3,7 @@ import { isSafeGitHubUrl } from "../../lib/url";
 import { relativeTime, shortRelativeTime, formatCount } from "../../lib/format";
 import { expandEmoji } from "../../lib/emoji";
 import { labelColorClass } from "../../lib/label-colors";
+import { Tooltip } from "../shared/Tooltip";
 
 export interface ItemRowProps {
   repo: string;
@@ -169,6 +170,7 @@ export default function ItemRow(props: ItemRowProps) {
       </div>
 
       {/* Ignore button — visible on hover */}
+      <Tooltip content="Ignore">
       <button
         data-ignore-btn
         onClick={() => props.onIgnore()}
@@ -177,7 +179,6 @@ export default function ItemRow(props: ItemRowProps) {
           hover:text-error
           opacity-0 group-hover:opacity-100 focus:opacity-100
           transition-opacity focus:outline-none focus:ring-2 focus:ring-error`}
-        title="Ignore this item"
         aria-label={`Ignore #${props.number} ${props.title}`}
       >
         {/* Eye-slash icon */}
@@ -196,6 +197,7 @@ export default function ItemRow(props: ItemRowProps) {
           <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
         </svg>
       </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -3,6 +3,7 @@ import { isSafeGitHubUrl } from "../../lib/url";
 import { relativeTime, shortRelativeTime, formatCount } from "../../lib/format";
 import { expandEmoji } from "../../lib/emoji";
 import { labelColorClass } from "../../lib/label-colors";
+import { Tooltip } from "../shared/Tooltip";
 
 export interface ItemRowProps {
   repo: string;
@@ -78,14 +79,15 @@ export default function ItemRow(props: ItemRowProps) {
 
       {/* Repo badge */}
       <Show when={!props.hideRepo}>
-        <span
-          class={`shrink-0 inline-flex items-center rounded-full font-mono font-medium
-            bg-primary/10 text-primary
-            ${isCompact() ? "text-xs px-2 py-0.5" : "text-xs px-2.5 py-1"}`}
-          title={props.repo}
-        >
-          {props.repo}
-        </span>
+        <Tooltip content={props.repo} class="relative z-10">
+          <span
+            class={`shrink-0 inline-flex items-center rounded-full font-mono font-medium
+              bg-primary/10 text-primary
+              ${isCompact() ? "text-xs px-2 py-0.5" : "text-xs px-2.5 py-1"}`}
+          >
+            {props.repo}
+          </span>
+        </Tooltip>
       </Show>
 
       {/* Main content */}
@@ -127,22 +129,24 @@ export default function ItemRow(props: ItemRowProps) {
           <div class="relative z-10">{props.surfacedByBadge}</div>
         </Show>
         <span class="inline-flex items-center gap-1 whitespace-nowrap">
-          <time
-            datetime={props.createdAt}
-            title={staticDateInfo().createdTitle}
-            aria-label={dateDisplay().createdLabel}
-          >
-            {dateDisplay().created}
-          </time>
+          <Tooltip content={staticDateInfo().createdTitle} class="relative z-10">
+            <time
+              datetime={props.createdAt}
+              aria-label={dateDisplay().createdLabel}
+            >
+              {dateDisplay().created}
+            </time>
+          </Tooltip>
           <Show when={shouldShowUpdated()}>
             <span aria-hidden="true">{"\u00B7"}</span>
-            <time
-              datetime={props.updatedAt}
-              title={staticDateInfo().updatedTitle}
-              aria-label={dateDisplay().updatedLabel}
-            >
-              {dateDisplay().updated}
-            </time>
+            <Tooltip content={staticDateInfo().updatedTitle} class="relative z-10">
+              <time
+                datetime={props.updatedAt}
+                aria-label={dateDisplay().updatedLabel}
+              >
+                {dateDisplay().updated}
+              </time>
+            </Tooltip>
           </Show>
         </span>
         <Show when={props.isPolling}>
@@ -169,33 +173,34 @@ export default function ItemRow(props: ItemRowProps) {
       </div>
 
       {/* Ignore button — visible on hover */}
-      <button
-        data-ignore-btn
-        onClick={() => props.onIgnore()}
-        class={`relative z-10 shrink-0 self-center rounded p-1
-          text-base-content/30
-          hover:text-error
-          opacity-0 group-hover:opacity-100 focus:opacity-100
-          transition-opacity focus:outline-none focus:ring-2 focus:ring-error`}
-        title="Ignore this item"
-        aria-label={`Ignore #${props.number} ${props.title}`}
-      >
-        {/* Eye-slash icon */}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class={isCompact() ? "h-3.5 w-3.5" : "h-4 w-4"}
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
+      <Tooltip content="Ignore" class="relative z-10">
+        <button
+          data-ignore-btn
+          onClick={() => props.onIgnore()}
+          class={`shrink-0 self-center rounded p-1
+            text-base-content/30
+            hover:text-error
+            opacity-0 group-hover:opacity-100 focus:opacity-100
+            transition-opacity focus:outline-none focus:ring-2 focus:ring-error`}
+          aria-label={`Ignore #${props.number} ${props.title}`}
         >
-          <path
-            fill-rule="evenodd"
-            d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
-            clip-rule="evenodd"
-          />
-          <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
-        </svg>
-      </button>
+          {/* Eye-slash icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class={isCompact() ? "h-3.5 w-3.5" : "h-4 w-4"}
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
+              clip-rule="evenodd"
+            />
+            <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
+          </svg>
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -79,7 +79,7 @@ export default function ItemRow(props: ItemRowProps) {
 
       {/* Repo badge */}
       <Show when={!props.hideRepo}>
-        <Tooltip content={props.repo} class="relative z-10">
+        <Tooltip content={props.repo} class="shrink-0 relative z-10">
           <span
             class={`shrink-0 inline-flex items-center rounded-full font-mono font-medium
               bg-primary/10 text-primary
@@ -153,27 +153,29 @@ export default function ItemRow(props: ItemRowProps) {
           <span class="loading loading-spinner loading-xs text-base-content/40" />
         </Show>
         <Show when={(props.commentCount ?? 0) > 0}>
-          <span class="flex items-center gap-0.5">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-3 w-3"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z"
-                clip-rule="evenodd"
-              />
-            </svg>
-            {formatCount(props.commentCount!)}
-          </span>
+          <Tooltip content={`${props.commentCount} total ${props.commentCount === 1 ? "comment" : "comments"}`} focusable class="relative z-10">
+            <span class="flex items-center gap-0.5">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-3 w-3"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              {formatCount(props.commentCount!)}
+            </span>
+          </Tooltip>
         </Show>
       </div>
 
       {/* Ignore button — visible on hover */}
-      <Tooltip content="Ignore" class="relative z-10">
+      <Tooltip content="Ignore" class="shrink-0 self-center relative z-10">
         <button
           data-ignore-btn
           onClick={() => props.onIgnore()}

--- a/src/app/components/dashboard/PersonalSummaryStrip.tsx
+++ b/src/app/components/dashboard/PersonalSummaryStrip.tsx
@@ -177,7 +177,7 @@ export default function PersonalSummaryStrip(props: PersonalSummaryStripProps) {
             </>
           )}
         </For>
-        <InfoTooltip content="Click a stat to jump to that tab with filters applied." placement="bottom" />
+        <InfoTooltip content="Click any count to view those items." placement="bottom" />
       </div>
     </Show>
   );

--- a/src/app/components/dashboard/PersonalSummaryStrip.tsx
+++ b/src/app/components/dashboard/PersonalSummaryStrip.tsx
@@ -2,6 +2,7 @@ import { createMemo, For, Show } from "solid-js";
 import type { Issue, PullRequest, WorkflowRun } from "../../services/api";
 import type { TabId } from "../layout/TabBar";
 import { viewState, updateViewState, resetAllTabFilters, setTabFilter } from "../../stores/view";
+import { InfoTooltip } from "../shared/Tooltip";
 
 interface SummaryCount {
   label: string;
@@ -176,6 +177,7 @@ export default function PersonalSummaryStrip(props: PersonalSummaryStripProps) {
             </>
           )}
         </For>
+        <InfoTooltip content="Click a stat to jump to that tab with filters applied." placement="bottom" />
       </div>
     </Show>
   );

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -608,11 +608,13 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                                     </span>
                                   </Show>
                                   <Show when={pr.enriched !== false && pr.reviewerLogins.length > 0}>
-                                    <span class="text-xs text-base-content/60" title={pr.reviewerLogins.join(", ")}>
-                                      Reviewers: {pr.reviewerLogins.slice(0, 5).join(", ")}
-                                      {pr.reviewerLogins.length > 5 && ` +${pr.reviewerLogins.length - 5} more`}
-                                      {pr.totalReviewCount > pr.reviewerLogins.length && ` (${pr.totalReviewCount} total)`}
-                                    </span>
+                                    <Tooltip content={pr.reviewerLogins.join(", ")} focusable>
+                                      <span class="text-xs text-base-content/60">
+                                        Reviewers: {pr.reviewerLogins.slice(0, 5).join(", ")}
+                                        {pr.reviewerLogins.length > 5 && ` +${pr.reviewerLogins.length - 5} more`}
+                                        {pr.totalReviewCount > pr.reviewerLogins.length && ` (${pr.totalReviewCount} total)`}
+                                      </span>
+                                    </Tooltip>
                                   </Show>
                                 </div>
                               </ItemRow>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -23,6 +23,7 @@ import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
+import { Tooltip } from "../shared/Tooltip";
 
 export interface PullRequestsTabProps {
   pullRequests: PullRequest[];
@@ -470,7 +471,9 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         <ChevronIcon size="md" rotated={!isExpanded()} />
                         {repoGroup.repoFullName}
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
-                          <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                          <Tooltip content="Showing all activity, not just yours" focusable>
+                            <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                          </Tooltip>
                         </Show>
                         <Show when={repoGroup.starCount != null && repoGroup.starCount > 0}>
                           <span class="text-xs text-base-content/50 font-normal" aria-label={`${repoGroup.starCount} stars`}>

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -3,7 +3,6 @@ import type { WorkflowRun } from "../../services/api";
 import type { Config } from "../../stores/config";
 import { isSafeGitHubUrl } from "../../lib/url";
 import { relativeTime, formatDuration } from "../../lib/format";
-import { Tooltip } from "../shared/Tooltip";
 
 interface WorkflowRunRowProps {
   run: WorkflowRun;
@@ -195,10 +194,10 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
         <span class="loading loading-spinner loading-xs text-base-content/40" />
       </Show>
 
-      <Tooltip content="Ignore">
-        <button
+      <button
           onClick={() => props.onIgnore(props.run)}
           class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
+          title="Ignore this run"
           aria-label={`Ignore run ${props.run.name}`}
         >
           <svg
@@ -216,7 +215,6 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
             <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
           </svg>
         </button>
-      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -3,6 +3,7 @@ import type { WorkflowRun } from "../../services/api";
 import type { Config } from "../../stores/config";
 import { isSafeGitHubUrl } from "../../lib/url";
 import { relativeTime, formatDuration } from "../../lib/format";
+import { Tooltip } from "../shared/Tooltip";
 
 interface WorkflowRunRowProps {
   run: WorkflowRun;
@@ -194,27 +195,28 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
         <span class="loading loading-spinner loading-xs text-base-content/40" />
       </Show>
 
-      <button
-        onClick={() => props.onIgnore(props.run)}
-        class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
-        title="Ignore this run"
-        aria-label={`Ignore run ${props.run.name}`}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
+      <Tooltip content="Ignore">
+        <button
+          onClick={() => props.onIgnore(props.run)}
+          class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
+          aria-label={`Ignore run ${props.run.name}`}
         >
-          <path
-            fill-rule="evenodd"
-            d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
-            clip-rule="evenodd"
-          />
-          <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
-        </svg>
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-4 w-4"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
+              clip-rule="evenodd"
+            />
+            <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
+          </svg>
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -3,6 +3,7 @@ import type { WorkflowRun } from "../../services/api";
 import type { Config } from "../../stores/config";
 import { isSafeGitHubUrl } from "../../lib/url";
 import { relativeTime, formatDuration } from "../../lib/format";
+import { Tooltip } from "../shared/Tooltip";
 
 interface WorkflowRunRowProps {
   run: WorkflowRun;
@@ -182,39 +183,41 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
         {durationLabel(props.run)}
       </span>
 
-      <time
-        class="text-xs text-base-content/40 shrink-0"
-        datetime={props.run.createdAt}
-        title={createdTitle()}
-      >
-        {timeLabel()}
-      </time>
+      <Tooltip content={createdTitle()}>
+        <time
+          class="text-xs text-base-content/40 shrink-0"
+          datetime={props.run.createdAt}
+        >
+          {timeLabel()}
+        </time>
+      </Tooltip>
 
       <Show when={props.isPolling}>
         <span class="loading loading-spinner loading-xs text-base-content/40" />
       </Show>
 
-      <button
-        onClick={() => props.onIgnore(props.run)}
-        class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
-        title="Ignore this run"
-        aria-label={`Ignore run ${props.run.name}`}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
+      <Tooltip content="Ignore">
+        <button
+          onClick={() => props.onIgnore(props.run)}
+          class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
+          aria-label={`Ignore run ${props.run.name}`}
         >
-          <path
-            fill-rule="evenodd"
-            d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
-            clip-rule="evenodd"
-          />
-          <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
-        </svg>
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-4 w-4"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
+              clip-rule="evenodd"
+            />
+            <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
+          </svg>
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -195,26 +195,26 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
       </Show>
 
       <button
-          onClick={() => props.onIgnore(props.run)}
-          class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
-          title="Ignore this run"
-          aria-label={`Ignore run ${props.run.name}`}
+        onClick={() => props.onIgnore(props.run)}
+        class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
+        title="Ignore this run"
+        aria-label={`Ignore run ${props.run.name}`}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
-              clip-rule="evenodd"
-            />
-            <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
-          </svg>
-        </button>
+          <path
+            fill-rule="evenodd"
+            d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z"
+            clip-rule="evenodd"
+          />
+          <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z" />
+        </svg>
+      </button>
     </div>
   );
 }

--- a/src/app/components/dashboard/WorkflowRunRow.tsx
+++ b/src/app/components/dashboard/WorkflowRunRow.tsx
@@ -183,9 +183,9 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
         {durationLabel(props.run)}
       </span>
 
-      <Tooltip content={createdTitle()}>
+      <Tooltip content={createdTitle()} class="shrink-0">
         <time
-          class="text-xs text-base-content/40 shrink-0"
+          class="text-xs text-base-content/40"
           datetime={props.run.createdAt}
         >
           {timeLabel()}
@@ -196,10 +196,10 @@ export default function WorkflowRunRow(props: WorkflowRunRowProps) {
         <span class="loading loading-spinner loading-xs text-base-content/40" />
       </Show>
 
-      <Tooltip content="Ignore">
+      <Tooltip content="Ignore" class="shrink-0">
         <button
           onClick={() => props.onIgnore(props.run)}
-          class="shrink-0 rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
+          class="rounded p-1 text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-error"
           aria-label={`Ignore run ${props.run.name}`}
         >
           <svg

--- a/src/app/components/dashboard/WorkflowSummaryCard.tsx
+++ b/src/app/components/dashboard/WorkflowSummaryCard.tsx
@@ -82,21 +82,21 @@ export default function WorkflowSummaryCard(props: WorkflowSummaryCardProps) {
         </span>
         <div class="flex items-center gap-1.5 shrink-0">
           <Show when={counts().success > 0}>
-            <Tooltip content={`${counts().success} successful`} focusable>
+            <Tooltip content={`${counts().success} successful`}>
               <span class="text-xs font-medium text-success" aria-label={`${counts().success} successful`}>
                 {counts().success}
               </span>
             </Tooltip>
           </Show>
           <Show when={counts().failure > 0}>
-            <Tooltip content={`${counts().failure} failed`} focusable>
+            <Tooltip content={`${counts().failure} failed`}>
               <span class="text-xs font-medium text-error" aria-label={`${counts().failure} failed`}>
                 {counts().failure}
               </span>
             </Tooltip>
           </Show>
           <Show when={counts().running > 0}>
-            <Tooltip content={`${counts().running} running`} focusable>
+            <Tooltip content={`${counts().running} running`}>
               <span class="text-xs font-medium text-warning" aria-label={`${counts().running} running`}>
                 {counts().running}
               </span>

--- a/src/app/components/dashboard/WorkflowSummaryCard.tsx
+++ b/src/app/components/dashboard/WorkflowSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { createMemo, For, Show } from "solid-js";
 import type { WorkflowRun } from "../../services/api";
 import WorkflowRunRow from "./WorkflowRunRow";
+import { Tooltip } from "../shared/Tooltip";
 
 interface WorkflowSummaryCardProps {
   workflowName: string;
@@ -81,19 +82,25 @@ export default function WorkflowSummaryCard(props: WorkflowSummaryCardProps) {
         </span>
         <div class="flex items-center gap-1.5 shrink-0">
           <Show when={counts().success > 0}>
-            <span class="text-xs font-medium text-success" title={`${counts().success} successful`} aria-label={`${counts().success} successful`}>
-              {counts().success}
-            </span>
+            <Tooltip content={`${counts().success} successful`} focusable>
+              <span class="text-xs font-medium text-success" aria-label={`${counts().success} successful`}>
+                {counts().success}
+              </span>
+            </Tooltip>
           </Show>
           <Show when={counts().failure > 0}>
-            <span class="text-xs font-medium text-error" title={`${counts().failure} failed`} aria-label={`${counts().failure} failed`}>
-              {counts().failure}
-            </span>
+            <Tooltip content={`${counts().failure} failed`} focusable>
+              <span class="text-xs font-medium text-error" aria-label={`${counts().failure} failed`}>
+                {counts().failure}
+              </span>
+            </Tooltip>
           </Show>
           <Show when={counts().running > 0}>
-            <span class="text-xs font-medium text-warning" title={`${counts().running} running`} aria-label={`${counts().running} running`}>
-              {counts().running}
-            </span>
+            <Tooltip content={`${counts().running} running`} focusable>
+              <span class="text-xs font-medium text-warning" aria-label={`${counts().running} running`}>
+                {counts().running}
+              </span>
+            </Tooltip>
           </Show>
         </div>
       </div>

--- a/src/app/components/layout/FilterBar.tsx
+++ b/src/app/components/layout/FilterBar.tsx
@@ -2,6 +2,7 @@ import { createMemo, createSignal, createEffect, onCleanup, Show } from "solid-j
 import { Select } from "@kobalte/core/select";
 import { config } from "../../stores/config";
 import { viewState, setGlobalFilter } from "../../stores/view";
+import { Tooltip } from "../shared/Tooltip";
 
 interface FilterBarProps {
   isRefreshing?: boolean;
@@ -118,34 +119,35 @@ export default function FilterBar(props: FilterBarProps) {
         </span>
       </Show>
 
-      <button
-        onClick={props.onRefresh}
-        disabled={props.isRefreshing}
-        class="btn btn-ghost btn-sm"
-        aria-label="Refresh data"
-      >
-        <Show
-          when={props.isRefreshing}
-          fallback={
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-4 w-4 inline-block mr-1"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
-                clip-rule="evenodd"
-              />
-            </svg>
-          }
+      <Tooltip content="Refresh data">
+        <button
+          onClick={props.onRefresh}
+          disabled={props.isRefreshing}
+          class="btn btn-ghost btn-sm"
+          aria-label="Refresh data"
         >
-          <span class="loading loading-spinner loading-xs mr-1" />
-        </Show>
-        Refresh
-      </button>
+          <Show
+            when={props.isRefreshing}
+            fallback={
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            }
+          >
+            <span class="loading loading-spinner loading-xs" />
+          </Show>
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/layout/FilterBar.tsx
+++ b/src/app/components/layout/FilterBar.tsx
@@ -119,7 +119,7 @@ export default function FilterBar(props: FilterBarProps) {
         </span>
       </Show>
 
-      <Tooltip content="Refresh data">
+      <Tooltip content={updatedLabel() ? `Refresh — ${updatedLabel()!.toLowerCase()}` : "Refresh data"}>
         <button
           onClick={props.onRefresh}
           disabled={props.isRefreshing}

--- a/src/app/components/layout/FilterBar.tsx
+++ b/src/app/components/layout/FilterBar.tsx
@@ -2,6 +2,7 @@ import { createMemo, createSignal, createEffect, onCleanup, Show } from "solid-j
 import { Select } from "@kobalte/core/select";
 import { config } from "../../stores/config";
 import { viewState, setGlobalFilter } from "../../stores/view";
+import { Tooltip } from "../shared/Tooltip";
 
 interface FilterBarProps {
   isRefreshing?: boolean;
@@ -118,34 +119,36 @@ export default function FilterBar(props: FilterBarProps) {
         </span>
       </Show>
 
-      <button
-        onClick={props.onRefresh}
-        disabled={props.isRefreshing}
-        class="btn btn-ghost btn-sm"
-        aria-label="Refresh data"
-      >
-        <Show
-          when={props.isRefreshing}
-          fallback={
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-4 w-4 inline-block mr-1"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
-                clip-rule="evenodd"
-              />
-            </svg>
-          }
+      <Tooltip content="Refresh data">
+        <button
+          onClick={props.onRefresh}
+          disabled={props.isRefreshing}
+          class="btn btn-ghost btn-sm"
+          aria-label="Refresh data"
         >
-          <span class="loading loading-spinner loading-xs mr-1" />
-        </Show>
-        Refresh
-      </button>
+          <Show
+            when={props.isRefreshing}
+            fallback={
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-4 w-4 inline-block mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            }
+          >
+            <span class="loading loading-spinner loading-xs mr-1" />
+          </Show>
+          Refresh
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/layout/FilterBar.tsx
+++ b/src/app/components/layout/FilterBar.tsx
@@ -119,7 +119,7 @@ export default function FilterBar(props: FilterBarProps) {
         </span>
       </Show>
 
-      <Tooltip content={updatedLabel() ? `Refresh — ${updatedLabel()!.toLowerCase()}` : "Refresh data"}>
+      <Tooltip content={props.isRefreshing ? "Refreshing…" : updatedLabel() ? `Refresh — ${updatedLabel()!.toLowerCase()}` : "Refresh data"}>
         <button
           onClick={props.onRefresh}
           disabled={props.isRefreshing}

--- a/src/app/components/layout/FilterBar.tsx
+++ b/src/app/components/layout/FilterBar.tsx
@@ -2,7 +2,6 @@ import { createMemo, createSignal, createEffect, onCleanup, Show } from "solid-j
 import { Select } from "@kobalte/core/select";
 import { config } from "../../stores/config";
 import { viewState, setGlobalFilter } from "../../stores/view";
-import { Tooltip } from "../shared/Tooltip";
 
 interface FilterBarProps {
   isRefreshing?: boolean;
@@ -119,36 +118,34 @@ export default function FilterBar(props: FilterBarProps) {
         </span>
       </Show>
 
-      <Tooltip content="Refresh data">
-        <button
-          onClick={props.onRefresh}
-          disabled={props.isRefreshing}
-          class="btn btn-ghost btn-sm"
-          aria-label="Refresh data"
+      <button
+        onClick={props.onRefresh}
+        disabled={props.isRefreshing}
+        class="btn btn-ghost btn-sm"
+        aria-label="Refresh data"
+      >
+        <Show
+          when={props.isRefreshing}
+          fallback={
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4 inline-block mr-1"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          }
         >
-          <Show
-            when={props.isRefreshing}
-            fallback={
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4 inline-block mr-1"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            }
-          >
-            <span class="loading loading-spinner loading-xs mr-1" />
-          </Show>
-          Refresh
-        </button>
-      </Tooltip>
+          <span class="loading loading-spinner loading-xs mr-1" />
+        </Show>
+        Refresh
+      </button>
     </div>
   );
 }

--- a/src/app/components/layout/Header.tsx
+++ b/src/app/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { user, clearAuth } from "../../stores/auth";
 import { getUnreadCount, markAllAsRead } from "../../lib/errors";
 import NotificationDrawer from "../shared/NotificationDrawer";
 import ToastContainer from "../shared/ToastContainer";
+import { Tooltip } from "../shared/Tooltip";
 
 export default function Header() {
   const navigate = useNavigate();
@@ -55,71 +56,77 @@ export default function Header() {
           )}
         </Show>
 
-        <a
-          href="/settings"
-          class="btn btn-ghost btn-sm shrink-0"
-          aria-label="Settings"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            aria-hidden="true"
+        <Tooltip content="Settings">
+          <a
+            href="/settings"
+            class="btn btn-ghost btn-sm shrink-0"
+            aria-label="Settings"
           >
-            <path
-              fill-rule="evenodd"
-              d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </Tooltip>
 
         {/* Bell icon with unread badge */}
-        <button
-          type="button"
-          onClick={handleBellClick}
-          class="btn btn-ghost btn-sm shrink-0 relative"
-          aria-label={unreadCount() > 0 ? `Notifications, ${unreadCount()} unread` : "Notifications"}
-          aria-expanded={drawerOpen()}
-          aria-haspopup="dialog"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            aria-hidden="true"
+        <Tooltip content="Notifications">
+          <button
+            type="button"
+            onClick={handleBellClick}
+            class="btn btn-ghost btn-sm shrink-0 relative"
+            aria-label={unreadCount() > 0 ? `Notifications, ${unreadCount()} unread` : "Notifications"}
+            aria-expanded={drawerOpen()}
+            aria-haspopup="dialog"
           >
-            <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
-          </svg>
-          <Show when={unreadCount() > 0}>
-            <span class="badge badge-error badge-xs absolute -top-1 -right-1 flex items-center justify-center text-[10px] font-bold">
-              {unreadCount() > 9 ? "9+" : unreadCount()}
-            </span>
-          </Show>
-        </button>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+            </svg>
+            <Show when={unreadCount() > 0}>
+              <span class="badge badge-error badge-xs absolute -top-1 -right-1 flex items-center justify-center text-[10px] font-bold">
+                {unreadCount() > 9 ? "9+" : unreadCount()}
+              </span>
+            </Show>
+          </button>
+        </Tooltip>
 
-        <button
-          type="button"
-          onClick={handleLogout}
-          class="btn btn-ghost btn-sm shrink-0"
-          aria-label="Sign out"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            aria-hidden="true"
+        <Tooltip content="Sign out">
+          <button
+            type="button"
+            onClick={handleLogout}
+            class="btn btn-ghost btn-sm shrink-0"
+            aria-label="Sign out"
           >
-            <path
-              fill-rule="evenodd"
-              d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </button>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </Tooltip>
         </div>
       </header>
       <NotificationDrawer open={drawerOpen()} onClose={() => setDrawerOpen(false)} />

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -14,6 +14,7 @@ import type { TrackedUser } from "../../stores/config";
 import { relativeTime } from "../../lib/format";
 import LoadingSpinner from "../shared/LoadingSpinner";
 import FilterInput from "../shared/FilterInput";
+import { Tooltip, InfoTooltip } from "../shared/Tooltip";
 
 // Validates owner/repo format (both segments must be non-empty, no spaces)
 const VALID_REPO_NAME = /^[a-zA-Z0-9._-]{1,100}\/[a-zA-Z0-9._-]{1,100}$/;
@@ -556,27 +557,28 @@ export default function RepoSelector(props: RepoSelectorProps) {
                                   </div>
                                 </label>
                                 <Show when={isSelected(repo().fullName) && props.onMonitorToggle && !upstreamSelectedSet().has(repo().fullName)}>
-                                  <button
-                                    type="button"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      props.onMonitorToggle?.(toRepoRef(repo()), !monitoredSet().has(repo().fullName));
-                                    }}
-                                    class="btn btn-ghost btn-sm btn-circle mr-2"
-                                    classList={{
-                                      "text-info": monitoredSet().has(repo().fullName),
-                                      "text-base-content/20": !monitoredSet().has(repo().fullName),
-                                    }}
-                                    title={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
-                                    aria-label={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
-                                    aria-pressed={monitoredSet().has(repo().fullName)}
-                                  >
-                                    {/* Heroicons eye outline 16px */}
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width={2} aria-hidden="true">
-                                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                      <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                    </svg>
-                                  </button>
+                                  <Tooltip content={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}>
+                                    <button
+                                      type="button"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        props.onMonitorToggle?.(toRepoRef(repo()), !monitoredSet().has(repo().fullName));
+                                      }}
+                                      class="btn btn-ghost btn-sm btn-circle mr-2"
+                                      classList={{
+                                        "text-info": monitoredSet().has(repo().fullName),
+                                        "text-base-content/20": !monitoredSet().has(repo().fullName),
+                                      }}
+                                      aria-label={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
+                                      aria-pressed={monitoredSet().has(repo().fullName)}
+                                    >
+                                      {/* Heroicons eye outline 16px */}
+                                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width={2} aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                      </svg>
+                                    </button>
+                                  </Tooltip>
                                 </Show>
                               </div>
                             </li>
@@ -597,7 +599,10 @@ export default function RepoSelector(props: RepoSelectorProps) {
         <div class="flex flex-col gap-3">
           {/* Section heading */}
           <div class="border-t border-base-300 pt-3">
-            <h3 class="text-sm font-semibold text-base-content">Upstream Repositories</h3>
+            <h3 class="flex items-center gap-1.5 text-sm font-semibold text-base-content">
+              Upstream Repositories
+              <InfoTooltip content="Repos discovered from your tracked users' activity. Issues and PRs from these repos appear in your dashboard." />
+            </h3>
             <p class="text-xs text-base-content/60 mt-0.5">
               Repos you contribute to but don't own. Issues and PRs are tracked; workflow runs are not.
             </p>

--- a/src/app/components/settings/SettingRow.tsx
+++ b/src/app/components/settings/SettingRow.tsx
@@ -2,13 +2,17 @@ import { JSX, Show } from "solid-js";
 
 export default function SettingRow(props: {
   label: string;
+  labelSuffix?: JSX.Element;
   description?: string;
   children: JSX.Element;
 }) {
   return (
     <div class="flex items-center justify-between px-4 py-3 border-b border-base-300 last:border-b-0">
       <div>
-        <div class="text-sm font-medium text-base-content">{props.label}</div>
+        <div class="flex items-center gap-1.5 text-sm font-medium text-base-content">
+          {props.label}
+          {props.labelSuffix}
+        </div>
         <Show when={props.description}>
           <div class="text-xs text-base-content/60">{props.description}</div>
         </Show>

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -378,30 +378,25 @@ export default function SettingsPage() {
               ))}
             </select>
           </SettingRow>
-          <div class="flex items-center justify-between px-4 py-3 border-b border-base-300 last:border-b-0">
-            <div>
-              <div class="flex items-center gap-1.5 text-sm font-medium text-base-content">
-                CI status refresh
-                <InfoTooltip content="Targeted refresh for in-flight CI checks and pending PR status. Separate from the full refresh cycle." />
-              </div>
-              <div class="text-xs text-base-content/60">How often to re-check in-flight CI checks and workflow runs (10-120s)</div>
-            </div>
-            <div>
-              <input
-                type="number"
-                min={10}
-                max={120}
-                value={config.hotPollInterval}
-                onInput={(e) => {
-                  const val = parseInt(e.currentTarget.value, 10);
-                  if (!isNaN(val) && val >= 10 && val <= 120) {
-                    saveWithFeedback({ hotPollInterval: val });
-                  }
-                }}
-                class="input input-sm w-20"
-              />
-            </div>
-          </div>
+          <SettingRow
+            label="CI status refresh"
+            labelSuffix={<InfoTooltip content="Targeted refresh for in-flight CI checks and pending PR status. Separate from the full refresh cycle." />}
+            description="How often to re-check in-flight CI checks and workflow runs (10-120s)"
+          >
+            <input
+              type="number"
+              min={10}
+              max={120}
+              value={config.hotPollInterval}
+              onInput={(e) => {
+                const val = parseInt(e.currentTarget.value, 10);
+                if (!isNaN(val) && val >= 10 && val <= 120) {
+                  saveWithFeedback({ hotPollInterval: val });
+                }
+              }}
+              class="input input-sm w-20"
+            />
+          </SettingRow>
         </Section>
 
         {/* Section 4: GitHub Actions */}

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -14,6 +14,7 @@ import Section from "./Section";
 import SettingRow from "./SettingRow";
 import ThemePicker from "./ThemePicker";
 import TrackedUsersSection from "./TrackedUsersSection";
+import { InfoTooltip } from "../shared/Tooltip";
 import type { RepoRef } from "../../services/api";
 
 export default function SettingsPage() {
@@ -377,24 +378,30 @@ export default function SettingsPage() {
               ))}
             </select>
           </SettingRow>
-          <SettingRow
-            label="CI status refresh"
-            description="How often to re-check in-flight CI checks and workflow runs (10-120s)"
-          >
-            <input
-              type="number"
-              min={10}
-              max={120}
-              value={config.hotPollInterval}
-              onInput={(e) => {
-                const val = parseInt(e.currentTarget.value, 10);
-                if (!isNaN(val) && val >= 10 && val <= 120) {
-                  saveWithFeedback({ hotPollInterval: val });
-                }
-              }}
-              class="input input-sm w-20"
-            />
-          </SettingRow>
+          <div class="flex items-center justify-between px-4 py-3 border-b border-base-300 last:border-b-0">
+            <div>
+              <div class="flex items-center gap-1.5 text-sm font-medium text-base-content">
+                CI status refresh
+                <InfoTooltip content="Targeted refresh for in-flight CI checks and pending PR status. Separate from the full refresh cycle." />
+              </div>
+              <div class="text-xs text-base-content/60">How often to re-check in-flight CI checks and workflow runs (10-120s)</div>
+            </div>
+            <div>
+              <input
+                type="number"
+                min={10}
+                max={120}
+                value={config.hotPollInterval}
+                onInput={(e) => {
+                  const val = parseInt(e.currentTarget.value, 10);
+                  if (!isNaN(val) && val >= 10 && val <= 120) {
+                    saveWithFeedback({ hotPollInterval: val });
+                  }
+                }}
+                class="input input-sm w-20"
+              />
+            </div>
+          </div>
         </Section>
 
         {/* Section 4: GitHub Actions */}
@@ -716,6 +723,35 @@ export default function SettingsPage() {
             </button>
           </SettingRow>
         </Section>
+
+        <footer class="mt-8 border-t border-base-300 pt-4 pb-8 text-xs text-base-content/50 text-center">
+          <div class="flex items-center justify-center gap-3">
+            <a
+              href="https://github.com/gordon-code/github-tracker"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="link link-hover"
+            >
+              Source
+            </a>
+            <span aria-hidden="true">·</span>
+            <a
+              href="https://github.com/gordon-code/github-tracker/blob/main/docs/USER_GUIDE.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="link link-hover"
+            >
+              Guide
+            </a>
+            <span aria-hidden="true">·</span>
+            <a
+              href="/privacy"
+              class="link link-hover"
+            >
+              Privacy
+            </a>
+          </div>
+        </footer>
       </div>
     </div>
   );

--- a/src/app/components/settings/TrackedUsersSection.tsx
+++ b/src/app/components/settings/TrackedUsersSection.tsx
@@ -132,7 +132,7 @@ export default function TrackedUsersSection(props: TrackedUsersSectionProps) {
                 </Show>
               </div>
             </div>
-            <Tooltip content={`Remove ${trackedUser.login}`}>
+            <Tooltip content={`Stop tracking ${trackedUser.login}`}>
               <button
                 type="button"
                 onClick={() => handleRemove(trackedUser.login)}

--- a/src/app/components/settings/TrackedUsersSection.tsx
+++ b/src/app/components/settings/TrackedUsersSection.tsx
@@ -126,7 +126,9 @@ export default function TrackedUsersSection(props: TrackedUsersSectionProps) {
                   </span>
                 </Show>
                 <Show when={trackedUser.type === "bot"}>
-                  <span class="badge badge-xs badge-outline" aria-label={`${trackedUser.login} is a bot account`}>bot</span>
+                  <Tooltip content="GitHub identifies this as a bot account" focusable>
+                    <span class="badge badge-xs badge-outline" aria-label={`${trackedUser.login} is a bot account`}>bot</span>
+                  </Tooltip>
                 </Show>
               </div>
             </div>

--- a/src/app/components/settings/TrackedUsersSection.tsx
+++ b/src/app/components/settings/TrackedUsersSection.tsx
@@ -3,6 +3,7 @@ import type { TrackedUser } from "../../stores/config";
 import { user } from "../../stores/auth";
 import { validateGitHubUser } from "../../services/api";
 import { getClient } from "../../services/github";
+import { Tooltip } from "../shared/Tooltip";
 
 interface TrackedUsersSectionProps {
   users: TrackedUser[];
@@ -129,25 +130,27 @@ export default function TrackedUsersSection(props: TrackedUsersSectionProps) {
                 </Show>
               </div>
             </div>
-            <button
-              type="button"
-              onClick={() => handleRemove(trackedUser.login)}
-              class="btn btn-sm btn-ghost btn-circle"
-              aria-label={`Remove ${trackedUser.login}`}
-            >
-              <svg
-                class="h-4 w-4"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
+            <Tooltip content={`Remove ${trackedUser.login}`}>
+              <button
+                type="button"
+                onClick={() => handleRemove(trackedUser.login)}
+                class="btn btn-sm btn-ghost btn-circle"
+                aria-label={`Remove ${trackedUser.login}`}
               >
-                <path
-                  fill-rule="evenodd"
-                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </button>
+                <svg
+                  class="h-4 w-4"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </Tooltip>
           </div>
         )}
       </For>

--- a/src/app/components/shared/ExpandCollapseButtons.tsx
+++ b/src/app/components/shared/ExpandCollapseButtons.tsx
@@ -8,10 +8,10 @@ export interface ExpandCollapseButtonsProps {
 export default function ExpandCollapseButtons(props: ExpandCollapseButtonsProps) {
   return (
     <div class="flex items-center gap-1">
-      <Tooltip content="Expand all">
+      <Tooltip content="Expand all repos">
         <button
           class="btn btn-ghost btn-xs"
-          aria-label="Expand all"
+          aria-label="Expand all repos"
           onClick={props.onExpandAll}
         >
           <svg
@@ -30,10 +30,10 @@ export default function ExpandCollapseButtons(props: ExpandCollapseButtonsProps)
           </svg>
         </button>
       </Tooltip>
-      <Tooltip content="Collapse all">
+      <Tooltip content="Collapse all repos">
         <button
           class="btn btn-ghost btn-xs"
-          aria-label="Collapse all"
+          aria-label="Collapse all repos"
           onClick={props.onCollapseAll}
         >
           <svg

--- a/src/app/components/shared/ExpandCollapseButtons.tsx
+++ b/src/app/components/shared/ExpandCollapseButtons.tsx
@@ -1,3 +1,5 @@
+import { Tooltip } from "./Tooltip";
+
 export interface ExpandCollapseButtonsProps {
   onExpandAll: () => void;
   onCollapseAll: () => void;
@@ -6,48 +8,50 @@ export interface ExpandCollapseButtonsProps {
 export default function ExpandCollapseButtons(props: ExpandCollapseButtonsProps) {
   return (
     <div class="flex items-center gap-1">
-      <button
-        class="btn btn-ghost btn-xs"
-        title="Expand all"
-        aria-label="Expand all"
-        onClick={props.onExpandAll}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width={1.5}
-          stroke="currentColor"
-          class="h-4 w-4"
+      <Tooltip content="Expand all">
+        <button
+          class="btn btn-ghost btn-xs"
+          aria-label="Expand all"
+          onClick={props.onExpandAll}
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="m4.5 5.25 7.5 7.5 7.5-7.5m-15 6 7.5 7.5 7.5-7.5"
-          />
-        </svg>
-      </button>
-      <button
-        class="btn btn-ghost btn-xs"
-        title="Collapse all"
-        aria-label="Collapse all"
-        onClick={props.onCollapseAll}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width={1.5}
-          stroke="currentColor"
-          class="h-4 w-4"
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width={1.5}
+            stroke="currentColor"
+            class="h-4 w-4"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m4.5 5.25 7.5 7.5 7.5-7.5m-15 6 7.5 7.5 7.5-7.5"
+            />
+          </svg>
+        </button>
+      </Tooltip>
+      <Tooltip content="Collapse all">
+        <button
+          class="btn btn-ghost btn-xs"
+          aria-label="Collapse all"
+          onClick={props.onCollapseAll}
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="m4.5 18.75 7.5-7.5 7.5 7.5m-15-6 7.5-7.5 7.5 7.5"
-          />
-        </svg>
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width={1.5}
+            stroke="currentColor"
+            class="h-4 w-4"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m4.5 18.75 7.5-7.5 7.5 7.5m-15-6 7.5-7.5 7.5 7.5"
+            />
+          </svg>
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/app/components/shared/RepoGitHubLink.tsx
+++ b/src/app/components/shared/RepoGitHubLink.tsx
@@ -1,4 +1,5 @@
 import ExternalLinkIcon from "./ExternalLinkIcon";
+import { Tooltip } from "./Tooltip";
 
 const sectionLabels = {
   issues: "issues",
@@ -13,15 +14,16 @@ export default function RepoGitHubLink(props: {
   const label = () => sectionLabels[props.section];
 
   return (
-    <a
-      href={`https://github.com/${props.repoFullName}/${props.section}`}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
-      title={`Open ${props.repoFullName} ${label()} on GitHub`}
-      aria-label={`Open ${props.repoFullName} ${label()} on GitHub`}
-    >
-      <ExternalLinkIcon />
-    </a>
+    <Tooltip content={`Open ${props.repoFullName} ${label()} on GitHub`}>
+      <a
+        href={`https://github.com/${props.repoFullName}/${props.section}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="opacity-0 group-hover/repo-header:opacity-100 focus-visible:opacity-100 transition-opacity text-base-content/40 hover:text-primary px-1"
+        aria-label={`Open ${props.repoFullName} ${label()} on GitHub`}
+      >
+        <ExternalLinkIcon />
+      </a>
+    </Tooltip>
   );
 }

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -49,7 +49,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
             </svg>
           </button>
         </Tooltip>
-        <Tooltip content={lockInfo().isFirst ? "Already at top" : "Move up"}>
+        <Tooltip content={lockInfo().isFirst ? "Already at top of pinned list" : "Move up"}>
           <button
             class="btn btn-ghost btn-xs"
             onClick={() => moveLockedRepo(props.tab, props.repoFullName, "up")}
@@ -62,7 +62,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
             </svg>
           </button>
         </Tooltip>
-        <Tooltip content={lockInfo().isLast ? "Already at bottom" : "Move down"}>
+        <Tooltip content={lockInfo().isLast ? "Already at bottom of pinned list" : "Move down"}>
           <button
             class="btn btn-ghost btn-xs"
             onClick={() => moveLockedRepo(props.tab, props.repoFullName, "down")}

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -1,5 +1,6 @@
 import { Show, createMemo } from "solid-js";
 import { viewState, lockRepo, unlockRepo, moveLockedRepo, type LockedReposTab } from "../../stores/view";
+import { Tooltip } from "./Tooltip";
 
 interface RepoLockControlsProps {
   tab: LockedReposTab;
@@ -22,52 +23,58 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
       <Show
         when={lockInfo().isLocked}
         fallback={
-          <button
-            class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
-            onClick={() => lockRepo(props.tab, props.repoFullName)}
-            title="Pin this repo to top of list"
-            aria-label={`Pin ${props.repoFullName} to top of list`}
-          >
-            {/* Heroicons 20px solid: lock-open */}
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-base-content/40">
-              <path d="M14.5 1A4.5 4.5 0 0010 5.5V9H3a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-1.5V5.5a3 3 0 116 0v2.75a.75.75 0 001.5 0V5.5A4.5 4.5 0 0014.5 1z" />
-            </svg>
-          </button>
+          <Tooltip content="Pin to top">
+            <button
+              class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
+              onClick={() => lockRepo(props.tab, props.repoFullName)}
+              aria-label={`Pin ${props.repoFullName} to top of list`}
+            >
+              {/* Heroicons 20px solid: lock-open */}
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-base-content/40">
+                <path d="M14.5 1A4.5 4.5 0 0010 5.5V9H3a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-1.5V5.5a3 3 0 116 0v2.75a.75.75 0 001.5 0V5.5A4.5 4.5 0 0014.5 1z" />
+              </svg>
+            </button>
+          </Tooltip>
         }
       >
-        <button
-          class="btn btn-ghost btn-xs"
-          onClick={() => unlockRepo(props.tab, props.repoFullName)}
-          title="Pinned to top. Click to unpin."
-          aria-label={`Unpin ${props.repoFullName}`}
-        >
-          {/* Heroicons 20px solid: lock-closed */}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-primary">
-            <path fill-rule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clip-rule="evenodd" />
-          </svg>
-        </button>
-        <button
-          class="btn btn-ghost btn-xs"
-          onClick={() => moveLockedRepo(props.tab, props.repoFullName, "up")}
-          disabled={lockInfo().isFirst}
-          aria-label={`Move ${props.repoFullName} up`}
-        >
-          {/* Heroicons 20px solid: chevron-up */}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
-            <path fill-rule="evenodd" d="M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z" clip-rule="evenodd" />
-          </svg>
-        </button>
-        <button
-          class="btn btn-ghost btn-xs"
-          onClick={() => moveLockedRepo(props.tab, props.repoFullName, "down")}
-          disabled={lockInfo().isLast}
-          aria-label={`Move ${props.repoFullName} down`}
-        >
-          {/* Heroicons 20px solid: chevron-down */}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
-            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-          </svg>
-        </button>
+        <Tooltip content="Unpin">
+          <button
+            class="btn btn-ghost btn-xs"
+            onClick={() => unlockRepo(props.tab, props.repoFullName)}
+            aria-label={`Unpin ${props.repoFullName}`}
+          >
+            {/* Heroicons 20px solid: lock-closed */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-primary">
+              <path fill-rule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        </Tooltip>
+        <Tooltip content="Move up">
+          <button
+            class="btn btn-ghost btn-xs"
+            onClick={() => moveLockedRepo(props.tab, props.repoFullName, "up")}
+            disabled={lockInfo().isFirst}
+            aria-label={`Move ${props.repoFullName} up`}
+          >
+            {/* Heroicons 20px solid: chevron-up */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
+              <path fill-rule="evenodd" d="M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        </Tooltip>
+        <Tooltip content="Move down">
+          <button
+            class="btn btn-ghost btn-xs"
+            onClick={() => moveLockedRepo(props.tab, props.repoFullName, "down")}
+            disabled={lockInfo().isLast}
+            aria-label={`Move ${props.repoFullName} down`}
+          >
+            {/* Heroicons 20px solid: chevron-down */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        </Tooltip>
       </Show>
     </div>
   );

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -49,7 +49,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
             </svg>
           </button>
         </Tooltip>
-        <Tooltip content="Move up">
+        <Tooltip content={lockInfo().isFirst ? "Already at top" : "Move up"}>
           <button
             class="btn btn-ghost btn-xs"
             onClick={() => moveLockedRepo(props.tab, props.repoFullName, "up")}
@@ -62,7 +62,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
             </svg>
           </button>
         </Tooltip>
-        <Tooltip content="Move down">
+        <Tooltip content={lockInfo().isLast ? "Already at bottom" : "Move down"}>
           <button
             class="btn btn-ghost btn-xs"
             onClick={() => moveLockedRepo(props.tab, props.repoFullName, "down")}

--- a/src/app/components/shared/SizeBadge.tsx
+++ b/src/app/components/shared/SizeBadge.tsx
@@ -18,11 +18,11 @@ const SIZE_CONFIG = {
   XL: "badge badge-error badge-sm",
 } as const;
 
-const SIZE_TOOLTIP: Record<string, string> = {
-  XS: "XS: under 10 lines changed",
-  S: "S: under 100 lines changed",
-  M: "M: under 500 lines changed",
-  L: "L: under 1000 lines changed",
+const SIZE_TOOLTIP: Record<"XS" | "S" | "M" | "L" | "XL", string> = {
+  XS: "XS: <10 lines changed",
+  S: "S: 10–99 lines changed",
+  M: "M: 100–499 lines changed",
+  L: "L: 500–999 lines changed",
   XL: "XL: 1000+ lines changed",
 };
 

--- a/src/app/components/shared/SizeBadge.tsx
+++ b/src/app/components/shared/SizeBadge.tsx
@@ -1,5 +1,6 @@
 import { Show } from "solid-js";
 import { prSizeCategory } from "../../lib/format";
+import { Tooltip } from "./Tooltip";
 
 interface SizeBadgeProps {
   additions: number;
@@ -17,15 +18,25 @@ const SIZE_CONFIG = {
   XL: "badge badge-error badge-sm",
 } as const;
 
+const SIZE_TOOLTIP: Record<string, string> = {
+  XS: "XS: under 10 lines changed",
+  S: "S: under 100 lines changed",
+  M: "M: under 500 lines changed",
+  L: "L: under 1000 lines changed",
+  XL: "XL: 1000+ lines changed",
+};
+
 export default function SizeBadge(props: SizeBadgeProps) {
   const size = () => props.category ?? prSizeCategory(props.additions, props.deletions);
 
   return (
     <Show when={props.additions + props.deletions > 0 || props.changedFiles > 0}>
       <span class="flex items-center gap-1 text-xs">
-        <span class={SIZE_CONFIG[size()]}>
-          {size()}
-        </span>
+        <Tooltip content={SIZE_TOOLTIP[size()]} focusable>
+          <span class={SIZE_CONFIG[size()]}>
+            {size()}
+          </span>
+        </Tooltip>
         <Show when={props.filesUrl} fallback={
           <>
             <span class="text-success">+{props.additions}</span>

--- a/src/app/components/shared/SizeBadge.tsx
+++ b/src/app/components/shared/SizeBadge.tsx
@@ -32,7 +32,7 @@ export default function SizeBadge(props: SizeBadgeProps) {
   return (
     <Show when={props.additions + props.deletions > 0 || props.changedFiles > 0}>
       <span class="flex items-center gap-1 text-xs">
-        <Tooltip content={SIZE_TOOLTIP[size()]} focusable>
+        <Tooltip content={SIZE_TOOLTIP[size()]} focusable={!props.filesUrl}>
           <span class={SIZE_CONFIG[size()]}>
             {size()}
           </span>

--- a/src/app/components/shared/StatusDot.tsx
+++ b/src/app/components/shared/StatusDot.tsx
@@ -1,4 +1,5 @@
 import { Show } from "solid-js";
+import { Tooltip } from "./Tooltip";
 
 export interface StatusDotProps {
   status: "success" | "pending" | "failure" | "error" | "conflict" | null;
@@ -42,7 +43,6 @@ export default function StatusDot(props: StatusDotProps) {
   const dot = () => (
     <span
       class={`relative inline-flex items-center justify-center w-3 h-3${props.href ? " cursor-pointer" : ""}`}
-      title={cfg().label}
       aria-label={cfg().label}
     >
       <Show when={cfg().pulse}>
@@ -57,17 +57,19 @@ export default function StatusDot(props: StatusDotProps) {
   );
 
   return (
-    <Show when={props.href} fallback={dot()}>
-      {(url) => (
-        <a
-          href={url()}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {dot()}
-        </a>
-      )}
-    </Show>
+    <Tooltip content={cfg().label} focusable={!props.href}>
+      <Show when={props.href} fallback={dot()}>
+        {(url) => (
+          <a
+            href={url()}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {dot()}
+          </a>
+        )}
+      </Show>
+    </Tooltip>
   );
 }

--- a/src/app/components/shared/StatusDot.tsx
+++ b/src/app/components/shared/StatusDot.tsx
@@ -57,7 +57,7 @@ export default function StatusDot(props: StatusDotProps) {
   );
 
   return (
-    <Tooltip content={cfg().label} focusable={!props.href}>
+    <Tooltip content={cfg().label} focusable={!props.href} placement="right">
       <Show when={props.href} fallback={dot()}>
         {(url) => (
           <a

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -36,7 +36,7 @@ export function Tooltip(props: TooltipProps) {
     >
       <KobalteTooltip.Trigger
         as="span"
-        class="inline-flex"
+        class="inline-flex items-center"
         tabindex={props.focusable ? "0" : undefined}
         onPointerEnter={() => {
           hoverTimer = setTimeout(() => setIsHovered(true), 300);

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -39,6 +39,7 @@ export function Tooltip(props: TooltipProps) {
         class="inline-flex items-center"
         tabindex={props.focusable ? "0" : undefined}
         onPointerEnter={() => {
+          clearTimeout(hoverTimer);
           hoverTimer = setTimeout(() => setIsHovered(true), 300);
         }}
         onPointerLeave={() => {

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -31,6 +31,8 @@ export function Tooltip(props: TooltipProps) {
       open={open()}
       onOpenChange={(isOpen) => {
         if (!isOpen) {
+          clearTimeout(hoverTimer);
+          clearTimeout(closeTimer);
           setIsHovered(false);
           setIsFocused(false);
         }

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -10,6 +10,7 @@ interface TooltipProps {
   content: string;
   placement?: "top" | "bottom" | "left" | "right";
   focusable?: boolean;
+  class?: string;
   children: JSX.Element;
 }
 
@@ -42,7 +43,7 @@ export function Tooltip(props: TooltipProps) {
     >
       <KobalteTooltip.Trigger
         as="span"
-        class="inline-flex items-center"
+        class={`inline-flex items-center${props.class ? ` ${props.class}` : ""}`}
         tabindex={props.focusable ? "0" : undefined}
         onPointerEnter={() => {
           clearTimeout(hoverTimer);

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -1,0 +1,81 @@
+import { createMemo, createSignal } from "solid-js";
+import { Tooltip as KobalteTooltip } from "@kobalte/core/tooltip";
+import type { JSX } from "solid-js";
+
+// SECURITY: tooltip content must be JSX children, never raw HTML
+
+interface TooltipProps {
+  content: string;
+  placement?: "top" | "bottom" | "left" | "right";
+  focusable?: boolean;
+  children: JSX.Element;
+}
+
+export function Tooltip(props: TooltipProps) {
+  const [isHovered, setIsHovered] = createSignal(false);
+  const [isFocused, setIsFocused] = createSignal(false);
+  const open = createMemo(() => isHovered() || isFocused());
+
+  return (
+    <KobalteTooltip
+      open={open()}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          setIsHovered(false);
+          setIsFocused(false);
+        }
+      }}
+      placement={props.placement ?? "top"}
+      gutter={4}
+      openDelay={300}
+    >
+      <KobalteTooltip.Trigger
+        as="span"
+        class="inline-flex"
+        tabindex={props.focusable ? "0" : undefined}
+        onPointerEnter={() => setIsHovered(true)}
+        onPointerLeave={() => setIsHovered(false)}
+        onFocusIn={() => setIsFocused(true)}
+        onFocusOut={() => setIsFocused(false)}
+      >
+        {props.children}
+      </KobalteTooltip.Trigger>
+      <KobalteTooltip.Portal>
+        <KobalteTooltip.Content class="z-50 max-w-xs rounded bg-neutral px-2 py-1 text-xs text-neutral-content shadow-lg">
+          <KobalteTooltip.Arrow />
+          {props.content}
+        </KobalteTooltip.Content>
+      </KobalteTooltip.Portal>
+    </KobalteTooltip>
+  );
+}
+
+interface InfoTooltipProps {
+  content: string;
+  placement?: "top" | "bottom" | "left" | "right";
+}
+
+export function InfoTooltip(props: InfoTooltipProps) {
+  return (
+    <KobalteTooltip
+      placement={props.placement ?? "top"}
+      gutter={4}
+      openDelay={300}
+    >
+      <KobalteTooltip.Trigger
+        as="button"
+        type="button"
+        aria-label="More information"
+        class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-base-300 text-base-content/60 text-[10px] font-bold cursor-help border-none p-0"
+      >
+        i
+      </KobalteTooltip.Trigger>
+      <KobalteTooltip.Portal>
+        <KobalteTooltip.Content class="z-50 max-w-xs rounded bg-neutral px-2 py-1 text-xs text-neutral-content shadow-lg">
+          <KobalteTooltip.Arrow />
+          {props.content}
+        </KobalteTooltip.Content>
+      </KobalteTooltip.Portal>
+    </KobalteTooltip>
+  );
+}

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -1,8 +1,10 @@
-import { createMemo, createSignal } from "solid-js";
+import { createMemo, createSignal, onCleanup } from "solid-js";
 import { Tooltip as KobalteTooltip } from "@kobalte/core/tooltip";
 import type { JSX } from "solid-js";
 
 // SECURITY: tooltip content must be JSX children, never raw HTML
+
+const TOOLTIP_CONTENT_CLASS = "z-50 max-w-xs rounded bg-neutral px-2 py-1 text-xs text-neutral-content shadow-lg";
 
 interface TooltipProps {
   content: string;
@@ -16,6 +18,10 @@ export function Tooltip(props: TooltipProps) {
   const [isFocused, setIsFocused] = createSignal(false);
   const open = createMemo(() => isHovered() || isFocused());
 
+  // openDelay is ignored in controlled mode; implement the delay manually
+  let hoverTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => clearTimeout(hoverTimer));
+
   return (
     <KobalteTooltip
       open={open()}
@@ -27,21 +33,25 @@ export function Tooltip(props: TooltipProps) {
       }}
       placement={props.placement ?? "top"}
       gutter={4}
-      openDelay={300}
     >
       <KobalteTooltip.Trigger
         as="span"
         class="inline-flex"
         tabindex={props.focusable ? "0" : undefined}
-        onPointerEnter={() => setIsHovered(true)}
-        onPointerLeave={() => setIsHovered(false)}
+        onPointerEnter={() => {
+          hoverTimer = setTimeout(() => setIsHovered(true), 300);
+        }}
+        onPointerLeave={() => {
+          clearTimeout(hoverTimer);
+          setIsHovered(false);
+        }}
         onFocusIn={() => setIsFocused(true)}
         onFocusOut={() => setIsFocused(false)}
       >
         {props.children}
       </KobalteTooltip.Trigger>
       <KobalteTooltip.Portal>
-        <KobalteTooltip.Content class="z-50 max-w-xs rounded bg-neutral px-2 py-1 text-xs text-neutral-content shadow-lg">
+        <KobalteTooltip.Content class={TOOLTIP_CONTENT_CLASS}>
           <KobalteTooltip.Arrow />
           {props.content}
         </KobalteTooltip.Content>
@@ -71,7 +81,7 @@ export function InfoTooltip(props: InfoTooltipProps) {
         i
       </KobalteTooltip.Trigger>
       <KobalteTooltip.Portal>
-        <KobalteTooltip.Content class="z-50 max-w-xs rounded bg-neutral px-2 py-1 text-xs text-neutral-content shadow-lg">
+        <KobalteTooltip.Content class={TOOLTIP_CONTENT_CLASS}>
           <KobalteTooltip.Arrow />
           {props.content}
         </KobalteTooltip.Content>

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -2,7 +2,7 @@ import { createMemo, createSignal, onCleanup } from "solid-js";
 import { Tooltip as KobalteTooltip } from "@kobalte/core/tooltip";
 import type { JSX } from "solid-js";
 
-// SECURITY: tooltip content must be JSX children, never raw HTML
+// content is plain string — JSX children are intentionally not supported to avoid needing sanitization
 
 const TOOLTIP_CONTENT_CLASS = "z-50 max-w-xs rounded bg-neutral px-2 py-1 text-xs text-neutral-content shadow-lg";
 
@@ -79,6 +79,7 @@ export function InfoTooltip(props: InfoTooltipProps) {
     <KobalteTooltip
       placement={props.placement ?? "top"}
       gutter={4}
+      // Uncontrolled mode — Kobalte openDelay works here, unlike Tooltip which uses controlled mode
       openDelay={300}
     >
       <KobalteTooltip.Trigger

--- a/src/app/components/shared/Tooltip.tsx
+++ b/src/app/components/shared/Tooltip.tsx
@@ -20,7 +20,11 @@ export function Tooltip(props: TooltipProps) {
 
   // openDelay is ignored in controlled mode; implement the delay manually
   let hoverTimer: ReturnType<typeof setTimeout> | undefined;
-  onCleanup(() => clearTimeout(hoverTimer));
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => {
+    clearTimeout(hoverTimer);
+    clearTimeout(closeTimer);
+  });
 
   return (
     <KobalteTooltip
@@ -40,11 +44,12 @@ export function Tooltip(props: TooltipProps) {
         tabindex={props.focusable ? "0" : undefined}
         onPointerEnter={() => {
           clearTimeout(hoverTimer);
+          clearTimeout(closeTimer);
           hoverTimer = setTimeout(() => setIsHovered(true), 300);
         }}
         onPointerLeave={() => {
           clearTimeout(hoverTimer);
-          setIsHovered(false);
+          closeTimer = setTimeout(() => setIsHovered(false), 100);
         }}
         onFocusIn={() => setIsFocused(true)}
         onFocusOut={() => setIsFocused(false)}

--- a/src/app/components/shared/UserAvatarBadge.tsx
+++ b/src/app/components/shared/UserAvatarBadge.tsx
@@ -31,18 +31,18 @@ export default function UserAvatarBadge(props: UserAvatarBadgeProps) {
       >
         <For each={trackedUsers()}>
           {(u, i) => (
-            <div
-              class={`avatar${i() > 0 ? " -ml-1.5" : ""}`}
-            >
-              <div class="w-5 rounded-full ring-1 ring-base-100">
-                <Tooltip content={`Surfaced by ${u.login}`} focusable>
+            <Tooltip content={`Surfaced by ${u.login}`} focusable>
+              <div
+                class={`avatar${i() > 0 ? " -ml-1.5" : ""}`}
+              >
+                <div class="w-5 rounded-full ring-1 ring-base-100">
                   <img
                     src={u.avatarUrl}
                     alt={u.login}
                   />
-                </Tooltip>
+                </div>
               </div>
-            </div>
+            </Tooltip>
           )}
         </For>
       </div>

--- a/src/app/components/shared/UserAvatarBadge.tsx
+++ b/src/app/components/shared/UserAvatarBadge.tsx
@@ -1,4 +1,5 @@
 import { createMemo, For, Show } from "solid-js";
+import { Tooltip } from "./Tooltip";
 
 export function buildSurfacedByUsers(
   surfacedBy: string[] | undefined,
@@ -34,11 +35,12 @@ export default function UserAvatarBadge(props: UserAvatarBadgeProps) {
               class={`avatar${i() > 0 ? " -ml-1.5" : ""}`}
             >
               <div class="w-5 rounded-full ring-1 ring-base-100">
-                <img
-                  src={u.avatarUrl}
-                  alt={u.login}
-                  title={u.login}
-                />
+                <Tooltip content={`Surfaced by ${u.login}`} focusable>
+                  <img
+                    src={u.avatarUrl}
+                    alt={u.login}
+                  />
+                </Tooltip>
               </div>
             </div>
           )}

--- a/tests/components/ExpandCollapseButtons.test.tsx
+++ b/tests/components/ExpandCollapseButtons.test.tsx
@@ -6,15 +6,15 @@ import ExpandCollapseButtons from "../../src/app/components/shared/ExpandCollaps
 describe("ExpandCollapseButtons", () => {
   it("renders both buttons with correct aria-labels", () => {
     render(() => <ExpandCollapseButtons onExpandAll={() => {}} onCollapseAll={() => {}} />);
-    expect(screen.getByRole("button", { name: "Expand all" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Collapse all" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Expand all repos" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Collapse all repos" })).toBeTruthy();
   });
 
   it("calls onExpandAll when expand button is clicked", async () => {
     const user = userEvent.setup();
     const onExpandAll = vi.fn();
     render(() => <ExpandCollapseButtons onExpandAll={onExpandAll} onCollapseAll={() => {}} />);
-    await user.click(screen.getByRole("button", { name: "Expand all" }));
+    await user.click(screen.getByRole("button", { name: "Expand all repos" }));
     expect(onExpandAll).toHaveBeenCalledTimes(1);
   });
 
@@ -22,7 +22,7 @@ describe("ExpandCollapseButtons", () => {
     const user = userEvent.setup();
     const onCollapseAll = vi.fn();
     render(() => <ExpandCollapseButtons onExpandAll={() => {}} onCollapseAll={onCollapseAll} />);
-    await user.click(screen.getByRole("button", { name: "Collapse all" }));
+    await user.click(screen.getByRole("button", { name: "Collapse all repos" }));
     expect(onCollapseAll).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -407,7 +407,7 @@ describe("IssuesTab", () => {
     expect(screen.queryByText("org/repo-b")).toBeNull();
 
     // Collapse all — only affects visible (filtered) repos
-    await user.click(screen.getByLabelText("Collapse all"));
+    await user.click(screen.getByLabelText("Collapse all repos"));
     expect(screen.queryByText("Alice issue")).toBeNull();
 
     // Remove filter — repo-b should still be expanded (was hidden during collapse-all)
@@ -469,7 +469,7 @@ describe("IssuesTab", () => {
     expect(screen.queryByText("Issue A")).toBeNull();
     expect(screen.queryByText("Issue B")).toBeNull();
 
-    await user.click(screen.getByLabelText("Expand all"));
+    await user.click(screen.getByLabelText("Expand all repos"));
     screen.getByText("Issue A");
     screen.getByText("Issue B");
   });
@@ -485,7 +485,7 @@ describe("IssuesTab", () => {
     screen.getByText("Issue A");
     screen.getByText("Issue B");
 
-    await user.click(screen.getByLabelText("Collapse all"));
+    await user.click(screen.getByLabelText("Collapse all repos"));
     expect(screen.queryByText("Issue A")).toBeNull();
     expect(screen.queryByText("Issue B")).toBeNull();
   });
@@ -581,7 +581,7 @@ describe("IssuesTab", () => {
     screen.getByText(/Page 1 of 2/);
 
     // Expand all — affects repos on ALL pages
-    await user.click(screen.getByLabelText("Expand all"));
+    await user.click(screen.getByLabelText("Expand all repos"));
     // Repo-a items visible on page 1
     screen.getByText("Repo A issue 0");
 

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
 import ItemRow from "../../src/app/components/dashboard/ItemRow";
@@ -108,6 +108,8 @@ describe("ItemRow", () => {
     const tooltipTrigger = ignoreBtn.closest("span.relative");
     expect(tooltipTrigger).not.toBeNull();
     expect(tooltipTrigger!.className).toContain("z-10");
+    expect(tooltipTrigger!.className).toContain("shrink-0");
+    expect(tooltipTrigger!.className).toContain("self-center");
   });
 
   it("applies compact padding in compact density", () => {
@@ -187,6 +189,42 @@ describe("ItemRow", () => {
     const dot = container.querySelector('span[aria-hidden="true"]');
     expect(dot).not.toBeNull();
     expect(dot!.textContent).toBe("\u00B7");
+  });
+
+  it("shows date tooltip content on hover", () => {
+    vi.useFakeTimers();
+    const { container, unmount } = render(() => <ItemRow {...defaultProps} />);
+    const createdTrigger = container.querySelector(
+      `time[datetime="${defaultProps.createdAt}"]`
+    )?.closest("span.inline-flex");
+    expect(createdTrigger).not.toBeNull();
+    fireEvent.pointerEnter(createdTrigger!);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain(
+      `Created: ${new Date(defaultProps.createdAt).toLocaleString()}`
+    );
+    fireEvent.pointerLeave(createdTrigger!);
+    vi.advanceTimersByTime(500);
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it("shows updated date tooltip content on hover", () => {
+    vi.useFakeTimers();
+    const { container, unmount } = render(() => <ItemRow {...defaultProps} />);
+    const updatedTrigger = container.querySelector(
+      `time[datetime="${defaultProps.updatedAt}"]`
+    )?.closest("span.inline-flex");
+    expect(updatedTrigger).not.toBeNull();
+    fireEvent.pointerEnter(updatedTrigger!);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain(
+      `Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`
+    );
+    fireEvent.pointerLeave(updatedTrigger!);
+    vi.advanceTimersByTime(500);
+    unmount();
+    vi.useRealTimers();
   });
 
   it("shows single date when createdAt equals updatedAt (zero diff)", () => {
@@ -274,6 +312,45 @@ describe("ItemRow", () => {
     const updated = container.querySelector(`time[datetime="${defaultProps.updatedAt}"]`);
     expect(created!.getAttribute("aria-label")).toMatch(/^Created 2 hours? ago$/);
     expect(updated!.getAttribute("aria-label")).toMatch(/^Updated 30 minutes? ago$/);
+  });
+
+  it("shows comment count tooltip with correct pluralization", () => {
+    vi.useFakeTimers();
+    const { container, unmount } = render(() => (
+      <ItemRow {...defaultProps} commentCount={5} />
+    ));
+    const tooltipTriggers = container.querySelectorAll("span.inline-flex");
+    const commentTrigger = Array.from(tooltipTriggers).find(
+      (el) => el.textContent?.includes("5")
+    );
+    expect(commentTrigger).not.toBeNull();
+    fireEvent.pointerEnter(commentTrigger!);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain("5 total comments");
+    fireEvent.pointerLeave(commentTrigger!);
+    vi.advanceTimersByTime(500);
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it("shows singular 'comment' for commentCount=1", () => {
+    vi.useFakeTimers();
+    const { container, unmount } = render(() => (
+      <ItemRow {...defaultProps} commentCount={1} />
+    ));
+    const tooltipTriggers = container.querySelectorAll("span.inline-flex");
+    const commentTrigger = Array.from(tooltipTriggers).find(
+      (el) => el.textContent?.trim() === "1"
+    );
+    expect(commentTrigger).not.toBeNull();
+    fireEvent.pointerEnter(commentTrigger!);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain("1 total comment");
+    expect(document.body.textContent).not.toContain("1 total comments");
+    fireEvent.pointerLeave(commentTrigger!);
+    vi.advanceTimersByTime(500);
+    unmount();
+    vi.useRealTimers();
   });
 
   it("refreshTick forces time display update", () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -104,8 +104,10 @@ describe("ItemRow", () => {
   it("ignore button has relative z-10 to sit above overlay link", () => {
     render(() => <ItemRow {...defaultProps} />);
     const ignoreBtn = screen.getByLabelText(/Ignore #42/i);
-    expect(ignoreBtn.className).toContain("relative");
-    expect(ignoreBtn.className).toContain("z-10");
+    // The Tooltip wrapper span carries relative z-10; the button itself is inside it
+    const tooltipTrigger = ignoreBtn.closest("span.relative");
+    expect(tooltipTrigger).not.toBeNull();
+    expect(tooltipTrigger!.className).toContain("z-10");
   });
 
   it("applies compact padding in compact density", () => {
@@ -180,9 +182,7 @@ describe("ItemRow", () => {
     const created = container.querySelector(`time[datetime="${defaultProps.createdAt}"]`);
     const updated = container.querySelector(`time[datetime="${defaultProps.updatedAt}"]`);
     expect(created!.textContent).toBe("2h");
-    expect(created!.getAttribute("title")).toBe(`Created: ${new Date(defaultProps.createdAt).toLocaleString()}`);
     expect(updated!.textContent).toBe("30m");
-    expect(updated!.getAttribute("title")).toBe(`Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`);
     // Middle dot separator is a <span> with aria-hidden
     const dot = container.querySelector('span[aria-hidden="true"]');
     expect(dot).not.toBeNull();

--- a/tests/components/PullRequestsTab.test.tsx
+++ b/tests/components/PullRequestsTab.test.tsx
@@ -509,7 +509,7 @@ describe("PullRequestsTab", () => {
     expect(screen.queryByText("PR in repo A")).toBeNull();
     expect(screen.queryByText("PR in repo B")).toBeNull();
 
-    await user.click(screen.getByLabelText("Expand all"));
+    await user.click(screen.getByLabelText("Expand all repos"));
 
     screen.getByText("PR in repo A");
     screen.getByText("PR in repo B");
@@ -527,7 +527,7 @@ describe("PullRequestsTab", () => {
     screen.getByText("PR in repo A");
     screen.getByText("PR in repo B");
 
-    await user.click(screen.getByLabelText("Collapse all"));
+    await user.click(screen.getByLabelText("Collapse all repos"));
 
     expect(screen.queryByText("PR in repo A")).toBeNull();
     expect(screen.queryByText("PR in repo B")).toBeNull();
@@ -618,7 +618,7 @@ describe("PullRequestsTab", () => {
     screen.getByText(/Page 1 of 2/);
 
     // Expand all — affects repos on ALL pages
-    await user.click(screen.getByLabelText("Expand all"));
+    await user.click(screen.getByLabelText("Expand all repos"));
     // Repo-a items visible on page 1
     screen.getByText("Repo A PR 0");
 

--- a/tests/components/WorkflowRunRow.test.tsx
+++ b/tests/components/WorkflowRunRow.test.tsx
@@ -36,7 +36,6 @@ describe("WorkflowRunRow", () => {
     const timeEl = container.querySelector("time");
     expect(timeEl).not.toBeNull();
     expect(timeEl!.getAttribute("datetime")).toBe(createdAt);
-    expect(timeEl!.getAttribute("title")).toBe(`Created: ${new Date(createdAt).toLocaleString()}`);
     expect(timeEl!.textContent).toMatch(/2 hours? ago/);
   });
 

--- a/tests/components/WorkflowRunRow.test.tsx
+++ b/tests/components/WorkflowRunRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
 import WorkflowRunRow from "../../src/app/components/dashboard/WorkflowRunRow";
@@ -37,6 +37,26 @@ describe("WorkflowRunRow", () => {
     expect(timeEl).not.toBeNull();
     expect(timeEl!.getAttribute("datetime")).toBe(createdAt);
     expect(timeEl!.textContent).toMatch(/2 hours? ago/);
+  });
+
+  it("shows date tooltip content on hover", () => {
+    vi.useFakeTimers();
+    const createdAt = new Date(MOCK_NOW - 2 * 60 * 60 * 1000).toISOString();
+    const run = makeWorkflowRun({ createdAt });
+    const { container, unmount } = render(() => (
+      <WorkflowRunRow run={run} onIgnore={() => {}} density="comfortable" />
+    ));
+    const timeTrigger = container.querySelector("time")?.closest("span.inline-flex");
+    expect(timeTrigger).not.toBeNull();
+    fireEvent.pointerEnter(timeTrigger!);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain(
+      `Created: ${new Date(createdAt).toLocaleString()}`
+    );
+    fireEvent.pointerLeave(timeTrigger!);
+    vi.advanceTimersByTime(500);
+    unmount();
+    vi.useRealTimers();
   });
 
   it("updates time display when refreshTick changes", () => {

--- a/tests/components/dashboard/PersonalSummaryStrip.test.tsx
+++ b/tests/components/dashboard/PersonalSummaryStrip.test.tsx
@@ -64,6 +64,12 @@ describe("PersonalSummaryStrip — assigned issues", () => {
     expect(screen.getByText(/assigned/)).toBeDefined();
   });
 
+  it("shows InfoTooltip 'More information' button when counts are visible", () => {
+    const issues = [makeIssue({ assigneeLogins: ["me"] })];
+    renderStrip({ issues });
+    expect(screen.getByRole("button", { name: "More information" })).toBeTruthy();
+  });
+
   it("does not count issues where user is not assigned", () => {
     const issues = [
       makeIssue({ assigneeLogins: ["other-user"] }),

--- a/tests/components/shared-badges.test.tsx
+++ b/tests/components/shared-badges.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
 import RoleBadge from "../../src/app/components/shared/RoleBadge";
 import ReviewBadge from "../../src/app/components/shared/ReviewBadge";
 import SizeBadge from "../../src/app/components/shared/SizeBadge";
@@ -83,5 +83,20 @@ describe("SizeBadge", () => {
   it("renders when only changedFiles > 0", () => {
     render(() => <SizeBadge additions={0} deletions={0} changedFiles={1} />);
     screen.getByText("XS");
+  });
+
+  it("shows tooltip with size description on hover", () => {
+    vi.useFakeTimers();
+    const { container } = render(() => (
+      <SizeBadge additions={3} deletions={2} changedFiles={1} />
+    ));
+    const trigger = container.querySelector("span.inline-flex");
+    expect(trigger).not.toBeNull();
+    fireEvent.pointerEnter(trigger!);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain("XS: <10 lines changed");
+    fireEvent.pointerLeave(trigger!);
+    vi.advanceTimersByTime(500);
+    vi.useRealTimers();
   });
 });

--- a/tests/components/shared/StatusDot.test.tsx
+++ b/tests/components/shared/StatusDot.test.tsx
@@ -33,6 +33,23 @@ describe("StatusDot", () => {
     expect(wrapper?.getAttribute("aria-label")).toBe("No checks");
   });
 
+  it('shows "Checks blocked by merge conflict" label for status="conflict"', () => {
+    const { container } = render(() => <StatusDot status="conflict" />);
+    const wrapper = container.querySelector("[aria-label]");
+    expect(wrapper?.getAttribute("aria-label")).toBe("Checks blocked by merge conflict");
+  });
+
+  it("wraps dot in a link when href is provided", () => {
+    const { container } = render(() => (
+      <StatusDot status="success" href="https://github.com/owner/repo/checks" />
+    ));
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("https://github.com/owner/repo/checks");
+    expect(link!.getAttribute("target")).toBe("_blank");
+    expect(link!.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
   it("has animate-slow-pulse class only for status=pending", () => {
     const { container: pendingContainer } = render(() => <StatusDot status="pending" />);
     expect(pendingContainer.querySelector(".animate-slow-pulse")).not.toBeNull();

--- a/tests/components/shared/StatusDot.test.tsx
+++ b/tests/components/shared/StatusDot.test.tsx
@@ -5,33 +5,31 @@ import StatusDot from "../../../src/app/components/shared/StatusDot";
 describe("StatusDot", () => {
   it('shows "All checks passed" label for status="success"', () => {
     const { container } = render(() => <StatusDot status="success" />);
-    const wrapper = container.querySelector("span");
+    const wrapper = container.querySelector("[aria-label]");
     expect(wrapper?.getAttribute("aria-label")).toBe("All checks passed");
-    expect(wrapper?.getAttribute("title")).toBe("All checks passed");
   });
 
   it('shows "Checks in progress" label for status="pending"', () => {
     const { container } = render(() => <StatusDot status="pending" />);
-    const wrapper = container.querySelector("span");
+    const wrapper = container.querySelector("[aria-label]");
     expect(wrapper?.getAttribute("aria-label")).toBe("Checks in progress");
-    expect(wrapper?.getAttribute("title")).toBe("Checks in progress");
   });
 
   it('shows "Checks failing" label for status="failure"', () => {
     const { container } = render(() => <StatusDot status="failure" />);
-    const wrapper = container.querySelector("span");
+    const wrapper = container.querySelector("[aria-label]");
     expect(wrapper?.getAttribute("aria-label")).toBe("Checks failing");
   });
 
   it('shows "Checks failing" label for status="error"', () => {
     const { container } = render(() => <StatusDot status="error" />);
-    const wrapper = container.querySelector("span");
+    const wrapper = container.querySelector("[aria-label]");
     expect(wrapper?.getAttribute("aria-label")).toBe("Checks failing");
   });
 
   it('shows "No checks" label for status=null', () => {
     const { container } = render(() => <StatusDot status={null} />);
-    const wrapper = container.querySelector("span");
+    const wrapper = container.querySelector("[aria-label]");
     expect(wrapper?.getAttribute("aria-label")).toBe("No checks");
   });
 

--- a/tests/components/shared/Tooltip.test.tsx
+++ b/tests/components/shared/Tooltip.test.tsx
@@ -86,6 +86,44 @@ describe("Tooltip", () => {
     vi.advanceTimersByTime(300);
     expect(document.body.textContent).not.toContain("tooltip text");
   });
+
+  it("closes tooltip state when pointer leaves after it is visible", () => {
+    const { container } = render(() => (
+      <Tooltip content="tooltip text">
+        <span>Trigger</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex")!;
+    fireEvent.pointerEnter(trigger);
+    vi.advanceTimersByTime(300);
+    expect(trigger.getAttribute("data-expanded")).toBe("");
+    fireEvent.pointerLeave(trigger);
+    expect(trigger.hasAttribute("data-expanded")).toBe(false);
+  });
+
+  it("shows tooltip on focusIn (keyboard access)", () => {
+    const { container } = render(() => (
+      <Tooltip content="focus tooltip" focusable>
+        <span>Badge</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex")!;
+    fireEvent.focusIn(trigger);
+    expect(document.body.textContent).toContain("focus tooltip");
+  });
+
+  it("closes tooltip state on focusOut", () => {
+    const { container } = render(() => (
+      <Tooltip content="focus tooltip" focusable>
+        <span>Badge</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex")!;
+    fireEvent.focusIn(trigger);
+    expect(trigger.getAttribute("data-expanded")).toBe("");
+    fireEvent.focusOut(trigger);
+    expect(trigger.hasAttribute("data-expanded")).toBe(false);
+  });
 });
 
 describe("InfoTooltip", () => {

--- a/tests/components/shared/Tooltip.test.tsx
+++ b/tests/components/shared/Tooltip.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
 import { Tooltip, InfoTooltip } from "../../../src/app/components/shared/Tooltip";
 
 describe("Tooltip", () => {
@@ -49,6 +49,43 @@ describe("Tooltip", () => {
     const trigger = container.querySelector("span.inline-flex");
     expect(trigger?.hasAttribute("tabindex")).toBe(false);
   });
+
+  it("tooltip content is not visible before hover", () => {
+    render(() => (
+      <Tooltip content="tooltip text">
+        <span>Trigger</span>
+      </Tooltip>
+    ));
+    expect(document.body.textContent).not.toContain("tooltip text");
+  });
+
+  it("shows tooltip content after 300ms hover delay", () => {
+    const { container } = render(() => (
+      <Tooltip content="tooltip text">
+        <span>Trigger</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex")!;
+    fireEvent.pointerEnter(trigger);
+    // Content should not be visible before delay fires
+    expect(document.body.textContent).not.toContain("tooltip text");
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain("tooltip text");
+  });
+
+  it("cancels tooltip if pointer leaves before 300ms delay", () => {
+    const { container } = render(() => (
+      <Tooltip content="tooltip text">
+        <span>Trigger</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex")!;
+    fireEvent.pointerEnter(trigger);
+    vi.advanceTimersByTime(150);
+    fireEvent.pointerLeave(trigger);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).not.toContain("tooltip text");
+  });
 });
 
 describe("InfoTooltip", () => {
@@ -71,5 +108,14 @@ describe("InfoTooltip", () => {
     render(() => <InfoTooltip content="Helpful info" />);
     const btn = screen.getByRole("button", { name: "More information" });
     expect(btn.classList.contains("cursor-help")).toBe(true);
+  });
+
+  it("shows tooltip content after hover (openDelay=300ms)", () => {
+    render(() => <InfoTooltip content="helpful info text" />);
+    const btn = screen.getByRole("button", { name: "More information" });
+    fireEvent.pointerEnter(btn);
+    expect(document.body.textContent).not.toContain("helpful info text");
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain("helpful info text");
   });
 });

--- a/tests/components/shared/Tooltip.test.tsx
+++ b/tests/components/shared/Tooltip.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { Tooltip, InfoTooltip } from "../../../src/app/components/shared/Tooltip";
+
+describe("Tooltip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders children correctly", () => {
+    render(() => (
+      <Tooltip content="Tooltip text">
+        <button type="button">Click me</button>
+      </Tooltip>
+    ));
+    expect(screen.getByRole("button", { name: "Click me" })).toBeTruthy();
+  });
+
+  it("trigger has inline-flex class", () => {
+    const { container } = render(() => (
+      <Tooltip content="Tooltip text">
+        <span>Child</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex");
+    expect(trigger).not.toBeNull();
+  });
+
+  it("focusable prop adds tabindex='0' to trigger span", () => {
+    const { container } = render(() => (
+      <Tooltip content="Tooltip text" focusable>
+        <span>Badge</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex");
+    expect(trigger?.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("without focusable, trigger span has no tabindex", () => {
+    const { container } = render(() => (
+      <Tooltip content="Tooltip text">
+        <span>Badge</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex");
+    expect(trigger?.hasAttribute("tabindex")).toBe(false);
+  });
+});
+
+describe("InfoTooltip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders (i) button with aria-label 'More information'", () => {
+    render(() => <InfoTooltip content="Helpful info" />);
+    const btn = screen.getByRole("button", { name: "More information" });
+    expect(btn).toBeTruthy();
+    expect(btn.textContent?.trim()).toBe("i");
+  });
+
+  it("button has cursor-help class", () => {
+    render(() => <InfoTooltip content="Helpful info" />);
+    const btn = screen.getByRole("button", { name: "More information" });
+    expect(btn.classList.contains("cursor-help")).toBe(true);
+  });
+});

--- a/tests/components/shared/Tooltip.test.tsx
+++ b/tests/components/shared/Tooltip.test.tsx
@@ -98,6 +98,9 @@ describe("Tooltip", () => {
     vi.advanceTimersByTime(300);
     expect(trigger.getAttribute("data-expanded")).toBe("");
     fireEvent.pointerLeave(trigger);
+    // closeDelay is 100ms. Advance 300ms to cover both the 100ms closeDelay and Kobalte's
+    // globalSkipDelayTimeout (300ms), so global tooltip state resets before the next test.
+    vi.advanceTimersByTime(300);
     expect(trigger.hasAttribute("data-expanded")).toBe(false);
   });
 

--- a/tests/components/shared/Tooltip.test.tsx
+++ b/tests/components/shared/Tooltip.test.tsx
@@ -50,6 +50,18 @@ describe("Tooltip", () => {
     expect(trigger?.hasAttribute("tabindex")).toBe(false);
   });
 
+  it("class prop merges with trigger span classes", () => {
+    const { container } = render(() => (
+      <Tooltip content="Tooltip text" class="relative z-10">
+        <span>Child</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex");
+    expect(trigger?.classList.contains("inline-flex")).toBe(true);
+    expect(trigger?.classList.contains("relative")).toBe(true);
+    expect(trigger?.classList.contains("z-10")).toBe(true);
+  });
+
   it("tooltip content is not visible before hover", () => {
     render(() => (
       <Tooltip content="tooltip text">
@@ -147,6 +159,23 @@ describe("Tooltip", () => {
     expect(trigger.getAttribute("data-expanded")).toBe("");
     fireEvent.focusOut(trigger);
     expect(trigger.hasAttribute("data-expanded")).toBe(false);
+  });
+
+  it("closes tooltip on Escape key via onOpenChange", () => {
+    const { container } = render(() => (
+      <Tooltip content="escape tooltip" focusable>
+        <span>Badge</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex")!;
+    // Open via focus
+    fireEvent.focusIn(trigger);
+    expect(trigger.getAttribute("data-expanded")).toBe("");
+    // Escape should close via Kobalte's onOpenChange(false)
+    fireEvent.keyDown(trigger, { key: "Escape" });
+    expect(trigger.hasAttribute("data-expanded")).toBe(false);
+    // Advance past Kobalte's globalSkipDelayTimeout (300ms) so global state resets
+    vi.advanceTimersByTime(500);
   });
 });
 

--- a/tests/components/shared/Tooltip.test.tsx
+++ b/tests/components/shared/Tooltip.test.tsx
@@ -104,6 +104,27 @@ describe("Tooltip", () => {
     expect(trigger.hasAttribute("data-expanded")).toBe(false);
   });
 
+  it("re-entering during closeDelay cancels the close timer", () => {
+    const { container } = render(() => (
+      <Tooltip content="tooltip text">
+        <span>Trigger</span>
+      </Tooltip>
+    ));
+    const trigger = container.querySelector("span.inline-flex")!;
+    fireEvent.pointerEnter(trigger);
+    vi.advanceTimersByTime(300);
+    expect(trigger.getAttribute("data-expanded")).toBe("");
+    fireEvent.pointerLeave(trigger);
+    // Re-enter within 100ms closeDelay — should cancel close
+    vi.advanceTimersByTime(50);
+    fireEvent.pointerEnter(trigger);
+    // The tooltip should still be expanded (closeTimer was cancelled before it fired)
+    expect(trigger.getAttribute("data-expanded")).toBe("");
+    // Clean up: close the tooltip so Kobalte's global state resets
+    fireEvent.pointerLeave(trigger);
+    vi.advanceTimersByTime(500);
+  });
+
   it("shows tooltip on focusIn (keyboard access)", () => {
     const { container } = render(() => (
       <Tooltip content="focus tooltip" focusable>

--- a/tests/components/shared/UserAvatarBadge.test.tsx
+++ b/tests/components/shared/UserAvatarBadge.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
 import UserAvatarBadge from "../../../src/app/components/shared/UserAvatarBadge";
 
 describe("UserAvatarBadge", () => {
@@ -57,6 +57,24 @@ describe("UserAvatarBadge", () => {
     const imgs = screen.getAllByRole("img");
     expect(imgs).toHaveLength(1);
     expect(imgs[0].getAttribute("alt")).toBe("tracked1");
+  });
+
+  it("shows 'Surfaced by' tooltip on hover", () => {
+    vi.useFakeTimers();
+    const { container } = render(() => (
+      <UserAvatarBadge
+        users={[{ login: "octocat", avatarUrl: "https://avatars.githubusercontent.com/u/583231" }]}
+        currentUserLogin="me"
+      />
+    ));
+    const trigger = container.querySelector("span.inline-flex");
+    expect(trigger).not.toBeNull();
+    fireEvent.pointerEnter(trigger!);
+    vi.advanceTimersByTime(300);
+    expect(document.body.textContent).toContain("Surfaced by octocat");
+    fireEvent.pointerLeave(trigger!);
+    vi.advanceTimersByTime(500);
+    vi.useRealTimers();
   });
 
   it("uses avatarUrl as img src", () => {

--- a/tests/components/shared/UserAvatarBadge.test.tsx
+++ b/tests/components/shared/UserAvatarBadge.test.tsx
@@ -59,17 +59,6 @@ describe("UserAvatarBadge", () => {
     expect(imgs[0].getAttribute("alt")).toBe("tracked1");
   });
 
-  it("shows tooltip with login via title attribute", () => {
-    render(() => (
-      <UserAvatarBadge
-        users={[{ login: "octocat", avatarUrl: "https://avatars.githubusercontent.com/u/583231" }]}
-        currentUserLogin="me"
-      />
-    ));
-    const img = screen.getByRole("img");
-    expect(img.getAttribute("title")).toBe("octocat");
-  });
-
   it("uses avatarUrl as img src", () => {
     const avatarUrl = "https://avatars.githubusercontent.com/u/583231";
     render(() => (


### PR DESCRIPTION
## Summary
- Adds Kobalte Tooltip wrapper (Tooltip + InfoTooltip) with dual-signal controlled mode, 300ms hover delay, 100ms close delay, and keyboard focus via focusin/focusout
- Applies accessible tooltips to ~20 dashboard and settings elements, replacing native title attributes with WCAG 1.4.13 compliant Kobalte tooltips
- Writes comprehensive 409-line user guide (docs/USER_GUIDE.md) covering all features, settings reference, and troubleshooting