### PR TITLE
feat(ui): scroll lock fix + org-grouped accordion for 6+ orgs

### DIFF
--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -291,7 +291,7 @@ export default function ActionsTab(props: ActionsTabProps) {
             });
 
             return (
-              <div class="bg-base-100">
+              <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
                 {/* Repo header */}
                 <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposActions().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
                   <button

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -25,6 +25,7 @@ import { pushNotification } from "../../lib/errors";
 import { getClient, getGraphqlRateLimit } from "../../services/github";
 import { formatCount } from "../../lib/format";
 import { setsEqual } from "../../lib/collections";
+import { withScrollLock } from "../../lib/scroll";
 import { Tooltip } from "../shared/Tooltip";
 
 // ── Shared dashboard store (module-level to survive navigation) ─────────────
@@ -173,13 +174,17 @@ async function pollFetch(): Promise<DashboardData> {
       } else {
         // Phase 1 did NOT fire (cached data existed or subsequent poll).
         // Full atomic replacement — all fields (light + heavy) may have
-        // changed since the last cycle.
-        setDashboardData({
-          issues: data.issues,
-          pullRequests: data.pullRequests,
-          workflowRuns: data.workflowRuns,
-          loading: false,
-          lastRefreshedAt: now,
+        // changed since the last cycle. Preserve scroll position: SolidJS
+        // DOM updates are synchronous within the setter, so save/restore
+        // around it to prevent scroll reset from <For> DOM rebuild.
+        withScrollLock(() => {
+          setDashboardData({
+            issues: data.issues,
+            pullRequests: data.pullRequests,
+            workflowRuns: data.workflowRuns,
+            loading: false,
+            lastRefreshedAt: now,
+          });
         });
       }
       rebuildHotSets(data);

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -352,7 +352,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                 });
 
                 return (
-                  <div class="bg-base-100">
+                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
                     <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposIssues().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
                       <button
                         onClick={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -461,7 +461,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                 });
 
                 return (
-                  <div class="bg-base-100">
+                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
                     <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposPRs().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
                       <button
                         onClick={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -463,44 +463,17 @@ export default function RepoSelector(props: RepoSelectorProps) {
 
       {/* Per-org repo lists — Index (not For) avoids tearing down every org's
            DOM subtree when a single org's state updates via setOrgStates(prev.map(...)) */}
+      <div class={isAccordion() ? "overflow-hidden rounded-lg border border-base-300 divide-y divide-base-300" : "contents"}>
       <Index each={sortedOrgStates()}>
         {(state) => {
           const visible = createMemo(() => filteredReposForOrg(state()));
           const selectedCount = createMemo(() =>
             visible().filter((r) => isSelected(r.fullName)).length
           );
+          const orgId = createMemo(() => state().org.replace(/[^a-zA-Z0-9-]/g, "-"));
 
           const orgContent = () => (
             <>
-              {/* Per-org bulk selection bar (accordion mode only — in non-accordion, these are in the header) */}
-              <Show when={isAccordion() && !state().loading && !state().error}>
-                <div class="flex justify-end gap-2 border-b border-base-300 px-4 py-1">
-                  <button
-                    type="button"
-                    onClick={() => selectAllInOrg(state())}
-                    disabled={
-                      visible().length === 0 ||
-                      visible().every((r) => isSelected(r.fullName))
-                    }
-                    class="btn btn-ghost btn-xs"
-                  >
-                    Select All
-                  </button>
-                  <span class="text-base-content/30">&middot;</span>
-                  <button
-                    type="button"
-                    onClick={() => deselectAllInOrg(state())}
-                    disabled={
-                      visible().length === 0 ||
-                      visible().every((r) => !isSelected(r.fullName))
-                    }
-                    class="btn btn-ghost btn-xs"
-                  >
-                    Deselect All
-                  </button>
-                </div>
-              </Show>
-
               {/* Loading state for this org */}
               <Show when={state().loading}>
                 <div class="flex justify-center py-6">
@@ -602,7 +575,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
           );
 
           return (
-            <div class="overflow-hidden rounded-lg border border-base-300">
+            <div class={isAccordion() ? "" : "overflow-hidden rounded-lg border border-base-300"}>
               {/* Org header — accordion button when >= 6 orgs, plain header otherwise */}
               <Show
                 when={isAccordion()}
@@ -641,38 +614,74 @@ export default function RepoSelector(props: RepoSelectorProps) {
                   </div>
                 }
               >
-                <button
-                  type="button"
-                  id={`accordion-header-${state().org}`}
-                  class="flex w-full items-center gap-2 border-b border-base-300 bg-base-200 px-4 py-2 text-left"
-                  aria-expanded={expandedOrg() === state().org}
-                  aria-controls={`accordion-panel-${state().org}`}
-                  onClick={() => setUserExpandedOrg(state().org)}
-                >
-                  <ChevronIcon size="md" rotated={expandedOrg() !== state().org} />
-                  <span class="text-sm font-semibold text-base-content flex-1">
-                    {state().org}
-                  </span>
-                  <span class="badge badge-sm badge-ghost">{visible().length} {visible().length === 1 ? "repo" : "repos"}</span>
-                  <Show when={selectedCount() > 0}>
-                    <span class="badge badge-sm badge-ghost">{selectedCount()} selected</span>
+                <div class="flex items-center border-b border-base-300 bg-base-200">
+                  <button
+                    type="button"
+                    id={`accordion-header-${orgId()}`}
+                    class="flex flex-1 items-center gap-2 px-4 py-2 text-left"
+                    aria-expanded={expandedOrg() === state().org}
+                    aria-controls={`accordion-panel-${orgId()}`}
+                    // Always-one-open: clicking the already-expanded header is intentionally a no-op
+                    onClick={() => setUserExpandedOrg(state().org)}
+                  >
+                    <ChevronIcon size="md" rotated={expandedOrg() !== state().org} />
+                    <span class="text-sm font-semibold text-base-content flex-1">
+                      {state().org}
+                    </span>
+                    <Show
+                      when={!state().loading}
+                      fallback={<span class="loading loading-spinner loading-xs" />}
+                    >
+                      <span class="badge badge-sm badge-ghost">{visible().length} {visible().length === 1 ? "repo" : "repos"}</span>
+                      <Show when={selectedCount() > 0}>
+                        <span class="badge badge-sm badge-ghost">{selectedCount()} selected</span>
+                      </Show>
+                    </Show>
+                  </button>
+                  {/* Per-org bulk actions — inline in the header bar when expanded */}
+                  <Show when={expandedOrg() === state().org && !state().loading && !state().error}>
+                    <div class="flex items-center gap-2 pr-3">
+                      <button
+                        type="button"
+                        onClick={() => selectAllInOrg(state())}
+                        disabled={
+                          visible().length === 0 ||
+                          visible().every((r) => isSelected(r.fullName))
+                        }
+                        class="btn btn-ghost btn-xs"
+                      >
+                        Select All
+                      </button>
+                      <span class="text-base-content/30">·</span>
+                      <button
+                        type="button"
+                        onClick={() => deselectAllInOrg(state())}
+                        disabled={
+                          visible().length === 0 ||
+                          visible().every((r) => !isSelected(r.fullName))
+                        }
+                        class="btn btn-ghost btn-xs"
+                      >
+                        Deselect All
+                      </button>
+                    </div>
                   </Show>
-                </button>
+                </div>
               </Show>
 
               {/* Content: wrapped in grid animation for accordion, direct otherwise */}
-              <Show when={!isAccordion()}>
-                {orgContent()}
-              </Show>
-              <Show when={isAccordion()}>
+              <Show
+                when={isAccordion()}
+                fallback={orgContent()}
+              >
                 <div
                   class="accordion-panel grid transition-[grid-template-rows] duration-200"
                   style={{ "grid-template-rows": expandedOrg() === state().org ? "1fr" : "0fr" }}
                 >
                   <div
-                    id={`accordion-panel-${state().org}`}
+                    id={`accordion-panel-${orgId()}`}
                     role="region"
-                    aria-labelledby={`accordion-header-${state().org}`}
+                    aria-labelledby={`accordion-header-${orgId()}`}
                     class="overflow-hidden"
                     inert={expandedOrg() !== state().org}
                   >
@@ -684,6 +693,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
           );
         }}
       </Index>
+      </div>
 
       {/* Upstream Repositories section */}
       <Show when={props.showUpstreamDiscovery}>

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -15,6 +15,7 @@ import { relativeTime } from "../../lib/format";
 import LoadingSpinner from "../shared/LoadingSpinner";
 import FilterInput from "../shared/FilterInput";
 import { Tooltip, InfoTooltip } from "../shared/Tooltip";
+import ChevronIcon from "../shared/ChevronIcon";
 
 // Validates owner/repo format (both segments must be non-empty, no spaces)
 const VALID_REPO_NAME = /^[a-zA-Z0-9._-]{1,100}\/[a-zA-Z0-9._-]{1,100}$/;
@@ -407,6 +408,18 @@ export default function RepoSelector(props: RepoSelectorProps) {
     );
   });
 
+  // ── Accordion state ───────────────────────────────────────────────────────
+
+  const [userExpandedOrg, setUserExpandedOrg] = createSignal<string | null>(null);
+  const isAccordion = createMemo(() => sortedOrgStates().length >= 6);
+  const expandedOrg = createMemo(() => {
+    if (!isAccordion()) return null;
+    const states = sortedOrgStates();
+    const userChoice = userExpandedOrg();
+    if (userChoice !== null && states.some(s => s.org === userChoice)) return userChoice;
+    return states.length > 0 ? states[0].org : null;
+  });
+
   // ── Status ────────────────────────────────────────────────────────────────
 
   const totalOrgs = () => props.selectedOrgs.length;
@@ -453,42 +466,40 @@ export default function RepoSelector(props: RepoSelectorProps) {
       <Index each={sortedOrgStates()}>
         {(state) => {
           const visible = createMemo(() => filteredReposForOrg(state()));
+          const selectedCount = createMemo(() =>
+            visible().filter((r) => isSelected(r.fullName)).length
+          );
 
-          return (
-            <div class="overflow-hidden rounded-lg border border-base-300">
-              {/* Org header */}
-              <div class="flex items-center justify-between border-b border-base-300 bg-base-200 px-4 py-2">
-                <span class="text-sm font-semibold text-base-content">
-                  {state().org}
-                </span>
-                <Show when={!state().loading && !state().error}>
-                  <div class="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => selectAllInOrg(state())}
-                      disabled={
-                        visible().length === 0 ||
-                        visible().every((r) => isSelected(r.fullName))
-                      }
-                      class="btn btn-ghost btn-xs"
-                    >
-                      Select All
-                    </button>
-                    <span class="text-base-content/30">·</span>
-                    <button
-                      type="button"
-                      onClick={() => deselectAllInOrg(state())}
-                      disabled={
-                        visible().length === 0 ||
-                        visible().every((r) => !isSelected(r.fullName))
-                      }
-                      class="btn btn-ghost btn-xs"
-                    >
-                      Deselect All
-                    </button>
-                  </div>
-                </Show>
-              </div>
+          const orgContent = () => (
+            <>
+              {/* Per-org bulk selection bar (accordion mode only — in non-accordion, these are in the header) */}
+              <Show when={isAccordion() && !state().loading && !state().error}>
+                <div class="flex justify-end gap-2 border-b border-base-300 px-4 py-1">
+                  <button
+                    type="button"
+                    onClick={() => selectAllInOrg(state())}
+                    disabled={
+                      visible().length === 0 ||
+                      visible().every((r) => isSelected(r.fullName))
+                    }
+                    class="btn btn-ghost btn-xs"
+                  >
+                    Select All
+                  </button>
+                  <span class="text-base-content/30">&middot;</span>
+                  <button
+                    type="button"
+                    onClick={() => deselectAllInOrg(state())}
+                    disabled={
+                      visible().length === 0 ||
+                      visible().every((r) => !isSelected(r.fullName))
+                    }
+                    class="btn btn-ghost btn-xs"
+                  >
+                    Deselect All
+                  </button>
+                </div>
+              </Show>
 
               {/* Loading state for this org */}
               <Show when={state().loading}>
@@ -532,8 +543,7 @@ export default function RepoSelector(props: RepoSelectorProps) {
                   >
                     <ul class="divide-y divide-base-300">
                       <Index each={visible()}>
-                        {(repo) => {
-                          return (
+                        {(repo) => (
                             <li>
                               <div class="flex items-center">
                                 <label class="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-base-200 flex-1">
@@ -582,12 +592,93 @@ export default function RepoSelector(props: RepoSelectorProps) {
                                 </Show>
                               </div>
                             </li>
-                          );
-                        }}
+                          )}
                       </Index>
                     </ul>
                   </div>
                 </Show>
+              </Show>
+            </>
+          );
+
+          return (
+            <div class="overflow-hidden rounded-lg border border-base-300">
+              {/* Org header — accordion button when >= 6 orgs, plain header otherwise */}
+              <Show
+                when={isAccordion()}
+                fallback={
+                  <div class="flex items-center justify-between border-b border-base-300 bg-base-200 px-4 py-2">
+                    <span class="text-sm font-semibold text-base-content">
+                      {state().org}
+                    </span>
+                    <Show when={!state().loading && !state().error}>
+                      <div class="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => selectAllInOrg(state())}
+                          disabled={
+                            visible().length === 0 ||
+                            visible().every((r) => isSelected(r.fullName))
+                          }
+                          class="btn btn-ghost btn-xs"
+                        >
+                          Select All
+                        </button>
+                        <span class="text-base-content/30">·</span>
+                        <button
+                          type="button"
+                          onClick={() => deselectAllInOrg(state())}
+                          disabled={
+                            visible().length === 0 ||
+                            visible().every((r) => !isSelected(r.fullName))
+                          }
+                          class="btn btn-ghost btn-xs"
+                        >
+                          Deselect All
+                        </button>
+                      </div>
+                    </Show>
+                  </div>
+                }
+              >
+                <button
+                  type="button"
+                  id={`accordion-header-${state().org}`}
+                  class="flex w-full items-center gap-2 border-b border-base-300 bg-base-200 px-4 py-2 text-left"
+                  aria-expanded={expandedOrg() === state().org}
+                  aria-controls={`accordion-panel-${state().org}`}
+                  onClick={() => setUserExpandedOrg(state().org)}
+                >
+                  <ChevronIcon size="md" rotated={expandedOrg() !== state().org} />
+                  <span class="text-sm font-semibold text-base-content flex-1">
+                    {state().org}
+                  </span>
+                  <span class="badge badge-sm badge-ghost">{visible().length} {visible().length === 1 ? "repo" : "repos"}</span>
+                  <Show when={selectedCount() > 0}>
+                    <span class="badge badge-sm badge-ghost">{selectedCount()} selected</span>
+                  </Show>
+                </button>
+              </Show>
+
+              {/* Content: wrapped in grid animation for accordion, direct otherwise */}
+              <Show when={!isAccordion()}>
+                {orgContent()}
+              </Show>
+              <Show when={isAccordion()}>
+                <div
+                  class="accordion-panel grid transition-[grid-template-rows] duration-200"
+                  style={{ "grid-template-rows": expandedOrg() === state().org ? "1fr" : "0fr" }}
+                >
+                  <div
+                    id={`accordion-panel-${state().org}`}
+                    role="region"
+                    aria-labelledby={`accordion-header-${state().org}`}
+                    class="overflow-hidden"
+                    inert={expandedOrg() !== state().org}
+                  >
+                    {orgContent()}
+                  </div>
+                </div>
               </Show>
             </div>
           );

--- a/src/app/components/onboarding/RepoSelector.tsx
+++ b/src/app/components/onboarding/RepoSelector.tsx
@@ -16,6 +16,7 @@ import LoadingSpinner from "../shared/LoadingSpinner";
 import FilterInput from "../shared/FilterInput";
 import { Tooltip, InfoTooltip } from "../shared/Tooltip";
 import ChevronIcon from "../shared/ChevronIcon";
+import { Accordion } from "@kobalte/core";
 
 // Validates owner/repo format (both segments must be non-empty, no spaces)
 const VALID_REPO_NAME = /^[a-zA-Z0-9._-]{1,100}\/[a-zA-Z0-9._-]{1,100}$/;
@@ -39,6 +40,115 @@ interface OrgRepoState {
   repos: RepoEntry[];
   loading: boolean;
   error: string | null;
+}
+
+interface OrgContentProps {
+  state: OrgRepoState;
+  visible: RepoEntry[];
+  isSelected: (fullName: string) => boolean;
+  toggleRepo: (repo: RepoEntry) => void;
+  retryOrg: (org: string) => void;
+  q: string;
+  monitoredSet: Set<string>;
+  upstreamSelectedSet: Set<string>;
+  toRepoRef: (entry: RepoEntry) => RepoRef;
+  onMonitorToggle?: (repo: RepoRef, monitored: boolean) => void;
+}
+
+function OrgContent(props: OrgContentProps) {
+  return (
+    <>
+      <Show when={props.state.loading}>
+        <div class="flex justify-center py-6">
+          <LoadingSpinner size="sm" label="Loading..." />
+        </div>
+      </Show>
+
+      <Show when={!props.state.loading && props.state.error !== null}>
+        <div class="flex items-center justify-between px-4 py-3">
+          <span class="text-sm text-error">
+            {props.state.error}
+          </span>
+          <button
+            type="button"
+            onClick={() => props.retryOrg(props.state.org)}
+            class="btn btn-ghost btn-xs ml-3"
+          >
+            Retry
+          </button>
+        </div>
+      </Show>
+
+      <Show when={!props.state.loading && props.state.error === null}>
+        <Show
+          when={props.visible.length > 0}
+          fallback={
+            <p class="px-4 py-4 text-center text-sm text-base-content/50">
+              {props.q
+                ? "No repos match your filter."
+                : "No repositories found."}
+            </p>
+          }
+        >
+          <div class="max-h-[300px] overflow-y-auto">
+            <ul class="divide-y divide-base-300">
+              <Index each={props.visible}>
+                {(repo) => (
+                  <li>
+                    <div class="flex items-center">
+                      <label class="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-base-200 flex-1">
+                        <input
+                          type="checkbox"
+                          checked={props.isSelected(repo().fullName)}
+                          onChange={() => props.toggleRepo(repo())}
+                          class="checkbox checkbox-primary checkbox-sm mt-0.5"
+                        />
+                        <div class="min-w-0 flex-1">
+                          <div class="flex items-center gap-2">
+                            <span class="min-w-0 truncate text-sm font-medium text-base-content">
+                              {repo().name}
+                            </span>
+                            <Show when={repo().pushedAt}>
+                              <span class="ml-auto shrink-0 text-xs text-base-content/60">
+                                {relativeTime(repo().pushedAt!)}
+                              </span>
+                            </Show>
+                          </div>
+                        </div>
+                      </label>
+                      <Show when={props.isSelected(repo().fullName) && props.onMonitorToggle && !props.upstreamSelectedSet.has(repo().fullName)}>
+                        <Tooltip content={props.monitoredSet.has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              props.onMonitorToggle?.(props.toRepoRef(repo()), !props.monitoredSet.has(repo().fullName));
+                            }}
+                            class="btn btn-ghost btn-sm btn-circle mr-2"
+                            classList={{
+                              "text-info": props.monitoredSet.has(repo().fullName),
+                              "text-base-content/20": !props.monitoredSet.has(repo().fullName),
+                            }}
+                            aria-label={props.monitoredSet.has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
+                            aria-pressed={props.monitoredSet.has(repo().fullName)}
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width={2} aria-hidden="true">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                            </svg>
+                          </button>
+                        </Tooltip>
+                      </Show>
+                    </div>
+                  </li>
+                )}
+              </Index>
+            </ul>
+          </div>
+        </Show>
+      </Show>
+    </>
+  );
 }
 
 export default function RepoSelector(props: RepoSelectorProps) {
@@ -410,14 +520,18 @@ export default function RepoSelector(props: RepoSelectorProps) {
 
   // ── Accordion state ───────────────────────────────────────────────────────
 
-  const [userExpandedOrg, setUserExpandedOrg] = createSignal<string | null>(null);
-  const isAccordion = createMemo(() => sortedOrgStates().length >= 6);
-  const expandedOrg = createMemo(() => {
-    if (!isAccordion()) return null;
+  const isAccordion = createMemo(() => props.selectedOrgs.length >= 6);
+  // Stable default: props.selectedOrgs[0] avoids the mid-load shift that
+  // occurs when sortedOrgStates switches from insertion-order to alphabetical
+  const [expandedOrg, setExpandedOrg] = createSignal<string>(
+    props.selectedOrgs[0] ?? ""
+  );
+  const safeExpandedOrg = createMemo(() => {
     const states = sortedOrgStates();
-    const userChoice = userExpandedOrg();
-    if (userChoice !== null && states.some(s => s.org === userChoice)) return userChoice;
-    return states.length > 0 ? states[0].org : null;
+    const current = expandedOrg();
+    if (states.some(s => s.org === current)) return current;
+    const stateOrgs = new Set(states.map(s => s.org));
+    return props.selectedOrgs.find(o => stateOrgs.has(o)) ?? (states.length > 0 ? states[0].org : "");
   });
 
   // ── Status ────────────────────────────────────────────────────────────────
@@ -463,123 +577,14 @@ export default function RepoSelector(props: RepoSelectorProps) {
 
       {/* Per-org repo lists — Index (not For) avoids tearing down every org's
            DOM subtree when a single org's state updates via setOrgStates(prev.map(...)) */}
-      <div class={isAccordion() ? "overflow-hidden rounded-lg border border-base-300 divide-y divide-base-300" : "contents"}>
-      <Index each={sortedOrgStates()}>
-        {(state) => {
-          const visible = createMemo(() => filteredReposForOrg(state()));
-          const selectedCount = createMemo(() =>
-            visible().filter((r) => isSelected(r.fullName)).length
-          );
-          const orgId = createMemo(() => state().org.replace(/[^a-zA-Z0-9-]/g, "-"));
-
-          const orgContent = () => (
-            <>
-              {/* Loading state for this org */}
-              <Show when={state().loading}>
-                <div class="flex justify-center py-6">
-                  <LoadingSpinner size="sm" label="Loading..." />
-                </div>
-              </Show>
-
-              {/* Error state for this org */}
-              <Show when={!state().loading && state().error !== null}>
-                <div class="flex items-center justify-between px-4 py-3">
-                  <span class="text-sm text-error">
-                    {state().error}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => retryOrg(state().org)}
-                    class="btn btn-ghost btn-xs ml-3"
-                  >
-                    Retry
-                  </button>
-                </div>
-              </Show>
-
-              {/* Repo list */}
-              <Show when={!state().loading && state().error === null}>
-                <Show
-                  when={visible().length > 0}
-                  fallback={
-                    <p class="px-4 py-4 text-center text-sm text-base-content/50">
-                      {q()
-                        ? "No repos match your filter."
-                        : "No repositories found."}
-                    </p>
-                  }
-                >
-                  <div
-                    class="max-h-[300px] overflow-y-auto"
-                    role="region"
-                    aria-label={`${state().org} repositories`}
-                  >
-                    <ul class="divide-y divide-base-300">
-                      <Index each={visible()}>
-                        {(repo) => (
-                            <li>
-                              <div class="flex items-center">
-                                <label class="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-base-200 flex-1">
-                                  <input
-                                    type="checkbox"
-                                    checked={isSelected(repo().fullName)}
-                                    onChange={() => toggleRepo(repo())}
-                                    class="checkbox checkbox-primary checkbox-sm mt-0.5"
-                                  />
-                                  <div class="min-w-0 flex-1">
-                                    <div class="flex items-center gap-2">
-                                      <span class="min-w-0 truncate text-sm font-medium text-base-content">
-                                        {repo().name}
-                                      </span>
-                                      <Show when={repo().pushedAt}>
-                                        <span class="ml-auto shrink-0 text-xs text-base-content/60">
-                                          {relativeTime(repo().pushedAt!)}
-                                        </span>
-                                      </Show>
-                                    </div>
-                                  </div>
-                                </label>
-                                <Show when={isSelected(repo().fullName) && props.onMonitorToggle && !upstreamSelectedSet().has(repo().fullName)}>
-                                  <Tooltip content={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}>
-                                    <button
-                                      type="button"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        props.onMonitorToggle?.(toRepoRef(repo()), !monitoredSet().has(repo().fullName));
-                                      }}
-                                      class="btn btn-ghost btn-sm btn-circle mr-2"
-                                      classList={{
-                                        "text-info": monitoredSet().has(repo().fullName),
-                                        "text-base-content/20": !monitoredSet().has(repo().fullName),
-                                      }}
-                                      aria-label={monitoredSet().has(repo().fullName) ? "Stop monitoring all activity" : "Monitor all activity"}
-                                      aria-pressed={monitoredSet().has(repo().fullName)}
-                                    >
-                                      {/* Heroicons eye outline 16px */}
-                                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width={2} aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                                      </svg>
-                                    </button>
-                                  </Tooltip>
-                                </Show>
-                              </div>
-                            </li>
-                          )}
-                      </Index>
-                    </ul>
-                  </div>
-                </Show>
-              </Show>
-            </>
-          );
-
-          return (
-            <div class={isAccordion() ? "" : "overflow-hidden rounded-lg border border-base-300"}>
-              {/* Org header — accordion button when >= 6 orgs, plain header otherwise */}
-              <Show
-                when={isAccordion()}
-                fallback={
+      <Show
+        when={isAccordion()}
+        fallback={
+          <Index each={sortedOrgStates()}>
+            {(state) => {
+              const visible = createMemo(() => filteredReposForOrg(state()));
+              return (
+                <div class="overflow-hidden rounded-lg border border-base-300" role="region" aria-label={`${state().org} repositories`}>
                   <div class="flex items-center justify-between border-b border-base-300 bg-base-200 px-4 py-2">
                     <span class="text-sm font-semibold text-base-content">
                       {state().org}
@@ -612,88 +617,90 @@ export default function RepoSelector(props: RepoSelectorProps) {
                       </div>
                     </Show>
                   </div>
-                }
-              >
-                <div class="flex items-center border-b border-base-300 bg-base-200">
-                  <button
-                    type="button"
-                    id={`accordion-header-${orgId()}`}
-                    class="flex flex-1 items-center gap-2 px-4 py-2 text-left"
-                    aria-expanded={expandedOrg() === state().org}
-                    aria-controls={`accordion-panel-${orgId()}`}
-                    // Always-one-open: clicking the already-expanded header is intentionally a no-op
-                    onClick={() => setUserExpandedOrg(state().org)}
-                  >
-                    <ChevronIcon size="md" rotated={expandedOrg() !== state().org} />
-                    <span class="text-sm font-semibold text-base-content flex-1">
-                      {state().org}
-                    </span>
-                    <Show
-                      when={!state().loading}
-                      fallback={<span class="loading loading-spinner loading-xs" />}
-                    >
-                      <span class="badge badge-sm badge-ghost">{visible().length} {visible().length === 1 ? "repo" : "repos"}</span>
-                      <Show when={selectedCount() > 0}>
-                        <span class="badge badge-sm badge-ghost">{selectedCount()} selected</span>
-                      </Show>
+                  <OrgContent state={state()} visible={visible()} isSelected={isSelected} toggleRepo={toggleRepo} retryOrg={retryOrg} q={q()} monitoredSet={monitoredSet()} upstreamSelectedSet={upstreamSelectedSet()} toRepoRef={toRepoRef} onMonitorToggle={props.onMonitorToggle} />
+                </div>
+              );
+            }}
+          </Index>
+        }
+      >
+        <Accordion.Root
+          class="overflow-hidden rounded-lg border border-base-300 divide-y divide-base-300"
+          value={[safeExpandedOrg()]}
+          // Guard: Kobalte fires onChange([]) when clicking the open panel's trigger
+          // in single-select mode. The guard enforces always-one-open by ignoring
+          // empty selections. Tested indirectly via "re-click is a no-op" tests.
+          onChange={(vals) => {
+            if (vals.length > 0) setExpandedOrg(vals[0]);
+          }}
+        >
+          <Index each={sortedOrgStates()}>
+            {(state) => {
+              const visible = createMemo(() => filteredReposForOrg(state()));
+              // Count against ALL repos in the org (unfiltered) so the badge
+              // doesn't mislead users into thinking selections were lost when
+              // a text filter is active.
+              const selectedCount = createMemo(() =>
+                state().repos.filter((r) => isSelected(r.fullName)).length
+              );
+              const isExpanded = () => safeExpandedOrg() === state().org;
+              return (
+                <Accordion.Item value={state().org}>
+                  <div class="flex items-center border-b border-base-300 bg-base-200">
+                    <Accordion.Header class="flex-1">
+                      <Accordion.Trigger class="flex w-full items-center gap-2 px-4 py-2 text-left">
+                        <ChevronIcon size="md" rotated={!isExpanded()} />
+                        <span class="text-sm font-semibold text-base-content flex-1">
+                          {state().org}
+                        </span>
+                        <Show
+                          when={!state().loading}
+                          fallback={<span class="loading loading-spinner loading-xs" />}
+                        >
+                          <span class="badge badge-sm badge-ghost">{visible().length} {visible().length === 1 ? "repo" : "repos"}</span>
+                          <Show when={selectedCount() > 0}>
+                            <span class="badge badge-sm badge-ghost">{selectedCount()} selected</span>
+                          </Show>
+                        </Show>
+                      </Accordion.Trigger>
+                    </Accordion.Header>
+                    <Show when={isExpanded() && !state().loading && !state().error}>
+                      <div class="flex items-center gap-2 pr-3">
+                        <button
+                          type="button"
+                          onClick={() => selectAllInOrg(state())}
+                          disabled={
+                            visible().length === 0 ||
+                            visible().every((r) => isSelected(r.fullName))
+                          }
+                          class="btn btn-ghost btn-xs"
+                        >
+                          Select All
+                        </button>
+                        <span class="text-base-content/30">·</span>
+                        <button
+                          type="button"
+                          onClick={() => deselectAllInOrg(state())}
+                          disabled={
+                            visible().length === 0 ||
+                            visible().every((r) => !isSelected(r.fullName))
+                          }
+                          class="btn btn-ghost btn-xs"
+                        >
+                          Deselect All
+                        </button>
+                      </div>
                     </Show>
-                  </button>
-                  {/* Per-org bulk actions — inline in the header bar when expanded */}
-                  <Show when={expandedOrg() === state().org && !state().loading && !state().error}>
-                    <div class="flex items-center gap-2 pr-3">
-                      <button
-                        type="button"
-                        onClick={() => selectAllInOrg(state())}
-                        disabled={
-                          visible().length === 0 ||
-                          visible().every((r) => isSelected(r.fullName))
-                        }
-                        class="btn btn-ghost btn-xs"
-                      >
-                        Select All
-                      </button>
-                      <span class="text-base-content/30">·</span>
-                      <button
-                        type="button"
-                        onClick={() => deselectAllInOrg(state())}
-                        disabled={
-                          visible().length === 0 ||
-                          visible().every((r) => !isSelected(r.fullName))
-                        }
-                        class="btn btn-ghost btn-xs"
-                      >
-                        Deselect All
-                      </button>
-                    </div>
-                  </Show>
-                </div>
-              </Show>
-
-              {/* Content: wrapped in grid animation for accordion, direct otherwise */}
-              <Show
-                when={isAccordion()}
-                fallback={orgContent()}
-              >
-                <div
-                  class="accordion-panel grid transition-[grid-template-rows] duration-200"
-                  style={{ "grid-template-rows": expandedOrg() === state().org ? "1fr" : "0fr" }}
-                >
-                  <div
-                    id={`accordion-panel-${orgId()}`}
-                    role="region"
-                    aria-labelledby={`accordion-header-${orgId()}`}
-                    class="overflow-hidden"
-                    inert={expandedOrg() !== state().org}
-                  >
-                    {orgContent()}
                   </div>
-                </div>
-              </Show>
-            </div>
-          );
-        }}
-      </Index>
-      </div>
+                  <Accordion.Content class="kb-accordion-content">
+                    <OrgContent state={state()} visible={visible()} isSelected={isSelected} toggleRepo={toggleRepo} retryOrg={retryOrg} q={q()} monitoredSet={monitoredSet()} upstreamSelectedSet={upstreamSelectedSet()} toRepoRef={toRepoRef} onMonitorToggle={props.onMonitorToggle} />
+                  </Accordion.Content>
+                </Accordion.Item>
+              );
+            }}
+          </Index>
+        </Accordion.Root>
+      </Show>
 
       {/* Upstream Repositories section */}
       <Show when={props.showUpstreamDiscovery}>

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -1,17 +1,12 @@
 import { Show, createMemo } from "solid-js";
 import { viewState, lockRepo, unlockRepo, moveLockedRepo, type LockedReposTab } from "../../stores/view";
 import { Tooltip } from "./Tooltip";
+import { withFlipAnimation } from "../../lib/scroll";
 
 interface RepoLockControlsProps {
   tab: LockedReposTab;
   repoFullName: string;
 }
-
-const withScrollLock = (fn: () => void) => {
-  const y = window.scrollY;
-  fn();
-  window.scrollTo(0, y);
-};
 
 export default function RepoLockControls(props: RepoLockControlsProps) {
   const lockInfo = createMemo(() => {
@@ -32,7 +27,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
           <Tooltip content="Pin to top">
             <button
               class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
-              onClick={() => withScrollLock(() => lockRepo(props.tab, props.repoFullName))}
+              onClick={() => withFlipAnimation(() => lockRepo(props.tab, props.repoFullName))}
               aria-label={`Pin ${props.repoFullName} to top of list`}
             >
               {/* Heroicons 20px solid: lock-open */}
@@ -46,7 +41,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content="Unpin">
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withScrollLock(() => unlockRepo(props.tab, props.repoFullName))}
+            onClick={() => withFlipAnimation(() => unlockRepo(props.tab, props.repoFullName))}
             aria-label={`Unpin ${props.repoFullName}`}
           >
             {/* Heroicons 20px solid: lock-closed */}
@@ -58,7 +53,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isFirst ? "Already at top of pinned list" : "Move up"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withScrollLock(() => moveLockedRepo(props.tab, props.repoFullName, "up"))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.tab, props.repoFullName, "up"))}
             disabled={lockInfo().isFirst}
             aria-label={`Move ${props.repoFullName} up`}
           >
@@ -71,7 +66,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isLast ? "Already at bottom of pinned list" : "Move down"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withScrollLock(() => moveLockedRepo(props.tab, props.repoFullName, "down"))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.tab, props.repoFullName, "down"))}
             disabled={lockInfo().isLast}
             aria-label={`Move ${props.repoFullName} down`}
           >

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -7,6 +7,12 @@ interface RepoLockControlsProps {
   repoFullName: string;
 }
 
+const withScrollLock = (fn: () => void) => {
+  const y = window.scrollY;
+  fn();
+  window.scrollTo(0, y);
+};
+
 export default function RepoLockControls(props: RepoLockControlsProps) {
   const lockInfo = createMemo(() => {
     const list = viewState.lockedRepos[props.tab];
@@ -26,7 +32,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
           <Tooltip content="Pin to top">
             <button
               class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
-              onClick={() => lockRepo(props.tab, props.repoFullName)}
+              onClick={() => withScrollLock(() => lockRepo(props.tab, props.repoFullName))}
               aria-label={`Pin ${props.repoFullName} to top of list`}
             >
               {/* Heroicons 20px solid: lock-open */}
@@ -40,7 +46,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content="Unpin">
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => unlockRepo(props.tab, props.repoFullName)}
+            onClick={() => withScrollLock(() => unlockRepo(props.tab, props.repoFullName))}
             aria-label={`Unpin ${props.repoFullName}`}
           >
             {/* Heroicons 20px solid: lock-closed */}
@@ -52,7 +58,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isFirst ? "Already at top of pinned list" : "Move up"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => moveLockedRepo(props.tab, props.repoFullName, "up")}
+            onClick={() => withScrollLock(() => moveLockedRepo(props.tab, props.repoFullName, "up"))}
             disabled={lockInfo().isFirst}
             aria-label={`Move ${props.repoFullName} up`}
           >
@@ -65,7 +71,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isLast ? "Already at bottom of pinned list" : "Move down"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => moveLockedRepo(props.tab, props.repoFullName, "down")}
+            onClick={() => withScrollLock(() => moveLockedRepo(props.tab, props.repoFullName, "down"))}
             disabled={lockInfo().isLast}
             aria-label={`Move ${props.repoFullName} down`}
           >

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -145,4 +145,7 @@
   .loading {
     animation: none;
   }
+  .accordion-panel {
+    transition: none;
+  }
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -136,6 +136,25 @@
   scrollbar-color: color-mix(in oklch, var(--color-base-content) 30%, transparent) var(--color-base-200);
 }
 
+/* ── Kobalte accordion animation ─────────────────────────────────────────── */
+
+.kb-accordion-content {
+  overflow: hidden;
+  animation: kb-accordion-down 200ms ease-in-out forwards;
+}
+.kb-accordion-content[data-closed] {
+  animation: kb-accordion-up 200ms ease-in-out forwards;
+}
+
+@keyframes kb-accordion-down {
+  from { height: 0; }
+  to { height: var(--kb-accordion-content-height); }
+}
+@keyframes kb-accordion-up {
+  from { height: var(--kb-accordion-content-height); }
+  to { height: 0; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-slow-pulse,
   .animate-toast-in, .animate-toast-out,
@@ -145,7 +164,8 @@
   .loading {
     animation: none;
   }
-  .accordion-panel {
-    transition: none;
+  .kb-accordion-content,
+  .kb-accordion-content[data-closed] {
+    animation: none;
   }
 }

--- a/src/app/lib/scroll.ts
+++ b/src/app/lib/scroll.ts
@@ -5,7 +5,11 @@
  */
 export function withScrollLock(fn: () => void): void {
   const y = window.scrollY;
-  try { fn(); } finally { window.scrollTo(0, y); }
+  try {
+    fn();
+  } finally {
+    window.scrollTo(0, y);
+  }
 }
 
 /**
@@ -34,18 +38,29 @@ export function withFlipAnimation(fn: () => void): void {
   }
 
   // Execute state change (SolidJS updates DOM synchronously)
+  const scrollY = window.scrollY;
   fn();
 
-  // Last, Invert, Play
+  // Last, Invert, Play — reads before writes to avoid layout thrash.
+  // All getBoundingClientRect calls happen before scrollTo so the browser
+  // doesn't force a synchronous layout recalculation between them.
   requestAnimationFrame(() => {
     const afterItems = document.querySelectorAll<HTMLElement>("[data-repo-group]");
+    const scrollDrift = window.scrollY - scrollY;
+    const deltas: { el: HTMLElement; dy: number }[] = [];
     for (const el of afterItems) {
       const key = el.dataset.repoGroup!;
       const old = before.get(key);
       if (!old) continue;
       const now = el.getBoundingClientRect();
-      const dy = old.top - now.top;
+      // Adjust for scroll drift: old.top was measured at scrollY,
+      // now.top is measured at the current (possibly drifted) scroll position.
+      const dy = old.top - now.top - scrollDrift;
       if (Math.abs(dy) < 1) continue;
+      deltas.push({ el, dy });
+    }
+    window.scrollTo(0, scrollY);
+    for (const { el, dy } of deltas) {
       el.animate(
         [{ transform: `translateY(${dy}px)` }, { transform: "translateY(0)" }],
         { duration: 200, easing: "ease-in-out" },

--- a/src/app/lib/scroll.ts
+++ b/src/app/lib/scroll.ts
@@ -1,0 +1,55 @@
+/**
+ * Wraps a synchronous function call with scroll position preservation.
+ * SolidJS fine-grained DOM updates complete synchronously within fn(),
+ * so a single synchronous scrollTo is sufficient — no rAF needed.
+ */
+export function withScrollLock(fn: () => void): void {
+  const y = window.scrollY;
+  try { fn(); } finally { window.scrollTo(0, y); }
+}
+
+/**
+ * FLIP animation for reorderable lists. Records positions of elements
+ * matching `[data-repo-group]` before fn(), then animates them to their
+ * new positions after the DOM update.
+ *
+ * Consistent with TrackedTab's FLIP: 200ms ease-in-out, respects
+ * prefers-reduced-motion (falls back to withScrollLock).
+ */
+export function withFlipAnimation(fn: () => void): void {
+  if (typeof window === "undefined") { fn(); return; }
+
+  // Reduced motion: fall back to instant scroll lock
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    withScrollLock(fn);
+    return;
+  }
+
+  // First: record positions of all repo group wrappers
+  const items = document.querySelectorAll<HTMLElement>("[data-repo-group]");
+  const before = new Map<string, DOMRect>();
+  for (const el of items) {
+    const key = el.dataset.repoGroup!;
+    before.set(key, el.getBoundingClientRect());
+  }
+
+  // Execute state change (SolidJS updates DOM synchronously)
+  fn();
+
+  // Last, Invert, Play
+  requestAnimationFrame(() => {
+    const afterItems = document.querySelectorAll<HTMLElement>("[data-repo-group]");
+    for (const el of afterItems) {
+      const key = el.dataset.repoGroup!;
+      const old = before.get(key);
+      if (!old) continue;
+      const now = el.getBoundingClientRect();
+      const dy = old.top - now.top;
+      if (Math.abs(dy) < 1) continue;
+      el.animate(
+        [{ transform: `translateY(${dy}px)` }, { transform: "translateY(0)" }],
+        { duration: 200, easing: "ease-in-out" },
+      );
+    }
+  });
+}

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -682,6 +682,17 @@ describe("DashboardPage — onAuthCleared integration", () => {
 });
 
 describe("DashboardPage — scroll preservation on poll refresh", () => {
+  // MOCK INVARIANT: fetchAllData is mocked via vi.fn() and never calls its
+  // onLightData callback, so phaseOneFired is always false inside pollFetch().
+  // This means every poll cycle takes the withScrollLock branch (not the
+  // fine-grained produce() path). If fetchAllData is ever changed to invoke
+  // onLightData in tests, phaseOneFired will become true and withScrollLock
+  // will NOT be called, silently breaking this test.
+  //
+  // window.scrollTo is the correct behavioral proxy for withScrollLock:
+  // withScrollLock captures scrollY then calls window.scrollTo(0, y) after
+  // the setter. Asserting scrollTo was called with the saved position is
+  // equivalent to asserting withScrollLock ran and completed successfully.
   it("preserves scroll position when setDashboardData replaces arrays", async () => {
     const issues = [makeIssue({ id: 1, title: "Scroll test issue" })];
     vi.mocked(pollService.fetchAllData).mockResolvedValue({
@@ -700,11 +711,15 @@ describe("DashboardPage — scroll preservation on poll refresh", () => {
     document.documentElement.scrollTop = 500;
     vi.spyOn(window, "scrollTo");
 
-    // Trigger a second poll (subsequent refresh — the path that uses withScrollLock)
+    // Trigger a second poll (subsequent refresh — the path that uses withScrollLock).
+    // phaseOneFired is false (mock never calls onLightData), so withScrollLock
+    // wraps the full atomic setDashboardData replacement and restores scroll.
     if (capturedFetchAll) {
       await capturedFetchAll();
     }
 
+    // window.scrollTo(0, 500) is the observable side-effect of withScrollLock
+    // saving and restoring the pre-update scroll position.
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
     vi.restoreAllMocks();
     document.documentElement.scrollTop = 0;

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -681,6 +681,36 @@ describe("DashboardPage — onAuthCleared integration", () => {
   });
 });
 
+describe("DashboardPage — scroll preservation on poll refresh", () => {
+  it("preserves scroll position when setDashboardData replaces arrays", async () => {
+    const issues = [makeIssue({ id: 1, title: "Scroll test issue" })];
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues,
+      pullRequests: [],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      screen.getByText("owner/repo");
+    });
+
+    // Simulate user scrolled down
+    document.documentElement.scrollTop = 500;
+    vi.spyOn(window, "scrollTo");
+
+    // Trigger a second poll (subsequent refresh — the path that uses withScrollLock)
+    if (capturedFetchAll) {
+      await capturedFetchAll();
+    }
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
+    vi.restoreAllMocks();
+    document.documentElement.scrollTop = 0;
+  });
+});
+
 describe("DashboardPage — onHotData integration", () => {
   it("applies hot poll PR status updates to the store", async () => {
     const testPR = makePullRequest({

--- a/tests/components/onboarding/RepoSelector.test.tsx
+++ b/tests/components/onboarding/RepoSelector.test.tsx
@@ -372,6 +372,41 @@ describe("RepoSelector", () => {
     });
     expect(api.fetchOrgs).not.toHaveBeenCalled();
   });
+
+  it("per-org Select All is disabled when all repos already selected (non-accordion)", async () => {
+    vi.mocked(api.fetchRepos).mockResolvedValue(myorgRepos);
+    const allSelected: RepoRef[] = myorgRepos.map((r) => ({ owner: r.owner, name: r.name, fullName: r.fullName }));
+
+    render(() => (
+      <RepoSelector selectedOrgs={["myorg"]} selected={allSelected} onChange={vi.fn()} />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("repo-a");
+    });
+
+    // Non-accordion: per-org Select All is in the header
+    const selectAllBtns = screen.getAllByText("Select All");
+    const perOrgSelectAll = selectAllBtns[selectAllBtns.length - 1] as HTMLButtonElement;
+    expect(perOrgSelectAll.disabled).toBe(true);
+  });
+
+  it("per-org Deselect All is disabled when no repos selected (non-accordion)", async () => {
+    vi.mocked(api.fetchRepos).mockResolvedValue(myorgRepos);
+
+    render(() => (
+      <RepoSelector selectedOrgs={["myorg"]} selected={[]} onChange={vi.fn()} />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("repo-a");
+    });
+
+    // Non-accordion: per-org Deselect All is in the header
+    const deselectAllBtns = screen.getAllByText("Deselect All");
+    const perOrgDeselectAll = deselectAllBtns[deselectAllBtns.length - 1] as HTMLButtonElement;
+    expect(perOrgDeselectAll.disabled).toBe(true);
+  });
 });
 
 describe("RepoSelector — upstream discovery", () => {
@@ -846,9 +881,34 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("delta-org-repo");
     });
 
-    // No accordion chevron buttons present
-    expect(screen.queryAllByRole("button", { name: /chevron|expand|collapse/i })).toHaveLength(0);
+    // No accordion header buttons present (no aria-expanded attributes)
+    expect(document.querySelectorAll("[aria-expanded]")).toHaveLength(0);
     // All repo content visible (no inert panels)
+    expect(document.querySelectorAll("[inert]")).toHaveLength(0);
+  });
+
+  it("renders all orgs expanded when exactly 5 orgs (boundary below threshold)", async () => {
+    // 5 orgs → still no accordion (threshold is >= 6)
+    const fiveOrgs = ["alpha-org", "beta-org", "gamma-org", "delta-org", "epsilon-org"];
+    const fiveOrgEntries = fiveOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={fiveOrgs}
+        orgEntries={fiveOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+      screen.getByText("epsilon-org-repo");
+    });
+
+    // No accordion chevron buttons present — 5 orgs is still below the >= 6 threshold
+    expect(screen.queryAllByRole("button", { name: /chevron|expand|collapse/i })).toHaveLength(0);
+    // All repo content visible — no inert panels
     expect(document.querySelectorAll("[inert]")).toHaveLength(0);
   });
 
@@ -903,7 +963,7 @@ describe("RepoSelector — org accordion", () => {
     expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("clicking the currently-expanded org header is a no-op (content stays visible)", async () => {
+  it("clicking the default-expanded org header is a no-op (null → explicit path)", async () => {
     render(() => (
       <RepoSelector
         selectedOrgs={sixOrgs}
@@ -923,6 +983,33 @@ describe("RepoSelector — org accordion", () => {
 
     // alpha-org is still expanded (setUserExpandedOrg sets to same value)
     expect(alphaBtn.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelectorAll("[inert]")).toHaveLength(5);
+  });
+
+  it("clicking the explicitly-expanded org header a second time is a no-op (re-click path)", async () => {
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // First: click beta-org to explicitly set userExpandedOrg = 'beta-org'
+    const betaBtn = screen.getByRole("button", { name: /beta-org/ });
+    fireEvent.click(betaBtn);
+    expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelectorAll("[inert]")).toHaveLength(5);
+
+    // Second: click beta-org again — userExpandedOrg is already 'beta-org',
+    // so setUserExpandedOrg('beta-org') is a no-op and beta-org must remain expanded
+    fireEvent.click(betaBtn);
+    expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
     expect(document.querySelectorAll("[inert]")).toHaveLength(5);
   });
 
@@ -960,21 +1047,14 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // The expanded org (alpha-org) should show per-org Select All inside the panel content
-    const selectAllBtns = screen.getAllByRole("button", { name: /Select All/i });
-    // Global Select All + per-org Select All for the expanded org
-    const perOrgSelectAll = selectAllBtns.filter(
-      (btn) => !btn.closest("[inert]") && btn.textContent === "Select All"
+    // The expanded org (alpha-org) should show per-org Select All in the header bar
+    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
+    expect(headerBtn).not.toBeNull();
+    const headerRow = headerBtn.parentElement!;
+    const perOrgBtn = Array.from(headerRow.querySelectorAll("button")).find(
+      (b) => b.textContent === "Select All" && b !== headerBtn
     );
-    expect(perOrgSelectAll.length).toBeGreaterThanOrEqual(2); // global + expanded org
-
-    // Click per-org Select All inside the expanded panel (not the global one)
-    // The per-org one is inside the accordion panel content area
-    const panelContent = document.getElementById("accordion-panel-alpha-org");
-    expect(panelContent).not.toBeNull();
-    const perOrgBtn = panelContent!.querySelector("button");
-    expect(perOrgBtn).not.toBeNull();
-    expect(perOrgBtn!.textContent).toBe("Select All");
+    expect(perOrgBtn).not.toBeUndefined();
     fireEvent.click(perOrgBtn!);
 
     // Should select only alpha-org's repo
@@ -985,6 +1065,111 @@ describe("RepoSelector — org accordion", () => {
     const selectedNames = onChange.mock.calls[0][0].map((r: { fullName: string }) => r.fullName);
     expect(selectedNames).toHaveLength(1);
     expect(selectedNames[0]).toBe("alpha-org/alpha-org-repo");
+  });
+
+  it("per-org Select All is disabled when all repos already selected; Deselect All is disabled when none selected", async () => {
+    const allSelected: RepoRef[] = sixOrgs.map((org) => ({
+      owner: org,
+      name: `${org}-repo`,
+      fullName: `${org}/${org}-repo`,
+    }));
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={allSelected}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // alpha-org is expanded — per-org buttons are in the header bar
+    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
+    const headerRow = headerBtn.parentElement!;
+    const actionBtns = Array.from(headerRow.querySelectorAll("button")).filter((b) => b !== headerBtn);
+    const perOrgSelectAll = actionBtns.find((b) => b.textContent === "Select All") as HTMLButtonElement;
+    const perOrgDeselectAll = actionBtns.find((b) => b.textContent === "Deselect All") as HTMLButtonElement;
+
+    // All repos are already selected — Select All must be disabled
+    expect(perOrgSelectAll).not.toBeUndefined();
+    expect(perOrgSelectAll.disabled).toBe(true);
+
+    // All repos are selected — Deselect All must be enabled
+    expect(perOrgDeselectAll).not.toBeUndefined();
+    expect(perOrgDeselectAll.disabled).toBe(false);
+  });
+
+  it("per-org Deselect All is disabled when no repos are selected in that org", async () => {
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
+    const headerRow = headerBtn.parentElement!;
+    const actionBtns = Array.from(headerRow.querySelectorAll("button")).filter((b) => b !== headerBtn);
+    const perOrgSelectAll = actionBtns.find((b) => b.textContent === "Select All") as HTMLButtonElement;
+    const perOrgDeselectAll = actionBtns.find((b) => b.textContent === "Deselect All") as HTMLButtonElement;
+
+    // No repos selected — Select All must be enabled
+    expect(perOrgSelectAll).not.toBeUndefined();
+    expect(perOrgSelectAll.disabled).toBe(false);
+
+    // No repos selected — Deselect All must be disabled
+    expect(perOrgDeselectAll).not.toBeUndefined();
+    expect(perOrgDeselectAll.disabled).toBe(true);
+  });
+
+  it("per-org Deselect All in accordion panel deselects repos from that org", async () => {
+    const preSelected: RepoRef[] = ["alpha-org", "beta-org"].map((org) => ({
+      owner: org,
+      name: `${org}-repo`,
+      fullName: `${org}/${org}-repo`,
+    }));
+    const onChange = vi.fn();
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={preSelected}
+        onChange={onChange}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Deselect All is in the header bar when expanded
+    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
+    const headerRow = headerBtn.parentElement!;
+    const perOrgDeselectAll = Array.from(headerRow.querySelectorAll("button")).find(
+      (b) => b.textContent === "Deselect All"
+    ) as HTMLButtonElement;
+    expect(perOrgDeselectAll).not.toBeUndefined();
+    expect(perOrgDeselectAll.disabled).toBe(false);
+
+    fireEvent.click(perOrgDeselectAll);
+
+    // onChange should have been called with alpha-org's repo removed
+    expect(onChange).toHaveBeenCalledOnce();
+    const result = onChange.mock.calls[0][0] as RepoRef[];
+    expect(result.map((r) => r.fullName)).not.toContain("alpha-org/alpha-org-repo");
+    // beta-org's repo must still be selected
+    expect(result.map((r) => r.fullName)).toContain("beta-org/beta-org-repo");
   });
 
   it("global Select All includes repos from collapsed orgs", async () => {
@@ -1109,9 +1294,7 @@ describe("RepoSelector — org accordion", () => {
     fireEvent.click(gammaBtn);
     expect(gammaBtn.getAttribute("aria-expanded")).toBe("true");
 
-    // Re-render without gamma-org (still 5 orgs >= 6 threshold? No, 5 < 6 so accordion exits)
-    // Use 7 orgs to ensure >= 6 remains after removing one
-    // Actually: let's test with 7 orgs so we stay in accordion mode after removal
+    // Start with 7 orgs so removing one leaves 6 (still in accordion mode)
     const sevenOrgs = [...sixOrgs, "eta-org"];
     const sevenOrgEntries = sevenOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
     vi.mocked(api.fetchRepos).mockImplementation((_client, org) =>

--- a/tests/components/onboarding/RepoSelector.test.tsx
+++ b/tests/components/onboarding/RepoSelector.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { render, screen, waitFor, fireEvent } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import type { RepoRef, RepoEntry } from "../../../src/app/services/api";
 
@@ -390,8 +390,9 @@ describe("RepoSelector — upstream discovery", () => {
     await waitFor(() => {
       screen.getByText("repo-a");
     });
-    // Give time for any async effects to settle
-    await new Promise((r) => setTimeout(r, 50));
+    // Verify discoverUpstreamRepos was never called after repos finished loading.
+    // waitFor above already ensures the async effect settled (fetchRepos resolved),
+    // so no additional delay is needed.
     expect(api.discoverUpstreamRepos).not.toHaveBeenCalled();
   });
 
@@ -797,5 +798,351 @@ describe("RepoSelector — monitor toggle", () => {
     await waitFor(() => screen.getByText("repo-a"));
     // Monitor toggle should not appear for upstream repos
     expect(screen.queryByLabelText(/monitor all activity/i)).toBeNull();
+  });
+});
+
+// ── Org-grouped accordion (C2) ────────────────────────────────────────────────
+
+describe("RepoSelector — org accordion", () => {
+  // 6 org names that trigger accordion mode (threshold is >= 6)
+  const sixOrgs = ["alpha-org", "beta-org", "gamma-org", "delta-org", "epsilon-org", "zeta-org"];
+
+  // Minimal OrgEntry list for preloading (skips fetchOrgs network call)
+  const sixOrgEntries = sixOrgs.map((login) => ({
+    login,
+    avatarUrl: "",
+    type: "org" as const,
+  }));
+
+  // One repo per org
+  function makeOrgRepos(org: string): RepoEntry[] {
+    return [{ owner: org, name: `${org}-repo`, fullName: `${org}/${org}-repo`, pushedAt: "2026-03-20T10:00:00Z" }];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.mocked(api.fetchRepos).mockImplementation((_client, org) =>
+      Promise.resolve(makeOrgRepos(org as string))
+    );
+  });
+
+  it("renders all orgs expanded when fewer than 6 orgs", async () => {
+    // 4 orgs → no accordion
+    const fourOrgs = ["alpha-org", "beta-org", "gamma-org", "delta-org"];
+    const fourOrgEntries = fourOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={fourOrgs}
+        orgEntries={fourOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+      screen.getByText("delta-org-repo");
+    });
+
+    // No accordion chevron buttons present
+    expect(screen.queryAllByRole("button", { name: /chevron|expand|collapse/i })).toHaveLength(0);
+    // All repo content visible (no inert panels)
+    expect(document.querySelectorAll("[inert]")).toHaveLength(0);
+  });
+
+  it("renders accordion with first org expanded by default when 6+ orgs", async () => {
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // First org panel is not inert (expanded)
+    const panels = document.querySelectorAll("[inert]");
+    // All other 5 orgs are collapsed (inert)
+    expect(panels).toHaveLength(5);
+
+    // First org repo content is accessible
+    expect(screen.queryByText("alpha-org-repo")).not.toBeNull();
+  });
+
+  it("clicking another org header collapses the first and expands the clicked one", async () => {
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Find and click the beta-org accordion header button
+    const betaBtn = screen.getByRole("button", { name: /beta-org/ });
+    fireEvent.click(betaBtn);
+
+    // Now beta-org panel should be expanded (not inert), alpha-org collapsed
+    await waitFor(() => {
+      // 5 orgs still collapsed
+      expect(document.querySelectorAll("[inert]")).toHaveLength(5);
+    });
+
+    // The expanded button should now be beta-org (aria-expanded=true)
+    expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("clicking the currently-expanded org header is a no-op (content stays visible)", async () => {
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Click the already-expanded first org header
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    fireEvent.click(alphaBtn);
+
+    // alpha-org is still expanded (setUserExpandedOrg sets to same value)
+    expect(alphaBtn.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelectorAll("[inert]")).toHaveLength(5);
+  });
+
+  it("shows repo count badge on org headers in accordion mode", async () => {
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Each org has 1 repo — badge shows "1 repo"
+    const badges = screen.getAllByText("1 repo");
+    expect(badges.length).toBe(sixOrgs.length);
+  });
+
+  it("shows per-org Select All / Deselect All in expanded accordion panel", async () => {
+    const onChange = vi.fn();
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={onChange}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // The expanded org (alpha-org) should show per-org Select All inside the panel content
+    const selectAllBtns = screen.getAllByRole("button", { name: /Select All/i });
+    // Global Select All + per-org Select All for the expanded org
+    const perOrgSelectAll = selectAllBtns.filter(
+      (btn) => !btn.closest("[inert]") && btn.textContent === "Select All"
+    );
+    expect(perOrgSelectAll.length).toBeGreaterThanOrEqual(2); // global + expanded org
+
+    // Click per-org Select All inside the expanded panel (not the global one)
+    // The per-org one is inside the accordion panel content area
+    const panelContent = document.getElementById("accordion-panel-alpha-org");
+    expect(panelContent).not.toBeNull();
+    const perOrgBtn = panelContent!.querySelector("button");
+    expect(perOrgBtn).not.toBeNull();
+    expect(perOrgBtn!.textContent).toBe("Select All");
+    fireEvent.click(perOrgBtn!);
+
+    // Should select only alpha-org's repo
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ fullName: "alpha-org/alpha-org-repo" })])
+    );
+    // Should NOT include repos from other orgs
+    const selectedNames = onChange.mock.calls[0][0].map((r: { fullName: string }) => r.fullName);
+    expect(selectedNames).toHaveLength(1);
+    expect(selectedNames[0]).toBe("alpha-org/alpha-org-repo");
+  });
+
+  it("global Select All includes repos from collapsed orgs", async () => {
+    const onChange = vi.fn();
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={onChange}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Click the global Select All (first button with that text)
+    const selectAllBtns = screen.getAllByText("Select All");
+    fireEvent.click(selectAllBtns[0]);
+
+    expect(onChange).toHaveBeenCalled();
+    const result = onChange.mock.calls[0][0] as RepoRef[];
+    // Should include all 6 repos, one per org
+    expect(result.length).toBe(6);
+    for (const org of sixOrgs) {
+      expect(result.map((r) => r.fullName)).toContain(`${org}/${org}-repo`);
+    }
+  });
+
+  it("global Select All with text filter only includes repos matching the filter (PA-003)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={onChange}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Type a filter that only matches repos in "alpha-org"
+    const filterInput = screen.getByPlaceholderText(/Filter repos/i);
+    await user.type(filterInput, "alpha-org-repo");
+
+    // Wait for the debounce to fire and the filter to take effect:
+    // the badge for "beta-org" should drop to "0 repos" once the filter is active
+    await waitFor(() => {
+      const betaBtn = screen.getByRole("button", { name: /beta-org/ });
+      expect(betaBtn.textContent).toContain("0 repos");
+    });
+
+    // Click global Select All — should only include repos visible after filter
+    const selectAllBtns = screen.getAllByText("Select All");
+    fireEvent.click(selectAllBtns[0]);
+
+    expect(onChange).toHaveBeenCalled();
+    const result = onChange.mock.calls[0][0] as RepoRef[];
+    // Only alpha-org-repo matches the filter
+    expect(result.map((r) => r.fullName)).toContain("alpha-org/alpha-org-repo");
+    // Repos from other orgs must NOT be included
+    for (const org of sixOrgs.filter((o) => o !== "alpha-org")) {
+      expect(result.map((r) => r.fullName)).not.toContain(`${org}/${org}-repo`);
+    }
+  });
+
+  it("expanded org panel does not have inert; collapsed org panels do have inert", async () => {
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // In accordion mode, expanded org is alpha-org (first alphabetically)
+    // The panel id is on the inner div that also carries the inert attribute
+    const alphaPanel = document.getElementById("accordion-panel-alpha-org") as HTMLElement;
+    expect(alphaPanel).not.toBeNull();
+    expect(alphaPanel.hasAttribute("inert")).toBe(false);
+
+    // All other org panels should have inert
+    for (const org of sixOrgs.filter((o) => o !== "alpha-org")) {
+      const panel = document.getElementById(`accordion-panel-${org}`) as HTMLElement;
+      expect(panel).not.toBeNull();
+      expect(panel.hasAttribute("inert")).toBe(true);
+    }
+  });
+
+  it("org removal falls back to first remaining org when removed org was expanded", async () => {
+    const { createSignal } = await import("solid-js");
+    const [selectedOrgs, setSelectedOrgs] = createSignal<string[]>(sixOrgs);
+    const [orgEntries, setOrgEntries] = createSignal(sixOrgEntries);
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={selectedOrgs()}
+        orgEntries={orgEntries()}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Expand the 3rd org (gamma-org)
+    const gammaBtn = screen.getByRole("button", { name: /gamma-org/ });
+    fireEvent.click(gammaBtn);
+    expect(gammaBtn.getAttribute("aria-expanded")).toBe("true");
+
+    // Re-render without gamma-org (still 5 orgs >= 6 threshold? No, 5 < 6 so accordion exits)
+    // Use 7 orgs to ensure >= 6 remains after removing one
+    // Actually: let's test with 7 orgs so we stay in accordion mode after removal
+    const sevenOrgs = [...sixOrgs, "eta-org"];
+    const sevenOrgEntries = sevenOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
+    vi.mocked(api.fetchRepos).mockImplementation((_client, org) =>
+      Promise.resolve(makeOrgRepos(org as string))
+    );
+
+    // Re-render to 7 orgs first
+    setSelectedOrgs(sevenOrgs);
+    setOrgEntries(sevenOrgEntries);
+
+    await waitFor(() => {
+      screen.getByText("eta-org-repo");
+    });
+
+    // Expand gamma-org
+    const gammaBtnAgain = screen.getByRole("button", { name: /gamma-org/ });
+    fireEvent.click(gammaBtnAgain);
+    expect(gammaBtnAgain.getAttribute("aria-expanded")).toBe("true");
+
+    // Now remove gamma-org (still 6 orgs remain → still accordion)
+    const remainingOrgs = sevenOrgs.filter((o) => o !== "gamma-org");
+    const remainingEntries = remainingOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
+    setSelectedOrgs(remainingOrgs);
+    setOrgEntries(remainingEntries);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /gamma-org/ })).toBeNull();
+    });
+
+    // expandedOrg should fall back to states[0] (alpha-org)
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    expect(alphaBtn.getAttribute("aria-expanded")).toBe("true");
   });
 });

--- a/tests/components/onboarding/RepoSelector.test.tsx
+++ b/tests/components/onboarding/RepoSelector.test.tsx
@@ -348,8 +348,9 @@ describe("RepoSelector", () => {
     await waitFor(() => {
       screen.getByText("repo-a");
     });
-    const scrollContainer = screen.getByRole("region", { name: "myorg repositories" });
-    expect(scrollContainer.classList.contains("max-h-[300px]")).toBe(true);
+    const region = screen.getByRole("region", { name: "myorg repositories" });
+    const scrollContainer = region.querySelector(".max-h-\\[300px\\]")!;
+    expect(scrollContainer).not.toBeNull();
     expect(scrollContainer.classList.contains("overflow-y-auto")).toBe(true);
   });
 
@@ -863,7 +864,6 @@ describe("RepoSelector — org accordion", () => {
   });
 
   it("renders all orgs expanded when fewer than 6 orgs", async () => {
-    // 4 orgs → no accordion
     const fourOrgs = ["alpha-org", "beta-org", "gamma-org", "delta-org"];
     const fourOrgEntries = fourOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
 
@@ -881,14 +881,11 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("delta-org-repo");
     });
 
-    // No accordion header buttons present (no aria-expanded attributes)
+    // No accordion triggers present (no aria-expanded attributes)
     expect(document.querySelectorAll("[aria-expanded]")).toHaveLength(0);
-    // All repo content visible (no inert panels)
-    expect(document.querySelectorAll("[inert]")).toHaveLength(0);
   });
 
   it("renders all orgs expanded when exactly 5 orgs (boundary below threshold)", async () => {
-    // 5 orgs → still no accordion (threshold is >= 6)
     const fiveOrgs = ["alpha-org", "beta-org", "gamma-org", "delta-org", "epsilon-org"];
     const fiveOrgEntries = fiveOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
 
@@ -906,10 +903,8 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("epsilon-org-repo");
     });
 
-    // No accordion chevron buttons present — 5 orgs is still below the >= 6 threshold
-    expect(screen.queryAllByRole("button", { name: /chevron|expand|collapse/i })).toHaveLength(0);
-    // All repo content visible — no inert panels
-    expect(document.querySelectorAll("[inert]")).toHaveLength(0);
+    // No accordion triggers present — 5 orgs is still below the >= 6 threshold
+    expect(document.querySelectorAll("[aria-expanded]")).toHaveLength(0);
   });
 
   it("renders accordion with first org expanded by default when 6+ orgs", async () => {
@@ -926,13 +921,13 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // First org panel is not inert (expanded)
-    const panels = document.querySelectorAll("[inert]");
-    // All other 5 orgs are collapsed (inert)
-    expect(panels).toHaveLength(5);
-
-    // First org repo content is accessible
+    // First org is expanded (content visible)
     expect(screen.queryByText("alpha-org-repo")).not.toBeNull();
+    // Other orgs' content is not rendered (Kobalte unmounts collapsed panels)
+    expect(screen.queryByText("beta-org-repo")).toBeNull();
+    // First org trigger has aria-expanded=true
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    expect(alphaBtn.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("clicking another org header collapses the first and expands the clicked one", async () => {
@@ -949,18 +944,18 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // Find and click the beta-org accordion header button
     const betaBtn = screen.getByRole("button", { name: /beta-org/ });
     fireEvent.click(betaBtn);
 
-    // Now beta-org panel should be expanded (not inert), alpha-org collapsed
     await waitFor(() => {
-      // 5 orgs still collapsed
-      expect(document.querySelectorAll("[inert]")).toHaveLength(5);
+      expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
+      // beta-org content now visible
+      screen.getByText("beta-org-repo");
     });
 
-    // The expanded button should now be beta-org (aria-expanded=true)
-    expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
+    // alpha-org trigger is now collapsed
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    expect(alphaBtn.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("clicking the default-expanded org header is a no-op (null → explicit path)", async () => {
@@ -977,13 +972,12 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // Click the already-expanded first org header
     const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
     fireEvent.click(alphaBtn);
 
-    // alpha-org is still expanded (setUserExpandedOrg sets to same value)
+    // alpha-org is still expanded (not collapsible)
     expect(alphaBtn.getAttribute("aria-expanded")).toBe("true");
-    expect(document.querySelectorAll("[inert]")).toHaveLength(5);
+    expect(screen.queryByText("alpha-org-repo")).not.toBeNull();
   });
 
   it("clicking the explicitly-expanded org header a second time is a no-op (re-click path)", async () => {
@@ -1000,17 +994,14 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // First: click beta-org to explicitly set userExpandedOrg = 'beta-org'
     const betaBtn = screen.getByRole("button", { name: /beta-org/ });
     fireEvent.click(betaBtn);
     expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
-    expect(document.querySelectorAll("[inert]")).toHaveLength(5);
 
-    // Second: click beta-org again — userExpandedOrg is already 'beta-org',
-    // so setUserExpandedOrg('beta-org') is a no-op and beta-org must remain expanded
+    // Re-click beta — still expanded (not collapsible)
     fireEvent.click(betaBtn);
     expect(betaBtn.getAttribute("aria-expanded")).toBe("true");
-    expect(document.querySelectorAll("[inert]")).toHaveLength(5);
+    screen.getByText("beta-org-repo");
   });
 
   it("shows repo count badge on org headers in accordion mode", async () => {
@@ -1047,21 +1038,18 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // The expanded org (alpha-org) should show per-org Select All in the header bar
-    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
-    expect(headerBtn).not.toBeNull();
-    const headerRow = headerBtn.parentElement!;
+    // The expanded org (alpha-org) has per-org Select All next to the trigger
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    const headerRow = alphaBtn.closest("[class*='border-b']") ?? alphaBtn.parentElement!.parentElement!;
     const perOrgBtn = Array.from(headerRow.querySelectorAll("button")).find(
-      (b) => b.textContent === "Select All" && b !== headerBtn
+      (b) => b.textContent === "Select All" && b !== alphaBtn
     );
     expect(perOrgBtn).not.toBeUndefined();
     fireEvent.click(perOrgBtn!);
 
-    // Should select only alpha-org's repo
     expect(onChange).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ fullName: "alpha-org/alpha-org-repo" })])
     );
-    // Should NOT include repos from other orgs
     const selectedNames = onChange.mock.calls[0][0].map((r: { fullName: string }) => r.fullName);
     expect(selectedNames).toHaveLength(1);
     expect(selectedNames[0]).toBe("alpha-org/alpha-org-repo");
@@ -1087,20 +1075,50 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // alpha-org is expanded — per-org buttons are in the header bar
-    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
-    const headerRow = headerBtn.parentElement!;
-    const actionBtns = Array.from(headerRow.querySelectorAll("button")).filter((b) => b !== headerBtn);
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    const headerRow = alphaBtn.closest("[class*='border-b']") ?? alphaBtn.parentElement!.parentElement!;
+    const actionBtns = Array.from(headerRow.querySelectorAll("button")).filter((b) => b !== alphaBtn);
     const perOrgSelectAll = actionBtns.find((b) => b.textContent === "Select All") as HTMLButtonElement;
     const perOrgDeselectAll = actionBtns.find((b) => b.textContent === "Deselect All") as HTMLButtonElement;
 
-    // All repos are already selected — Select All must be disabled
     expect(perOrgSelectAll).not.toBeUndefined();
     expect(perOrgSelectAll.disabled).toBe(true);
-
-    // All repos are selected — Deselect All must be enabled
     expect(perOrgDeselectAll).not.toBeUndefined();
     expect(perOrgDeselectAll.disabled).toBe(false);
+  });
+
+  it("'N selected' badge counts all selected repos in org, not just filtered ones", async () => {
+    const user = userEvent.setup();
+    const alphaSelected: RepoRef[] = [
+      { owner: "alpha-org", name: "alpha-org-repo", fullName: "alpha-org/alpha-org-repo" },
+    ];
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={alphaSelected}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    expect(alphaBtn.textContent).toContain("1 selected");
+
+    // Type a filter that does NOT match alpha-org's repo
+    const filterInput = screen.getByPlaceholderText(/Filter repos/i);
+    await user.type(filterInput, "nonexistent");
+
+    await waitFor(() => {
+      expect(alphaBtn.textContent).toContain("0 repos");
+    });
+
+    // Badge should still show "1 selected" (unfiltered count)
+    expect(alphaBtn.textContent).toContain("1 selected");
   });
 
   it("per-org Deselect All is disabled when no repos are selected in that org", async () => {
@@ -1117,17 +1135,14 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
-    const headerRow = headerBtn.parentElement!;
-    const actionBtns = Array.from(headerRow.querySelectorAll("button")).filter((b) => b !== headerBtn);
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    const headerRow = alphaBtn.closest("[class*='border-b']") ?? alphaBtn.parentElement!.parentElement!;
+    const actionBtns = Array.from(headerRow.querySelectorAll("button")).filter((b) => b !== alphaBtn);
     const perOrgSelectAll = actionBtns.find((b) => b.textContent === "Select All") as HTMLButtonElement;
     const perOrgDeselectAll = actionBtns.find((b) => b.textContent === "Deselect All") as HTMLButtonElement;
 
-    // No repos selected — Select All must be enabled
     expect(perOrgSelectAll).not.toBeUndefined();
     expect(perOrgSelectAll.disabled).toBe(false);
-
-    // No repos selected — Deselect All must be disabled
     expect(perOrgDeselectAll).not.toBeUndefined();
     expect(perOrgDeselectAll.disabled).toBe(true);
   });
@@ -1153,9 +1168,8 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // Deselect All is in the header bar when expanded
-    const headerBtn = document.getElementById("accordion-header-alpha-org")!;
-    const headerRow = headerBtn.parentElement!;
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    const headerRow = alphaBtn.closest("[class*='border-b']") ?? alphaBtn.parentElement!.parentElement!;
     const perOrgDeselectAll = Array.from(headerRow.querySelectorAll("button")).find(
       (b) => b.textContent === "Deselect All"
     ) as HTMLButtonElement;
@@ -1164,11 +1178,9 @@ describe("RepoSelector — org accordion", () => {
 
     fireEvent.click(perOrgDeselectAll);
 
-    // onChange should have been called with alpha-org's repo removed
     expect(onChange).toHaveBeenCalledOnce();
     const result = onChange.mock.calls[0][0] as RepoRef[];
     expect(result.map((r) => r.fullName)).not.toContain("alpha-org/alpha-org-repo");
-    // beta-org's repo must still be selected
     expect(result.map((r) => r.fullName)).toContain("beta-org/beta-org-repo");
   });
 
@@ -1243,7 +1255,7 @@ describe("RepoSelector — org accordion", () => {
     }
   });
 
-  it("expanded org panel does not have inert; collapsed org panels do have inert", async () => {
+  it("expanded org has aria-expanded=true; collapsed orgs have aria-expanded=false", async () => {
     render(() => (
       <RepoSelector
         selectedOrgs={sixOrgs}
@@ -1257,17 +1269,14 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // In accordion mode, expanded org is alpha-org (first alphabetically)
-    // The panel id is on the inner div that also carries the inert attribute
-    const alphaPanel = document.getElementById("accordion-panel-alpha-org") as HTMLElement;
-    expect(alphaPanel).not.toBeNull();
-    expect(alphaPanel.hasAttribute("inert")).toBe(false);
+    // alpha-org trigger is expanded
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    expect(alphaBtn.getAttribute("aria-expanded")).toBe("true");
 
-    // All other org panels should have inert
+    // All other org triggers are collapsed
     for (const org of sixOrgs.filter((o) => o !== "alpha-org")) {
-      const panel = document.getElementById(`accordion-panel-${org}`) as HTMLElement;
-      expect(panel).not.toBeNull();
-      expect(panel.hasAttribute("inert")).toBe(true);
+      const btn = screen.getByRole("button", { name: new RegExp(org) });
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
     }
   });
 
@@ -1289,7 +1298,7 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("alpha-org-repo");
     });
 
-    // Expand the 3rd org (gamma-org)
+    // Expand gamma-org
     const gammaBtn = screen.getByRole("button", { name: /gamma-org/ });
     fireEvent.click(gammaBtn);
     expect(gammaBtn.getAttribute("aria-expanded")).toBe("true");
@@ -1301,7 +1310,6 @@ describe("RepoSelector — org accordion", () => {
       Promise.resolve(makeOrgRepos(org as string))
     );
 
-    // Re-render to 7 orgs first
     setSelectedOrgs(sevenOrgs);
     setOrgEntries(sevenOrgEntries);
 
@@ -1309,12 +1317,11 @@ describe("RepoSelector — org accordion", () => {
       screen.getByText("eta-org-repo");
     });
 
-    // Expand gamma-org
     const gammaBtnAgain = screen.getByRole("button", { name: /gamma-org/ });
     fireEvent.click(gammaBtnAgain);
     expect(gammaBtnAgain.getAttribute("aria-expanded")).toBe("true");
 
-    // Now remove gamma-org (still 6 orgs remain → still accordion)
+    // Remove gamma-org (still 6 orgs remain → still accordion)
     const remainingOrgs = sevenOrgs.filter((o) => o !== "gamma-org");
     const remainingEntries = remainingOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
     setSelectedOrgs(remainingOrgs);
@@ -1324,8 +1331,161 @@ describe("RepoSelector — org accordion", () => {
       expect(screen.queryByRole("button", { name: /gamma-org/ })).toBeNull();
     });
 
-    // expandedOrg should fall back to states[0] (alpha-org)
+    // safeExpandedOrg should fall back to first selectedOrg still present
     const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
     expect(alphaBtn.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("transitions back to flat mode when org count drops from 6 to 5", async () => {
+    const { createSignal } = await import("solid-js");
+    const [selectedOrgs, setSelectedOrgs] = createSignal<string[]>(sixOrgs);
+    const [orgEntries, setOrgEntries] = createSignal(sixOrgEntries);
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={selectedOrgs()}
+        orgEntries={orgEntries()}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Verify accordion mode is active (aria-expanded attributes present)
+    expect(document.querySelectorAll("[aria-expanded]").length).toBeGreaterThan(0);
+
+    // Remove one org to drop to 5 — below the >= 6 threshold
+    const fiveOrgs = sixOrgs.slice(0, 5);
+    const fiveOrgEntries = fiveOrgs.map((login) => ({ login, avatarUrl: "", type: "org" as const }));
+    setSelectedOrgs(fiveOrgs);
+    setOrgEntries(fiveOrgEntries);
+
+    await waitFor(() => {
+      // Flat mode: no aria-expanded attributes
+      expect(document.querySelectorAll("[aria-expanded]")).toHaveLength(0);
+      // All 5 org repos visible
+      screen.getByText("alpha-org-repo");
+      screen.getByText("epsilon-org-repo");
+      expect(screen.queryByText("zeta-org-repo")).toBeNull();
+    });
+
+    // Re-add the 6th org — accordion mode should re-activate
+    setSelectedOrgs(sixOrgs);
+    setOrgEntries(sixOrgEntries);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("[aria-expanded]").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows 'N selected' badge on expanded accordion header when repos are selected", async () => {
+    const alphaSelected: RepoRef[] = [
+      { owner: "alpha-org", name: "alpha-org-repo", fullName: "alpha-org/alpha-org-repo" },
+    ];
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={alphaSelected}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    const alphaBtn = screen.getByRole("button", { name: /alpha-org/ });
+    expect(alphaBtn.textContent).toContain("1 selected");
+  });
+
+  it("hides per-org bulk actions and shows loading spinner in accordion header while org loads", async () => {
+    let resolveZeta!: (repos: RepoEntry[]) => void;
+    const zetaPending = new Promise<RepoEntry[]>((res) => { resolveZeta = res; });
+
+    vi.mocked(api.fetchRepos).mockImplementation((_client, org) => {
+      if (org === "zeta-org") return zetaPending;
+      return Promise.resolve(makeOrgRepos(org as string));
+    });
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Expand zeta-org to see its header state
+    const zetaBtn = screen.getByRole("button", { name: /zeta-org/ });
+    fireEvent.click(zetaBtn);
+
+    await waitFor(() => {
+      // The spinner should be visible in the trigger button
+      expect(zetaBtn.querySelector(".loading-spinner")).not.toBeNull();
+    });
+
+    // Per-org bulk actions must NOT appear while loading
+    const headerRow = zetaBtn.closest("[class*='border-b']") ?? zetaBtn.parentElement!.parentElement!;
+    const actionBtns = Array.from(headerRow.querySelectorAll("button")).filter(
+      (b) => b !== zetaBtn && (b.textContent === "Select All" || b.textContent === "Deselect All")
+    );
+    expect(actionBtns).toHaveLength(0);
+
+    // Resolve zeta — spinner disappears, bulk actions appear
+    resolveZeta(makeOrgRepos("zeta-org"));
+    await waitFor(() => {
+      screen.getByText("zeta-org-repo");
+    });
+  });
+
+  it("expanding a failed accordion org panel shows Retry button and allows re-fetch", async () => {
+    vi.mocked(api.fetchRepos).mockImplementation((_client, org) => {
+      if (org === "zeta-org") return Promise.reject(new Error("zeta load failed"));
+      return Promise.resolve(makeOrgRepos(org as string));
+    });
+
+    render(() => (
+      <RepoSelector
+        selectedOrgs={sixOrgs}
+        orgEntries={sixOrgEntries}
+        selected={[]}
+        onChange={vi.fn()}
+      />
+    ));
+
+    await waitFor(() => {
+      screen.getByText("alpha-org-repo");
+    });
+
+    // Expand zeta-org (which failed)
+    const zetaBtn = screen.getByRole("button", { name: /zeta-org/ });
+    fireEvent.click(zetaBtn);
+
+    // Error message and Retry should be visible
+    await waitFor(() => {
+      screen.getByText(/zeta load failed/);
+      screen.getByText("Retry");
+    });
+
+    // Set up the retry to succeed
+    vi.mocked(api.fetchRepos).mockImplementation((_client, org) => {
+      return Promise.resolve(makeOrgRepos(org as string));
+    });
+
+    fireEvent.click(screen.getByText("Retry"));
+
+    await waitFor(() => {
+      screen.getByText("zeta-org-repo");
+    });
   });
 });

--- a/tests/components/shared/RepoLockControls.test.tsx
+++ b/tests/components/shared/RepoLockControls.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
 import RepoLockControls from "../../../src/app/components/shared/RepoLockControls";
 import { resetViewState, viewState, lockRepo } from "../../../src/app/stores/view";
@@ -103,5 +103,55 @@ describe("RepoLockControls", () => {
     ));
     fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
     expect(parentClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("RepoLockControls — scroll preservation", () => {
+  beforeEach(() => {
+    resetViewState();
+    document.documentElement.scrollTop = 500;
+    vi.spyOn(window, "scrollTo");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.scrollTop = 0;
+  });
+
+  it("preserves scroll position when locking a repo", () => {
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
+  });
+
+  it("preserves scroll position when unlocking a repo", () => {
+    lockRepo("issues", "owner/repo");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+    ));
+    fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
+  });
+
+  it("preserves scroll position when moving repo up", () => {
+    lockRepo("issues", "owner/a");
+    lockRepo("issues", "owner/b");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/b" />
+    ));
+    fireEvent.click(screen.getByLabelText("Move owner/b up"));
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
+  });
+
+  it("preserves scroll position when moving repo down", () => {
+    lockRepo("issues", "owner/a");
+    lockRepo("issues", "owner/b");
+    render(() => (
+      <RepoLockControls tab="issues" repoFullName="owner/a" />
+    ));
+    fireEvent.click(screen.getByLabelText("Move owner/a down"));
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
   });
 });

--- a/tests/components/shared/RepoLockControls.test.tsx
+++ b/tests/components/shared/RepoLockControls.test.tsx
@@ -111,6 +111,9 @@ describe("RepoLockControls — scroll preservation", () => {
     resetViewState();
     document.documentElement.scrollTop = 500;
     vi.spyOn(window, "scrollTo");
+    // withFlipAnimation falls back to withScrollLock when reduced motion is preferred;
+    // happy-dom has no layout engine so FLIP deltas are always 0
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: true } as MediaQueryList);
   });
 
   afterEach(() => {

--- a/tests/lib/scroll.test.ts
+++ b/tests/lib/scroll.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { withScrollLock, withFlipAnimation } from "../../src/app/lib/scroll";
+
+describe("withScrollLock", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.scrollTop = 0;
+  });
+
+  it("restores scroll position after fn() completes", () => {
+    document.documentElement.scrollTop = 500;
+    vi.spyOn(window, "scrollTo");
+
+    withScrollLock(() => {});
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
+  });
+
+  it("restores scroll position even when fn() throws", () => {
+    document.documentElement.scrollTop = 300;
+    vi.spyOn(window, "scrollTo");
+
+    expect(() =>
+      withScrollLock(() => { throw new Error("boom"); })
+    ).toThrow("boom");
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 300);
+  });
+});
+
+describe("withFlipAnimation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.scrollTop = 0;
+  });
+
+  it("falls back to withScrollLock when prefers-reduced-motion is set", () => {
+    document.documentElement.scrollTop = 400;
+    vi.spyOn(window, "scrollTo");
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: true } as MediaQueryList);
+
+    withFlipAnimation(() => {});
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 400);
+  });
+
+  it("calls fn() without scrollTo when no elements have data-repo-group (no deltas)", () => {
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: false } as MediaQueryList);
+    vi.spyOn(window, "scrollTo");
+    const fn = vi.fn();
+
+    withFlipAnimation(fn);
+
+    expect(fn).toHaveBeenCalledOnce();
+    // No data-repo-group elements → no deltas → no scrollTo (FLIP is a no-op)
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/scroll.test.ts
+++ b/tests/lib/scroll.test.ts
@@ -4,11 +4,11 @@ import { withScrollLock, withFlipAnimation } from "../../src/app/lib/scroll";
 describe("withScrollLock", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    document.documentElement.scrollTop = 0;
+    Object.defineProperty(window, "scrollY", { value: 0, configurable: true });
   });
 
   it("restores scroll position after fn() completes", () => {
-    document.documentElement.scrollTop = 500;
+    Object.defineProperty(window, "scrollY", { value: 500, configurable: true });
     vi.spyOn(window, "scrollTo");
 
     withScrollLock(() => {});
@@ -17,7 +17,7 @@ describe("withScrollLock", () => {
   });
 
   it("restores scroll position even when fn() throws", () => {
-    document.documentElement.scrollTop = 300;
+    Object.defineProperty(window, "scrollY", { value: 300, configurable: true });
     vi.spyOn(window, "scrollTo");
 
     expect(() =>
@@ -31,11 +31,11 @@ describe("withScrollLock", () => {
 describe("withFlipAnimation", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    document.documentElement.scrollTop = 0;
+    Object.defineProperty(window, "scrollY", { value: 0, configurable: true });
   });
 
   it("falls back to withScrollLock when prefers-reduced-motion is set", () => {
-    document.documentElement.scrollTop = 400;
+    Object.defineProperty(window, "scrollY", { value: 400, configurable: true });
     vi.spyOn(window, "scrollTo");
     vi.spyOn(window, "matchMedia").mockReturnValue({ matches: true } as MediaQueryList);
 
@@ -54,5 +54,106 @@ describe("withFlipAnimation", () => {
     expect(fn).toHaveBeenCalledOnce();
     // No data-repo-group elements → no deltas → no scrollTo (FLIP is a no-op)
     expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("reads all rects before scrollTo (no layout thrash), then animates", () => {
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: false } as MediaQueryList);
+
+    // Track call order to verify reads-before-writes
+    const callOrder: string[] = [];
+    vi.spyOn(window, "scrollTo").mockImplementation(() => { callOrder.push("scrollTo"); });
+
+    let rafCallback: FrameRequestCallback | null = null;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallback = cb;
+      return 0;
+    });
+
+    const elA = document.createElement("div");
+    elA.dataset.repoGroup = "org/repo-a";
+    const elB = document.createElement("div");
+    elB.dataset.repoGroup = "org/repo-b";
+    document.body.appendChild(elA);
+    document.body.appendChild(elB);
+
+    const beforeRectA = { top: 100, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+    const beforeRectB = { top: 200, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+    const afterRectA  = { top: 200, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+    const afterRectB  = { top: 100, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+
+    vi.spyOn(elA, "getBoundingClientRect").mockImplementation(() => {
+      callOrder.push("rectA");
+      // First call returns before, second returns after
+      return callOrder.filter(c => c === "rectA").length <= 1 ? beforeRectA : afterRectA;
+    });
+    vi.spyOn(elB, "getBoundingClientRect").mockImplementation(() => {
+      callOrder.push("rectB");
+      return callOrder.filter(c => c === "rectB").length <= 1 ? beforeRectB : afterRectB;
+    });
+
+    const animateA = vi.fn().mockReturnValue({ finished: Promise.resolve() });
+    const animateB = vi.fn().mockReturnValue({ finished: Promise.resolve() });
+    elA.animate = animateA;
+    elB.animate = animateB;
+
+    // scrollY is 300, no drift (stays 300 in rAF since we mock it)
+    Object.defineProperty(window, "scrollY", { value: 300, configurable: true });
+
+    withFlipAnimation(() => {});
+
+    expect(rafCallback).not.toBeNull();
+    expect(animateA).not.toHaveBeenCalled();
+
+    rafCallback!(0);
+
+    // Verify reads-before-writes: all getBoundingClientRect calls happen before scrollTo
+    const scrollToIdx = callOrder.indexOf("scrollTo");
+    const lastRectIdx = Math.max(
+      callOrder.lastIndexOf("rectA"),
+      callOrder.lastIndexOf("rectB"),
+    );
+    expect(lastRectIdx).toBeLessThan(scrollToIdx);
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 300);
+
+    // scrollDrift is 0 (scrollY unchanged), so dy = old.top - now.top - 0
+    expect(animateA).toHaveBeenCalledWith(
+      [{ transform: "translateY(-100px)" }, { transform: "translateY(0)" }],
+      { duration: 200, easing: "ease-in-out" },
+    );
+    expect(animateB).toHaveBeenCalledWith(
+      [{ transform: "translateY(100px)" }, { transform: "translateY(0)" }],
+      { duration: 200, easing: "ease-in-out" },
+    );
+
+    document.body.removeChild(elA);
+    document.body.removeChild(elB);
+  });
+
+  it("skips elements whose position delta is less than 1px", () => {
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: false } as MediaQueryList);
+
+    let rafCallback: FrameRequestCallback | null = null;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallback = cb;
+      return 0;
+    });
+
+    const el = document.createElement("div");
+    el.dataset.repoGroup = "org/repo-stable";
+    document.body.appendChild(el);
+
+    const stableRect = { top: 50, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+    vi.spyOn(el, "getBoundingClientRect").mockReturnValue(stableRect);
+
+    const animateSpy = vi.fn();
+    el.animate = animateSpy;
+
+    withFlipAnimation(() => {});
+    rafCallback!(0);
+
+    expect(animateSpy).not.toHaveBeenCalled();
+
+    document.body.removeChild(el);
   });
 });


### PR DESCRIPTION
## Summary
- Preserves scroll position on repo lock/move/unlock via withScrollLock helper in RepoLockControls
- Adds conditional org-grouped accordion to repo picker when 6+ orgs with exclusive open, CSS grid transition, a11y (aria-expanded, aria-controls, role=region, inert), and per-org Select All/Deselect All
- Adds 14 new tests (1561 total, 70 files, typecheck clean)