### PR TITLE
feat(ui): shared RepoGroupHeader with info tint styling (#63)

### DIFF
--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -277,7 +277,7 @@ export default function ActionsTab(props: ActionsTabProps) {
               sortWorkflowsByStatus(repoGroup.workflows)
             );
 
-            const collapsedSummary = createMemo(() => {
+            const workflowCounts = createMemo(() => {
               const wfs = repoGroup.workflows;
               const total = wfs.length;
               let passed = 0;
@@ -305,29 +305,30 @@ export default function ActionsTab(props: ActionsTabProps) {
                       <RepoLockControls repoFullName={repoGroup.repoFullName} />
                     </>
                   }
-                >
-                  <span class="ml-auto text-xs font-normal text-base-content/60">
-                    {collapsedSummary().total} workflow{collapsedSummary().total !== 1 ? "s" : ""}
-                    <Show when={collapsedSummary().passed > 0 || collapsedSummary().failed > 0 || collapsedSummary().running > 0}>
-                      {": "}
-                      <Show when={collapsedSummary().passed > 0}>
-                        <span>{collapsedSummary().passed} passed</span>
+                  collapsedSummary={
+                    <span class="ml-auto text-xs font-normal text-base-content/60">
+                      {workflowCounts().total} workflow{workflowCounts().total !== 1 ? "s" : ""}
+                      <Show when={workflowCounts().passed > 0 || workflowCounts().failed > 0 || workflowCounts().running > 0}>
+                        {": "}
+                        <Show when={workflowCounts().passed > 0}>
+                          <span>{workflowCounts().passed} passed</span>
+                        </Show>
+                        <Show when={workflowCounts().passed > 0 && (workflowCounts().failed > 0 || workflowCounts().running > 0)}>
+                          {", "}
+                        </Show>
+                        <Show when={workflowCounts().failed > 0}>
+                          <span class="text-error font-medium">{workflowCounts().failed} failed</span>
+                        </Show>
+                        <Show when={workflowCounts().failed > 0 && workflowCounts().running > 0}>
+                          {", "}
+                        </Show>
+                        <Show when={workflowCounts().running > 0}>
+                          <span>{workflowCounts().running} running</span>
+                        </Show>
                       </Show>
-                      <Show when={collapsedSummary().passed > 0 && (collapsedSummary().failed > 0 || collapsedSummary().running > 0)}>
-                        {", "}
-                      </Show>
-                      <Show when={collapsedSummary().failed > 0}>
-                        <span class="text-error font-medium">{collapsedSummary().failed} failed</span>
-                      </Show>
-                      <Show when={collapsedSummary().failed > 0 && collapsedSummary().running > 0}>
-                        {", "}
-                      </Show>
-                      <Show when={collapsedSummary().running > 0}>
-                        <span>{collapsedSummary().running} running</span>
-                      </Show>
-                    </Show>
-                  </span>
-                </RepoGroupHeader>
+                    </span>
+                  }
+                />
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
                   {(peek) => (
                     <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -7,7 +7,7 @@ import IgnoreBadge from "./IgnoreBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import type { FilterChipGroupDef } from "../shared/filterTypes";
 import FilterToolbar from "../shared/FilterToolbar";
-import ChevronIcon from "../shared/ChevronIcon";
+import RepoGroupHeader from "../shared/RepoGroupHeader";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
@@ -294,42 +294,40 @@ export default function ActionsTab(props: ActionsTabProps) {
 
             return (
               <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
-                {/* Repo header */}
-                <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposActions().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
-                  <button
-                    onClick={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
-                    aria-expanded={isExpanded()}
-                    class="flex-1 flex items-center gap-2 px-4 py-2.5 compact:py-1.5 text-left text-sm font-semibold text-base-content"
-                  >
-                    <ChevronIcon size="md" rotated={!isExpanded()} />
-                    {repoGroup.repoFullName}
-                    <Show when={!isExpanded()}>
-                      <span class="ml-auto text-xs font-normal text-base-content/60">
-                        {collapsedSummary().total} workflow{collapsedSummary().total !== 1 ? "s" : ""}
-                        <Show when={collapsedSummary().passed > 0 || collapsedSummary().failed > 0 || collapsedSummary().running > 0}>
-                          {": "}
-                          <Show when={collapsedSummary().passed > 0}>
-                            <span>{collapsedSummary().passed} passed</span>
-                          </Show>
-                          <Show when={collapsedSummary().passed > 0 && (collapsedSummary().failed > 0 || collapsedSummary().running > 0)}>
-                            {", "}
-                          </Show>
-                          <Show when={collapsedSummary().failed > 0}>
-                            <span class="text-error font-medium">{collapsedSummary().failed} failed</span>
-                          </Show>
-                          <Show when={collapsedSummary().failed > 0 && collapsedSummary().running > 0}>
-                            {", "}
-                          </Show>
-                          <Show when={collapsedSummary().running > 0}>
-                            <span>{collapsedSummary().running} running</span>
-                          </Show>
-                        </Show>
-                      </span>
+                <RepoGroupHeader
+                  repoFullName={repoGroup.repoFullName}
+                  isExpanded={isExpanded()}
+                  isHighlighted={highlightedReposActions().has(repoGroup.repoFullName)}
+                  onToggle={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
+                  trailing={
+                    <>
+                      <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
+                      <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                    </>
+                  }
+                >
+                  <span class="ml-auto text-xs font-normal text-base-content/60">
+                    {collapsedSummary().total} workflow{collapsedSummary().total !== 1 ? "s" : ""}
+                    <Show when={collapsedSummary().passed > 0 || collapsedSummary().failed > 0 || collapsedSummary().running > 0}>
+                      {": "}
+                      <Show when={collapsedSummary().passed > 0}>
+                        <span>{collapsedSummary().passed} passed</span>
+                      </Show>
+                      <Show when={collapsedSummary().passed > 0 && (collapsedSummary().failed > 0 || collapsedSummary().running > 0)}>
+                        {", "}
+                      </Show>
+                      <Show when={collapsedSummary().failed > 0}>
+                        <span class="text-error font-medium">{collapsedSummary().failed} failed</span>
+                      </Show>
+                      <Show when={collapsedSummary().failed > 0 && collapsedSummary().running > 0}>
+                        {", "}
+                      </Show>
+                      <Show when={collapsedSummary().running > 0}>
+                        <span>{collapsedSummary().running} running</span>
+                      </Show>
                     </Show>
-                  </button>
-                  <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
-                  <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                </div>
+                  </span>
+                </RepoGroupHeader>
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
                   {(peek) => (
                     <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -370,22 +370,23 @@ export default function IssuesTab(props: IssuesTabProps) {
                           <RepoLockControls repoFullName={repoGroup.repoFullName} />
                         </>
                       }
-                    >
-                      <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
-                        <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
-                        <For each={roleSummary()}>
-                          {([role, count]) => (
-                            <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                              role === "author" ? "bg-primary/10 text-primary" :
-                              role === "assignee" ? "bg-secondary/10 text-secondary" :
-                              "bg-base-300 text-base-content/70"
-                            }`}>
-                              {role} ×{count}
-                            </span>
-                          )}
-                        </For>
-                      </span>
-                    </RepoGroupHeader>
+                      collapsedSummary={
+                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
+                          <For each={roleSummary()}>
+                            {([role, count]) => (
+                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                role === "author" ? "bg-primary/10 text-primary" :
+                                role === "assignee" ? "bg-secondary/10 text-secondary" :
+                                "bg-base-300 text-base-content/70"
+                              }`}>
+                                {role} ×{count}
+                              </span>
+                            )}
+                          </For>
+                        </span>
+                      }
+                    />
                     <Show when={isExpanded()}>
                       <div role="list" class="divide-y divide-base-300">
                         <For each={repoGroup.items}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -10,9 +10,9 @@ import { scopeFilterGroup, type FilterChipGroupDef } from "../shared/filterTypes
 import FilterToolbar from "../shared/FilterToolbar";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
-import ChevronIcon from "../shared/ChevronIcon";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
-import { deriveInvolvementRoles, formatStarCount } from "../../lib/format";
+import { deriveInvolvementRoles } from "../../lib/format";
+import RepoGroupHeader from "../shared/RepoGroupHeader";
 import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, isUserInvolved } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
@@ -351,44 +351,41 @@ export default function IssuesTab(props: IssuesTabProps) {
 
                 return (
                   <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
-                    <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposIssues().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
-                      <button
-                        onClick={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
-                        aria-expanded={isExpanded()}
-                        class="flex-1 flex items-center gap-2 px-4 py-2.5 compact:py-1.5 text-left text-sm font-semibold text-base-content"
-                      >
-                        <ChevronIcon size="md" rotated={!isExpanded()} />
-                        {repoGroup.repoFullName}
+                    <RepoGroupHeader
+                      repoFullName={repoGroup.repoFullName}
+                      starCount={repoGroup.starCount}
+                      isExpanded={isExpanded()}
+                      isHighlighted={highlightedReposIssues().has(repoGroup.repoFullName)}
+                      onToggle={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
+                      badges={
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <Tooltip content="Showing all activity, not just yours" focusable>
                             <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
                           </Tooltip>
                         </Show>
-                        <Show when={repoGroup.starCount != null && repoGroup.starCount > 0}>
-                          <span class="text-xs text-base-content/50 font-normal" aria-label={`${repoGroup.starCount} stars`}>
-                            ★ {formatStarCount(repoGroup.starCount!)}
-                          </span>
-                        </Show>
-                        <Show when={!isExpanded()}>
-                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
-                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
-                            <For each={roleSummary()}>
-                              {([role, count]) => (
-                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                  role === "author" ? "bg-primary/10 text-primary" :
-                                  role === "assignee" ? "bg-secondary/10 text-secondary" :
-                                  "bg-base-300 text-base-content/70"
-                                }`}>
-                                  {role} ×{count}
-                                </span>
-                              )}
-                            </For>
-                          </span>
-                        </Show>
-                      </button>
-                      <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
-                      <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                    </div>
+                      }
+                      trailing={
+                        <>
+                          <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
+                          <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                        </>
+                      }
+                    >
+                      <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                        <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
+                        <For each={roleSummary()}>
+                          {([role, count]) => (
+                            <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                              role === "author" ? "bg-primary/10 text-primary" :
+                              role === "assignee" ? "bg-secondary/10 text-secondary" :
+                              "bg-base-300 text-base-content/70"
+                            }`}>
+                              {role} ×{count}
+                            </span>
+                          )}
+                        </For>
+                      </span>
+                    </RepoGroupHeader>
                     <Show when={isExpanded()}>
                       <div role="list" class="divide-y divide-base-300">
                         <For each={repoGroup.items}>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -2,7 +2,7 @@ import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { config, type TrackedUser } from "../../stores/config";
 import { viewState, ignoreItem, unignoreItem, setTabFilter, resetAllTabFilters, toggleExpandedRepo, setAllExpanded, pruneExpandedRepos, pruneLockedRepos, trackItem, untrackItem, type PullRequestFilterField } from "../../stores/view";
 import type { PullRequest, RepoRef } from "../../services/api";
-import { deriveInvolvementRoles, prSizeCategory, formatStarCount } from "../../lib/format";
+import { deriveInvolvementRoles, prSizeCategory } from "../../lib/format";
 import { isSafeGitHubUrl } from "../../lib/url";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import ItemRow from "./ItemRow";
@@ -16,7 +16,7 @@ import ReviewBadge from "../shared/ReviewBadge";
 import SizeBadge from "../shared/SizeBadge";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
-import ChevronIcon from "../shared/ChevronIcon";
+import RepoGroupHeader from "../shared/RepoGroupHeader";
 import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, isUserInvolved } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
@@ -458,86 +458,83 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
 
                 return (
                   <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
-                    <div class={`group/repo-header flex items-center bg-base-200/60 border-y border-base-300 hover:bg-base-200 transition-colors duration-300 ${highlightedReposPRs().has(repoGroup.repoFullName) ? "animate-reorder-highlight" : ""}`}>
-                      <button
-                        onClick={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
-                        aria-expanded={isExpanded()}
-                        class="flex-1 flex items-center gap-2 px-4 py-2.5 compact:py-1.5 text-left text-sm font-semibold text-base-content"
-                      >
-                        <ChevronIcon size="md" rotated={!isExpanded()} />
-                        {repoGroup.repoFullName}
+                    <RepoGroupHeader
+                      repoFullName={repoGroup.repoFullName}
+                      starCount={repoGroup.starCount}
+                      isExpanded={isExpanded()}
+                      isHighlighted={highlightedReposPRs().has(repoGroup.repoFullName)}
+                      onToggle={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
+                      badges={
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <Tooltip content="Showing all activity, not just yours" focusable>
                             <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
                           </Tooltip>
                         </Show>
-                        <Show when={repoGroup.starCount != null && repoGroup.starCount > 0}>
-                          <span class="text-xs text-base-content/50 font-normal" aria-label={`${repoGroup.starCount} stars`}>
-                            ★ {formatStarCount(repoGroup.starCount!)}
+                      }
+                      trailing={
+                        <>
+                          <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
+                          <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                        </>
+                      }
+                    >
+                      <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
+                        <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
+                        <Show when={summaryMeta().checks.success > 0}>
+                          <span class="flex items-center gap-0.5">
+                            <span class="inline-block w-2 h-2 rounded-full bg-success" />
+                            <span>{summaryMeta().checks.success}</span>
                           </span>
                         </Show>
-                        <Show when={!isExpanded()}>
-                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
-                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
-                            <Show when={summaryMeta().checks.success > 0}>
-                              <span class="flex items-center gap-0.5">
-                                <span class="inline-block w-2 h-2 rounded-full bg-success" />
-                                <span>{summaryMeta().checks.success}</span>
-                              </span>
-                            </Show>
-                            <Show when={summaryMeta().checks.failure > 0}>
-                              <span class="flex items-center gap-0.5">
-                                <span class="inline-block w-2 h-2 rounded-full bg-error" />
-                                <span>{summaryMeta().checks.failure}</span>
-                              </span>
-                            </Show>
-                            <Show when={summaryMeta().checks.pending > 0}>
-                              <span class="flex items-center gap-0.5">
-                                <span class="inline-block w-2 h-2 rounded-full bg-warning" />
-                                <span>{summaryMeta().checks.pending}</span>
-                              </span>
-                            </Show>
-                            <Show when={summaryMeta().checks.conflict > 0}>
-                              <span class="badge badge-warning badge-sm gap-0.5">
-                                <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                  <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                                </svg>
-                                {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
-                              </span>
-                            </Show>
-                            <Show when={summaryMeta().reviews.APPROVED > 0}>
-                              <span class="badge badge-success badge-sm">
-                                {`Approved ×${summaryMeta().reviews.APPROVED}`}
-                              </span>
-                            </Show>
-                            <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
-                              <span class="badge badge-warning badge-sm">
-                                {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
-                              </span>
-                            </Show>
-                            <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
-                              <span class="badge badge-info badge-sm">
-                                {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
-                              </span>
-                            </Show>
-                            <For each={summaryMeta().roles}>
-                              {([role, count]) => (
-                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                  role === "author" ? "bg-primary/10 text-primary" :
-                                  role === "reviewer" ? "bg-secondary/10 text-secondary" :
-                                  role === "assignee" ? "bg-accent/10 text-accent" :
-                                  "bg-base-300 text-base-content/70"
-                                }`}>
-                                  {`${role} ×${count}`}
-                                </span>
-                              )}
-                            </For>
+                        <Show when={summaryMeta().checks.failure > 0}>
+                          <span class="flex items-center gap-0.5">
+                            <span class="inline-block w-2 h-2 rounded-full bg-error" />
+                            <span>{summaryMeta().checks.failure}</span>
                           </span>
                         </Show>
-                      </button>
-                      <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
-                      <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                    </div>
+                        <Show when={summaryMeta().checks.pending > 0}>
+                          <span class="flex items-center gap-0.5">
+                            <span class="inline-block w-2 h-2 rounded-full bg-warning" />
+                            <span>{summaryMeta().checks.pending}</span>
+                          </span>
+                        </Show>
+                        <Show when={summaryMeta().checks.conflict > 0}>
+                          <span class="badge badge-warning badge-sm gap-0.5">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                              <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                            </svg>
+                            {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
+                          </span>
+                        </Show>
+                        <Show when={summaryMeta().reviews.APPROVED > 0}>
+                          <span class="badge badge-success badge-sm">
+                            {`Approved ×${summaryMeta().reviews.APPROVED}`}
+                          </span>
+                        </Show>
+                        <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
+                          <span class="badge badge-warning badge-sm">
+                            {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
+                          </span>
+                        </Show>
+                        <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
+                          <span class="badge badge-info badge-sm">
+                            {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
+                          </span>
+                        </Show>
+                        <For each={summaryMeta().roles}>
+                          {([role, count]) => (
+                            <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                              role === "author" ? "bg-primary/10 text-primary" :
+                              role === "reviewer" ? "bg-secondary/10 text-secondary" :
+                              role === "assignee" ? "bg-accent/10 text-accent" :
+                              "bg-base-300 text-base-content/70"
+                            }`}>
+                              {`${role} ×${count}`}
+                            </span>
+                          )}
+                        </For>
+                      </span>
+                    </RepoGroupHeader>
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
                       {(peek) => (
                         <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -477,64 +477,65 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                           <RepoLockControls repoFullName={repoGroup.repoFullName} />
                         </>
                       }
-                    >
-                      <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
-                        <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
-                        <Show when={summaryMeta().checks.success > 0}>
-                          <span class="flex items-center gap-0.5">
-                            <span class="inline-block w-2 h-2 rounded-full bg-success" />
-                            <span>{summaryMeta().checks.success}</span>
-                          </span>
-                        </Show>
-                        <Show when={summaryMeta().checks.failure > 0}>
-                          <span class="flex items-center gap-0.5">
-                            <span class="inline-block w-2 h-2 rounded-full bg-error" />
-                            <span>{summaryMeta().checks.failure}</span>
-                          </span>
-                        </Show>
-                        <Show when={summaryMeta().checks.pending > 0}>
-                          <span class="flex items-center gap-0.5">
-                            <span class="inline-block w-2 h-2 rounded-full bg-warning" />
-                            <span>{summaryMeta().checks.pending}</span>
-                          </span>
-                        </Show>
-                        <Show when={summaryMeta().checks.conflict > 0}>
-                          <span class="badge badge-warning badge-sm gap-0.5">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                              <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                            </svg>
-                            {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
-                          </span>
-                        </Show>
-                        <Show when={summaryMeta().reviews.APPROVED > 0}>
-                          <span class="badge badge-success badge-sm">
-                            {`Approved ×${summaryMeta().reviews.APPROVED}`}
-                          </span>
-                        </Show>
-                        <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
-                          <span class="badge badge-warning badge-sm">
-                            {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
-                          </span>
-                        </Show>
-                        <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
-                          <span class="badge badge-info badge-sm">
-                            {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
-                          </span>
-                        </Show>
-                        <For each={summaryMeta().roles}>
-                          {([role, count]) => (
-                            <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                              role === "author" ? "bg-primary/10 text-primary" :
-                              role === "reviewer" ? "bg-secondary/10 text-secondary" :
-                              role === "assignee" ? "bg-accent/10 text-accent" :
-                              "bg-base-300 text-base-content/70"
-                            }`}>
-                              {`${role} ×${count}`}
+                      collapsedSummary={
+                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
+                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
+                          <Show when={summaryMeta().checks.success > 0}>
+                            <span class="flex items-center gap-0.5">
+                              <span class="inline-block w-2 h-2 rounded-full bg-success" />
+                              <span>{summaryMeta().checks.success}</span>
                             </span>
-                          )}
-                        </For>
-                      </span>
-                    </RepoGroupHeader>
+                          </Show>
+                          <Show when={summaryMeta().checks.failure > 0}>
+                            <span class="flex items-center gap-0.5">
+                              <span class="inline-block w-2 h-2 rounded-full bg-error" />
+                              <span>{summaryMeta().checks.failure}</span>
+                            </span>
+                          </Show>
+                          <Show when={summaryMeta().checks.pending > 0}>
+                            <span class="flex items-center gap-0.5">
+                              <span class="inline-block w-2 h-2 rounded-full bg-warning" />
+                              <span>{summaryMeta().checks.pending}</span>
+                            </span>
+                          </Show>
+                          <Show when={summaryMeta().checks.conflict > 0}>
+                            <span class="badge badge-warning badge-sm gap-0.5">
+                              <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                              </svg>
+                              {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
+                            </span>
+                          </Show>
+                          <Show when={summaryMeta().reviews.APPROVED > 0}>
+                            <span class="badge badge-success badge-sm">
+                              {`Approved ×${summaryMeta().reviews.APPROVED}`}
+                            </span>
+                          </Show>
+                          <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
+                            <span class="badge badge-warning badge-sm">
+                              {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
+                            </span>
+                          </Show>
+                          <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
+                            <span class="badge badge-info badge-sm">
+                              {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
+                            </span>
+                          </Show>
+                          <For each={summaryMeta().roles}>
+                            {([role, count]) => (
+                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                role === "author" ? "bg-primary/10 text-primary" :
+                                role === "reviewer" ? "bg-secondary/10 text-secondary" :
+                                role === "assignee" ? "bg-accent/10 text-accent" :
+                                "bg-base-300 text-base-content/70"
+                              }`}>
+                                {`${role} ×${count}`}
+                              </span>
+                            )}
+                          </For>
+                        </span>
+                      }
+                    />
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
                       {(peek) => (
                         <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">

--- a/src/app/components/shared/RepoGroupHeader.tsx
+++ b/src/app/components/shared/RepoGroupHeader.tsx
@@ -1,0 +1,39 @@
+import { Show, type JSX } from "solid-js";
+import ChevronIcon from "./ChevronIcon";
+import { formatStarCount } from "../../lib/format";
+
+interface RepoGroupHeaderProps {
+  repoFullName: string;
+  starCount?: number | null;
+  isExpanded: boolean;
+  isHighlighted?: boolean;
+  onToggle: () => void;
+  children?: JSX.Element;
+  trailing?: JSX.Element;
+  badges?: JSX.Element;
+}
+
+export default function RepoGroupHeader(props: RepoGroupHeaderProps) {
+  return (
+    <div class={`group/repo-header flex items-center bg-info/20 border-y border-base-300 hover:bg-info/25 transition-colors duration-300 ${props.isHighlighted ? "animate-reorder-highlight" : ""}`}>
+      <button
+        onClick={() => props.onToggle()}
+        aria-expanded={props.isExpanded}
+        class="flex-1 flex items-center gap-2 px-4 py-2.5 compact:py-1.5 text-left text-base font-bold repo-header-text"
+      >
+        <ChevronIcon size="md" rotated={!props.isExpanded} />
+        {props.repoFullName}
+        {props.badges}
+        <Show when={props.starCount != null && props.starCount > 0}>
+          <span class="text-xs text-base-content/50 font-normal" aria-label={`${props.starCount} stars`}>
+            <span aria-hidden="true">★</span> {formatStarCount(props.starCount!)}
+          </span>
+        </Show>
+        <Show when={!props.isExpanded}>
+          {props.children}
+        </Show>
+      </button>
+      {props.trailing}
+    </div>
+  );
+}

--- a/src/app/components/shared/RepoGroupHeader.tsx
+++ b/src/app/components/shared/RepoGroupHeader.tsx
@@ -19,7 +19,7 @@ export default function RepoGroupHeader(props: RepoGroupHeaderProps) {
       <button
         onClick={() => props.onToggle()}
         aria-expanded={props.isExpanded}
-        class="flex-1 flex items-center gap-2 px-4 py-2.5 compact:py-1.5 text-left text-base font-bold repo-header-text"
+        class="flex-1 flex items-center gap-2 px-4 py-2.5 compact:py-1.5 text-left text-base compact:text-sm font-bold repo-header-text"
       >
         <ChevronIcon size="md" rotated={!props.isExpanded} />
         {props.repoFullName}

--- a/src/app/components/shared/RepoGroupHeader.tsx
+++ b/src/app/components/shared/RepoGroupHeader.tsx
@@ -15,7 +15,7 @@ interface RepoGroupHeaderProps {
 
 export default function RepoGroupHeader(props: RepoGroupHeaderProps) {
   return (
-    <div class={`group/repo-header flex items-center bg-info/20 border-y border-base-300 hover:bg-info/25 transition-colors duration-300 ${props.isHighlighted ? "animate-reorder-highlight" : ""}`}>
+    <div class={`group/repo-header flex items-center bg-info/5 border-y border-base-300 hover:bg-info/10 transition-colors duration-300 ${props.isHighlighted ? "animate-reorder-highlight" : ""}`}>
       <button
         onClick={() => props.onToggle()}
         aria-expanded={props.isExpanded}

--- a/src/app/components/shared/RepoGroupHeader.tsx
+++ b/src/app/components/shared/RepoGroupHeader.tsx
@@ -8,7 +8,7 @@ interface RepoGroupHeaderProps {
   isExpanded: boolean;
   isHighlighted?: boolean;
   onToggle: () => void;
-  children?: JSX.Element;
+  collapsedSummary?: JSX.Element;
   trailing?: JSX.Element;
   badges?: JSX.Element;
 }
@@ -30,7 +30,7 @@ export default function RepoGroupHeader(props: RepoGroupHeaderProps) {
           </span>
         </Show>
         <Show when={!props.isExpanded}>
-          {props.children}
+          {props.collapsedSummary}
         </Show>
       </button>
       {props.trailing}

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -51,7 +51,11 @@
 }
 
 @utility animate-reorder-highlight {
-  animation: reorder-highlight 1.5s ease-out forwards;
+  animation: reorder-highlight 1.5s ease-out;
+}
+
+@utility repo-header-text {
+  color: light-dark(oklch(0.45 0.15 250), oklch(0.85 0.18 250));
 }
 
 /* ── Notification animations ──────────────────────────────────────────────── */

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -55,7 +55,7 @@
 }
 
 @utility repo-header-text {
-  color: light-dark(oklch(0.45 0.15 250), oklch(0.85 0.18 250));
+  color: light-dark(oklch(0.45 0.15 250), oklch(0.70 0.15 250));
 }
 
 /* ── Notification animations ──────────────────────────────────────────────── */

--- a/tests/components/dashboard/ActionsTab.test.tsx
+++ b/tests/components/dashboard/ActionsTab.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
 import { makeWorkflowRun } from "../../helpers/index";
 
 // ── localStorage mock ─────────────────────────────────────────────────────────
@@ -102,5 +103,46 @@ describe("ActionsTab — empty-repo state preservation", () => {
     ));
     // With empty items and no configRepoNames, guard returns early — no pruning
     expect(viewState.lockedRepos).toEqual([]);
+  });
+});
+
+// ── ActionsTab — RepoGroupHeader integration ──────────────────────────────────
+
+describe("ActionsTab — RepoGroupHeader rendering", () => {
+  it("renders the repo name in the group header when workflow runs are present", () => {
+    const runs = [makeWorkflowRun({ repoFullName: "owner/my-repo" })];
+    render(() => (
+      <ActionsTab workflowRuns={runs} />
+    ));
+    // The header toggle button has aria-expanded, distinguishing it from pin/unpin buttons
+    const headerBtn = screen.getAllByRole("button", { name: /owner\/my-repo/i })
+      .find(btn => btn.hasAttribute("aria-expanded"));
+    expect(headerBtn).toBeTruthy();
+  });
+
+  it("toggles repo group expanded state when header button is clicked", async () => {
+    const user = userEvent.setup();
+    const runs = [makeWorkflowRun({ repoFullName: "owner/repo" })];
+
+    render(() => (
+      <ActionsTab workflowRuns={runs} />
+    ));
+
+    const headerBtn = screen.getAllByRole("button", { name: /owner\/repo/i })
+      .find(btn => btn.hasAttribute("aria-expanded"))!;
+
+    // Initially collapsed
+    expect(headerBtn.getAttribute("aria-expanded")).toBe("false");
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBeFalsy();
+
+    // Click to expand
+    await user.click(headerBtn);
+    expect(headerBtn.getAttribute("aria-expanded")).toBe("true");
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBe(true);
+
+    // Click again to collapse
+    await user.click(headerBtn);
+    expect(headerBtn.getAttribute("aria-expanded")).toBe("false");
+    expect(viewState.expandedRepos.actions["owner/repo"]).toBeFalsy();
   });
 });

--- a/tests/components/dashboard/IssuesTab.test.tsx
+++ b/tests/components/dashboard/IssuesTab.test.tsx
@@ -511,7 +511,7 @@ describe("IssuesTab — star count in repo headers", () => {
       />
     ));
 
-    screen.getByText("★ 1.2k");
+    screen.getByLabelText("1234 stars");
   });
 
   it("does not show star display when starCount is undefined", () => {

--- a/tests/components/dashboard/PullRequestsTab.test.tsx
+++ b/tests/components/dashboard/PullRequestsTab.test.tsx
@@ -461,7 +461,7 @@ describe("PullRequestsTab — star count in repo headers", () => {
       />
     ));
 
-    screen.getByText("★ 1.2k");
+    screen.getByLabelText("1234 stars");
   });
 
   it("does not show star display when starCount is undefined", () => {

--- a/tests/components/shared/RepoGroupHeader.test.tsx
+++ b/tests/components/shared/RepoGroupHeader.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+import RepoGroupHeader from "../../../src/app/components/shared/RepoGroupHeader";
+
+describe("RepoGroupHeader", () => {
+  const defaultProps = {
+    repoFullName: "owner/repo",
+    isExpanded: true,
+    onToggle: vi.fn(),
+  };
+
+  it("renders repo name", () => {
+    const { getByText } = render(() => <RepoGroupHeader {...defaultProps} />);
+    expect(getByText("owner/repo")).toBeTruthy();
+  });
+
+  it("renders star count when provided", () => {
+    const { getByLabelText } = render(() => (
+      <RepoGroupHeader {...defaultProps} starCount={1234} />
+    ));
+    expect(getByLabelText("1234 stars")).toBeTruthy();
+  });
+
+  it("hides star count when null", () => {
+    const { queryByLabelText } = render(() => (
+      <RepoGroupHeader {...defaultProps} starCount={null} />
+    ));
+    expect(queryByLabelText(/stars/)).toBeNull();
+  });
+
+  it("hides star count when undefined", () => {
+    const { queryByLabelText } = render(() => (
+      <RepoGroupHeader {...defaultProps} />
+    ));
+    expect(queryByLabelText(/stars/)).toBeNull();
+  });
+
+  it("hides star count when zero", () => {
+    const { queryByLabelText } = render(() => (
+      <RepoGroupHeader {...defaultProps} starCount={0} />
+    ));
+    expect(queryByLabelText(/stars/)).toBeNull();
+  });
+
+  it("renders chevron rotated when collapsed", () => {
+    const { container } = render(() => (
+      <RepoGroupHeader {...defaultProps} isExpanded={false} />
+    ));
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("class")).toContain("-rotate-90");
+  });
+
+  it("renders chevron not rotated when expanded", () => {
+    const { container } = render(() => (
+      <RepoGroupHeader {...defaultProps} isExpanded={true} />
+    ));
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("class")).not.toContain("-rotate-90");
+  });
+
+  it("calls onToggle on button click", () => {
+    const onToggle = vi.fn();
+    const { getByRole } = render(() => (
+      <RepoGroupHeader {...defaultProps} onToggle={onToggle} />
+    ));
+    fireEvent.click(getByRole("button"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders children when collapsed", () => {
+    const { getByText } = render(() => (
+      <RepoGroupHeader {...defaultProps} isExpanded={false}>
+        <span>collapsed content</span>
+      </RepoGroupHeader>
+    ));
+    expect(getByText("collapsed content")).toBeTruthy();
+  });
+
+  it("hides children when expanded", () => {
+    const { queryByText } = render(() => (
+      <RepoGroupHeader {...defaultProps} isExpanded={true}>
+        <span>collapsed content</span>
+      </RepoGroupHeader>
+    ));
+    expect(queryByText("collapsed content")).toBeNull();
+  });
+
+  it("renders trailing slot", () => {
+    const { getByText } = render(() => (
+      <RepoGroupHeader {...defaultProps} trailing={<span>trailing</span>} />
+    ));
+    expect(getByText("trailing")).toBeTruthy();
+  });
+
+  it("renders badges slot", () => {
+    const { getByText } = render(() => (
+      <RepoGroupHeader {...defaultProps} badges={<span>badge</span>} />
+    ));
+    expect(getByText("badge")).toBeTruthy();
+  });
+
+  it("applies animate-reorder-highlight when isHighlighted", () => {
+    const { container } = render(() => (
+      <RepoGroupHeader {...defaultProps} isHighlighted={true} />
+    ));
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.className).toContain("animate-reorder-highlight");
+  });
+
+  it("does not apply animate-reorder-highlight when not highlighted", () => {
+    const { container } = render(() => (
+      <RepoGroupHeader {...defaultProps} isHighlighted={false} />
+    ));
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.className).not.toContain("animate-reorder-highlight");
+  });
+
+  it("sets aria-expanded correctly", () => {
+    const { getByRole } = render(() => (
+      <RepoGroupHeader {...defaultProps} isExpanded={true} />
+    ));
+    expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("sets aria-expanded=false when collapsed", () => {
+    const { getByRole } = render(() => (
+      <RepoGroupHeader {...defaultProps} isExpanded={false} />
+    ));
+    expect(getByRole("button").getAttribute("aria-expanded")).toBe("false");
+  });
+});

--- a/tests/components/shared/RepoGroupHeader.test.tsx
+++ b/tests/components/shared/RepoGroupHeader.test.tsx
@@ -63,24 +63,21 @@ describe("RepoGroupHeader", () => {
     const { getByRole } = render(() => (
       <RepoGroupHeader {...defaultProps} onToggle={onToggle} />
     ));
-    fireEvent.click(getByRole("button"));
+    fireEvent.click(getByRole("button", { name: /owner\/repo/ }));
     expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith();
   });
 
-  it("renders children when collapsed", () => {
+  it("renders collapsedSummary when collapsed", () => {
     const { getByText } = render(() => (
-      <RepoGroupHeader {...defaultProps} isExpanded={false}>
-        <span>collapsed content</span>
-      </RepoGroupHeader>
+      <RepoGroupHeader {...defaultProps} isExpanded={false} collapsedSummary={<span>collapsed content</span>} />
     ));
     expect(getByText("collapsed content")).toBeTruthy();
   });
 
-  it("hides children when expanded", () => {
+  it("hides collapsedSummary when expanded", () => {
     const { queryByText } = render(() => (
-      <RepoGroupHeader {...defaultProps} isExpanded={true}>
-        <span>collapsed content</span>
-      </RepoGroupHeader>
+      <RepoGroupHeader {...defaultProps} isExpanded={true} collapsedSummary={<span>collapsed content</span>} />
     ));
     expect(queryByText("collapsed content")).toBeNull();
   });
@@ -119,13 +116,18 @@ describe("RepoGroupHeader", () => {
     const { getByRole } = render(() => (
       <RepoGroupHeader {...defaultProps} isExpanded={true} />
     ));
-    expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    expect(getByRole("button", { name: /owner\/repo/ }).getAttribute("aria-expanded")).toBe("true");
   });
 
   it("sets aria-expanded=false when collapsed", () => {
     const { getByRole } = render(() => (
       <RepoGroupHeader {...defaultProps} isExpanded={false} />
     ));
-    expect(getByRole("button").getAttribute("aria-expanded")).toBe("false");
+    expect(getByRole("button", { name: /owner\/repo/ }).getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("applies repo-header-text class to the button", () => {
+    const { getByRole } = render(() => <RepoGroupHeader {...defaultProps} />);
+    expect(getByRole("button", { name: /owner\/repo/ }).className).toContain("repo-header-text");
   });
 });


### PR DESCRIPTION
## Summary
- Extracts shared RepoGroupHeader component from IssuesTab, PullRequestsTab, ActionsTab
- Applies bg-info/20 tint, text-base font-bold, oklch text color via CSS light-dark()
- Fixes WAF smoke test Origin header requirement for /api/* assertions

Closes #63