### PR TITLE
feat(view): unify lockedRepos and preserve empty-repo state

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -350,13 +350,13 @@ The Tracked tab lets you pin issues and PRs into a personal TODO list that you c
 
 ## Repo Pinning
 
-Each repo group header has a pin (lock) control, visible on hover on desktop and always visible on mobile. Pinning a repo keeps it at the top of the list within its tab regardless of sort order or how recently it was updated.
+Each repo group header has a pin (lock) control, visible on hover on desktop and always visible on mobile. Pinning a repo keeps it at the top of the list on all tabs regardless of sort order or how recently it was updated.
 
 - Click the pin icon to pin a repo to the top.
 - Click it again to unpin.
 - Use the up/down arrows (visible when pinned) to reorder pinned repos relative to each other.
 
-Pin state is per-tab — a repo can be pinned on the Issues tab but not the Pull Requests tab.
+Pin state is shared across all tabs — pinning a repo on the Issues tab also pins it on Pull Requests and Actions.
 
 ---
 
@@ -438,7 +438,7 @@ These are UI preferences that persist across sessions but are not included in th
 | Show PR runs (Actions) | Off | Whether to show workflow runs triggered by pull request events. |
 | Hide Dependency Dashboard | On | Whether to hide the Renovate Dependency Dashboard issue. |
 | Sort preferences | Updated (desc) | Sort field and direction per tab, remembered across sessions. |
-| Pinned repos | (none) | Repos pinned to the top of each tab's list. |
+| Pinned repos | (none) | Repos pinned to the top of the list across all tabs. |
 | Tracked items | (none) | Issues and PRs pinned to the Tracked tab (max 200). |
 
 ---

--- a/scripts/waf-smoke-test.sh
+++ b/scripts/waf-smoke-test.sh
@@ -58,9 +58,10 @@ TESTS=(
   "200|GET /privacy|${BASE}/privacy"
   "307|GET /index.html (html_handling redirect)|${BASE}/index.html"
   "200|GET /assets/nonexistent.js|${BASE}/assets/nonexistent.js"
-  "200|GET /api/health|${BASE}/api/health"
-  "400|POST /api/oauth/token (no body)|-X|POST|${BASE}/api/oauth/token"
-  "404|GET /api/nonexistent|${BASE}/api/nonexistent"
+  "200|GET /api/health (with origin)|-H|Origin: ${BASE}|${BASE}/api/health"
+  "400|POST /api/oauth/token (with origin)|-X|POST|-H|Origin: ${BASE}|${BASE}/api/oauth/token"
+  "404|GET /api/nonexistent (with origin)|-H|Origin: ${BASE}|${BASE}/api/nonexistent"
+  "403|GET /api/health (no origin)|${BASE}/api/health"
   # Rule 1: Path Allowlist — blocked paths
   "403|GET /wp-admin|${BASE}/wp-admin"
   "403|GET /wp-login.php|${BASE}/wp-login.php"
@@ -103,7 +104,7 @@ TESTS=(
 # --- Run in parallel (:::  passes array elements directly, avoiding stdin quoting issues) ---
 TOTAL=${#TESTS[@]}
 
-OUTPUT=$(parallel --will-cite -k -j10 --timeout 15 run_spec ::: "${TESTS[@]}") || true
+OUTPUT=$(parallel --will-cite -k -j2 --delay 0.3 --timeout 15 run_spec ::: "${TESTS[@]}") || true
 
 # Detect infrastructure failure (parallel crashed, no tests ran)
 if [[ -z "$OUTPUT" ]]; then

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -19,6 +19,7 @@ interface ActionsTabProps {
   workflowRuns: WorkflowRun[];
   loading?: boolean;
   hasUpstreamRepos?: boolean;
+  configRepoNames?: string[];
   refreshTick?: number;
   hotPollingRunIds?: ReadonlySet<number>;
 }
@@ -131,7 +132,7 @@ export default function ActionsTab(props: ActionsTabProps) {
   }
 
   const activeRepoNames = createMemo(() =>
-    [...new Set(props.workflowRuns.map((r) => r.repoFullName))]
+    props.configRepoNames ?? [...new Set(props.workflowRuns.map((r) => r.repoFullName))]
   );
 
   const ignoredWorkflowRuns = createMemo(() =>
@@ -201,18 +202,18 @@ export default function ActionsTab(props: ActionsTabProps) {
   });
 
   const repoGroups = createMemo(() =>
-    orderRepoGroups(groupRuns(filteredRuns()), viewState.lockedRepos.actions)
+    orderRepoGroups(groupRuns(filteredRuns()), viewState.lockedRepos)
   );
 
   createEffect(() => {
     const names = activeRepoNames();
     if (names.length === 0) return;
-    pruneLockedRepos("actions", names);
+    pruneLockedRepos(names);
   });
 
   const highlightedReposActions = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
-    () => viewState.lockedRepos.actions,
+    () => viewState.lockedRepos,
     () => ignoredWorkflowRuns().length,
     () => JSON.stringify(viewState.tabFilters.actions),
   );
@@ -327,7 +328,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                     </Show>
                   </button>
                   <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
-                  <RepoLockControls tab="actions" repoFullName={repoGroup.repoFullName} />
+                  <RepoLockControls repoFullName={repoGroup.repoFullName} />
                 </div>
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
                   {(peek) => (

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -507,6 +507,10 @@ export default function DashboardPage() {
     ];
   });
 
+  const configRepoNames = createMemo(() =>
+    [...new Set([...config.selectedRepos, ...config.upstreamRepos, ...config.monitoredRepos].map(r => r.fullName))]
+  );
+
   return (
     <div class="min-h-screen bg-base-200">
       <Header />
@@ -550,6 +554,7 @@ export default function DashboardPage() {
                   allUsers={allUsers()}
                   trackedUsers={config.trackedUsers}
                   monitoredRepos={config.monitoredRepos}
+                  configRepoNames={configRepoNames()}
                   refreshTick={refreshTick()}
                 />
               </Match>
@@ -562,6 +567,7 @@ export default function DashboardPage() {
                   trackedUsers={config.trackedUsers}
                   hotPollingPRIds={hotPollingPRIds()}
                   monitoredRepos={config.monitoredRepos}
+                  configRepoNames={configRepoNames()}
                   refreshTick={refreshTick()}
                 />
               </Match>
@@ -579,6 +585,7 @@ export default function DashboardPage() {
                   workflowRuns={dashboardData.workflowRuns}
                   loading={dashboardData.loading}
                   hasUpstreamRepos={config.upstreamRepos.length > 0}
+                  configRepoNames={configRepoNames()}
                   refreshTick={refreshTick()}
                   hotPollingRunIds={hotPollingRunIds()}
                 />

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -26,6 +26,7 @@ export interface IssuesTabProps {
   allUsers?: { login: string; label: string }[];
   trackedUsers?: TrackedUser[];
   monitoredRepos?: RepoRef[];
+  configRepoNames?: string[];
   refreshTick?: number;
 }
 
@@ -191,7 +192,7 @@ export default function IssuesTab(props: IssuesTabProps) {
   const issueMeta = createMemo(() => filteredSortedWithMeta().meta);
 
   const repoGroups = createMemo(() =>
-    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos.issues)
+    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos)
   );
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
@@ -205,7 +206,7 @@ export default function IssuesTab(props: IssuesTabProps) {
   });
 
   const activeRepoNames = createMemo(() =>
-    [...new Set(props.issues.map((i) => i.repoFullName))]
+    props.configRepoNames ?? [...new Set(props.issues.map((i) => i.repoFullName))]
   );
 
   createEffect(() => {
@@ -217,7 +218,7 @@ export default function IssuesTab(props: IssuesTabProps) {
   createEffect(() => {
     const names = activeRepoNames();
     if (names.length === 0) return;
-    pruneLockedRepos("issues", names);
+    pruneLockedRepos(names);
   });
 
   const trackedIssueIds = createMemo(() =>
@@ -228,7 +229,7 @@ export default function IssuesTab(props: IssuesTabProps) {
 
   const highlightedReposIssues = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
-    () => viewState.lockedRepos.issues,
+    () => viewState.lockedRepos,
     () => ignoredIssues().length,
     () => JSON.stringify(viewState.tabFilters.issues),
   );
@@ -386,7 +387,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                         </Show>
                       </button>
                       <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
-                      <RepoLockControls tab="issues" repoFullName={repoGroup.repoFullName} />
+                      <RepoLockControls repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={isExpanded()}>
                       <div role="list" class="divide-y divide-base-300">

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -32,6 +32,7 @@ export interface PullRequestsTabProps {
   trackedUsers?: TrackedUser[];
   hotPollingPRIds?: ReadonlySet<number>;
   monitoredRepos?: RepoRef[];
+  configRepoNames?: string[];
   refreshTick?: number;
 }
 
@@ -288,7 +289,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const prMeta = createMemo(() => filteredSortedWithMeta().meta);
 
   const repoGroups = createMemo(() =>
-    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos.pullRequests)
+    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos)
   );
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
@@ -302,7 +303,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   });
 
   const activeRepoNames = createMemo(() =>
-    [...new Set(props.pullRequests.map((pr) => pr.repoFullName))]
+    props.configRepoNames ?? [...new Set(props.pullRequests.map((pr) => pr.repoFullName))]
   );
 
   createEffect(() => {
@@ -314,7 +315,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   createEffect(() => {
     const names = activeRepoNames();
     if (names.length === 0) return;
-    pruneLockedRepos("pullRequests", names);
+    pruneLockedRepos(names);
   });
 
   const { flashingIds: flashingPRIds, peekUpdates } = createFlashDetection({
@@ -334,7 +335,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
 
   const highlightedReposPRs = createReorderHighlight(
     () => repoGroups().map(g => g.repoFullName),
-    () => viewState.lockedRepos.pullRequests,
+    () => viewState.lockedRepos,
     () => ignoredPullRequests().length,
     () => JSON.stringify(viewState.tabFilters.pullRequests),
   );
@@ -535,7 +536,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         </Show>
                       </button>
                       <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
-                      <RepoLockControls tab="pullRequests" repoFullName={repoGroup.repoFullName} />
+                      <RepoLockControls repoFullName={repoGroup.repoFullName} />
                     </div>
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
                       {(peek) => (

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -1,16 +1,15 @@
 import { Show, createMemo } from "solid-js";
-import { viewState, lockRepo, unlockRepo, moveLockedRepo, type LockedReposTab } from "../../stores/view";
+import { viewState, lockRepo, unlockRepo, moveLockedRepo } from "../../stores/view";
 import { Tooltip } from "./Tooltip";
 import { withFlipAnimation } from "../../lib/scroll";
 
 interface RepoLockControlsProps {
-  tab: LockedReposTab;
   repoFullName: string;
 }
 
 export default function RepoLockControls(props: RepoLockControlsProps) {
   const lockInfo = createMemo(() => {
-    const list = viewState.lockedRepos[props.tab];
+    const list = viewState.lockedRepos;
     const idx = list.indexOf(props.repoFullName);
     return {
       isLocked: idx !== -1,
@@ -27,7 +26,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
           <Tooltip content="Pin to top">
             <button
               class="btn btn-ghost btn-xs opacity-0 group-hover/repo-header:opacity-100 focus:opacity-100 max-sm:opacity-60 sm:max-lg:opacity-60 transition-opacity"
-              onClick={() => withFlipAnimation(() => lockRepo(props.tab, props.repoFullName))}
+              onClick={() => withFlipAnimation(() => lockRepo(props.repoFullName))}
               aria-label={`Pin ${props.repoFullName} to top of list`}
             >
               {/* Heroicons 20px solid: lock-open */}
@@ -41,7 +40,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content="Unpin">
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withFlipAnimation(() => unlockRepo(props.tab, props.repoFullName))}
+            onClick={() => withFlipAnimation(() => unlockRepo(props.repoFullName))}
             aria-label={`Unpin ${props.repoFullName}`}
           >
             {/* Heroicons 20px solid: lock-closed */}
@@ -53,7 +52,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isFirst ? "Already at top of pinned list" : "Move up"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withFlipAnimation(() => moveLockedRepo(props.tab, props.repoFullName, "up"))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "up"))}
             disabled={lockInfo().isFirst}
             aria-label={`Move ${props.repoFullName} up`}
           >
@@ -66,7 +65,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isLast ? "Already at bottom of pinned list" : "Move down"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withFlipAnimation(() => moveLockedRepo(props.tab, props.repoFullName, "down"))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "down"))}
             disabled={lockInfo().isLast}
             aria-label={`Move ${props.repoFullName} down`}
           >

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -125,7 +125,7 @@ export function migrateLockedRepos(raw: unknown, lastActiveTab?: unknown): unkno
       }
     }
   }
-  return result;
+  return result.slice(0, LOCKED_REPOS_CAP);
 }
 
 function loadViewState(): ViewState {
@@ -322,7 +322,7 @@ export function pruneExpandedRepos(
 
 export function lockRepo(repoFullName: string): void {
   setViewState(produce((draft) => {
-    if (!draft.lockedRepos.includes(repoFullName)) {
+    if (!draft.lockedRepos.includes(repoFullName) && draft.lockedRepos.length < LOCKED_REPOS_CAP) {
       draft.lockedRepos.push(repoFullName);
     }
   }));

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -6,6 +6,7 @@ import { pushNotification } from "../lib/errors";
 export const VIEW_STORAGE_KEY = "github-tracker:view";
 const IGNORED_ITEMS_CAP = 500;
 const TRACKED_ITEMS_CAP = 200;
+const LOCKED_REPOS_CAP = 50;
 
 export const TrackedItemSchema = z.object({
   id: z.number(),
@@ -93,7 +94,7 @@ export const ViewStateSchema = z.object({
     pullRequests: {},
     actions: {},
   }),
-  lockedRepos: z.array(z.string()).default([]),
+  lockedRepos: z.array(z.string().max(200)).max(LOCKED_REPOS_CAP).default([]),
   trackedItems: z.array(TrackedItemSchema).max(TRACKED_ITEMS_CAP).default([]),
 });
 
@@ -132,6 +133,9 @@ function loadViewState(): ViewState {
     const raw = localStorage.getItem(VIEW_STORAGE_KEY);
     if (raw === null) return ViewStateSchema.parse({});
     const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return ViewStateSchema.parse({});
+    }
     const obj = parsed as Record<string, unknown>;
     obj.lockedRepos = migrateLockedRepos(obj.lockedRepos, obj.lastActiveTab);
     const result = ViewStateSchema.safeParse(parsed);

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -138,6 +138,11 @@ function loadViewState(): ViewState {
     }
     const obj = parsed as Record<string, unknown>;
     obj.lockedRepos = migrateLockedRepos(obj.lockedRepos, obj.lastActiveTab);
+    // Cap lockedRepos before Zod validates — an oversized array would fail
+    // .max(LOCKED_REPOS_CAP) and reject the ENTIRE ViewState, wiping all settings.
+    if (Array.isArray(obj.lockedRepos) && obj.lockedRepos.length > LOCKED_REPOS_CAP) {
+      obj.lockedRepos = obj.lockedRepos.slice(0, LOCKED_REPOS_CAP);
+    }
     const result = ViewStateSchema.safeParse(parsed);
     if (result.success) return result.data;
     return ViewStateSchema.parse({});

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -93,27 +93,47 @@ export const ViewStateSchema = z.object({
     pullRequests: {},
     actions: {},
   }),
-  lockedRepos: z.object({
-    issues: z.array(z.string()).default([]),
-    pullRequests: z.array(z.string()).default([]),
-    actions: z.array(z.string()).default([]),
-  }).default({
-    issues: [],
-    pullRequests: [],
-    actions: [],
-  }),
+  lockedRepos: z.array(z.string()).default([]),
   trackedItems: z.array(TrackedItemSchema).max(TRACKED_ITEMS_CAP).default([]),
 });
 
 export type ViewState = z.infer<typeof ViewStateSchema>;
 export type IgnoredItem = ViewState["ignoredItems"][number];
-export type LockedReposTab = keyof ViewState["lockedRepos"];
+
+export function migrateLockedRepos(raw: unknown, lastActiveTab?: unknown): unknown {
+  if (Array.isArray(raw) || raw == null) return raw;
+  if (typeof raw !== "object") return raw;
+  const obj = raw as Record<string, unknown>;
+  if (!("issues" in obj || "pullRequests" in obj || "actions" in obj)) return raw;
+  const tabs = ["issues", "pullRequests", "actions"] as const;
+  const preferred = (typeof lastActiveTab === "string" && tabs.includes(lastActiveTab as typeof tabs[number]))
+    ? lastActiveTab as typeof tabs[number]
+    : "issues";
+  const remaining = tabs.filter(t => t !== preferred);
+  const all = [preferred, ...remaining];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tab of all) {
+    const arr = obj[tab];
+    if (Array.isArray(arr)) {
+      for (const item of arr) {
+        if (typeof item === "string" && !seen.has(item)) {
+          seen.add(item);
+          result.push(item);
+        }
+      }
+    }
+  }
+  return result;
+}
 
 function loadViewState(): ViewState {
   try {
     const raw = localStorage.getItem(VIEW_STORAGE_KEY);
     if (raw === null) return ViewStateSchema.parse({});
     const parsed = JSON.parse(raw) as unknown;
+    const obj = parsed as Record<string, unknown>;
+    obj.lockedRepos = migrateLockedRepos(obj.lockedRepos, obj.lastActiveTab);
     const result = ViewStateSchema.safeParse(parsed);
     if (result.success) return result.data;
     return ViewStateSchema.parse({});
@@ -140,7 +160,7 @@ export function resetViewState(): void {
     showPrRuns: false,
     hideDepDashboard: true,
     expandedRepos: { issues: {}, pullRequests: {}, actions: {} },
-    lockedRepos: { issues: [], pullRequests: [], actions: [] },
+    lockedRepos: [],
     trackedItems: [],
   });
 }
@@ -296,27 +316,26 @@ export function pruneExpandedRepos(
   );
 }
 
-export function lockRepo(tab: LockedReposTab, repoFullName: string): void {
+export function lockRepo(repoFullName: string): void {
   setViewState(produce((draft) => {
-    if (!draft.lockedRepos[tab].includes(repoFullName)) {
-      draft.lockedRepos[tab].push(repoFullName);
+    if (!draft.lockedRepos.includes(repoFullName)) {
+      draft.lockedRepos.push(repoFullName);
     }
   }));
 }
 
-export function unlockRepo(tab: LockedReposTab, repoFullName: string): void {
+export function unlockRepo(repoFullName: string): void {
   setViewState(produce((draft) => {
-    draft.lockedRepos[tab] = draft.lockedRepos[tab].filter(r => r !== repoFullName);
+    draft.lockedRepos = draft.lockedRepos.filter(r => r !== repoFullName);
   }));
 }
 
 export function moveLockedRepo(
-  tab: LockedReposTab,
   repoFullName: string,
   direction: "up" | "down"
 ): void {
   setViewState(produce((draft) => {
-    const arr = draft.lockedRepos[tab];
+    const arr = draft.lockedRepos;
     const idx = arr.indexOf(repoFullName);
     if (idx === -1) return;
     const targetIdx = direction === "up" ? idx - 1 : idx + 1;
@@ -328,16 +347,15 @@ export function moveLockedRepo(
 }
 
 export function pruneLockedRepos(
-  tab: LockedReposTab,
   activeRepoNames: string[]
 ): void {
-  const current = untrack(() => viewState.lockedRepos[tab]);
+  const current = untrack(() => viewState.lockedRepos);
   if (current.length === 0) return;
   const activeSet = new Set(activeRepoNames);
   const filtered = current.filter(name => activeSet.has(name));
   if (filtered.length === current.length) return;
   setViewState(produce((draft) => {
-    draft.lockedRepos[tab] = filtered;
+    draft.lockedRepos = filtered;
   }));
 }
 

--- a/tests/components/dashboard/ActionsTab.test.tsx
+++ b/tests/components/dashboard/ActionsTab.test.tsx
@@ -28,8 +28,9 @@ vi.mock("../../../src/app/lib/url", () => ({
 
 // ── Imports ───────────────────────────────────────────────────────────────────
 
+import { produce } from "solid-js/store";
 import ActionsTab from "../../../src/app/components/dashboard/ActionsTab";
-import { resetViewState } from "../../../src/app/stores/view";
+import { viewState, setViewState, resetViewState } from "../../../src/app/stores/view";
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
 
@@ -69,5 +70,37 @@ describe("ActionsTab — upstream exclusion note", () => {
       <ActionsTab workflowRuns={runs} hasUpstreamRepos={true} />
     ));
     screen.getByText(/workflow runs are not tracked for upstream/i);
+  });
+});
+
+describe("ActionsTab — empty-repo state preservation", () => {
+  it("preserves expand/lock state for empty repos in configRepoNames", () => {
+    setViewState(produce((s) => {
+      s.expandedRepos.actions["owner/empty-repo"] = true;
+      s.expandedRepos.actions["owner/stale-repo"] = true;
+      s.lockedRepos = ["owner/empty-repo", "owner/stale-repo"];
+    }));
+
+    render(() => (
+      <ActionsTab
+        workflowRuns={[makeWorkflowRun({ repoFullName: "owner/active-repo" })]}
+        configRepoNames={["owner/active-repo", "owner/empty-repo"]}
+      />
+    ));
+
+    // Empty repo preserved (in configRepoNames but no items)
+    expect(viewState.expandedRepos.actions["owner/empty-repo"]).toBe(true);
+    expect(viewState.lockedRepos).toContain("owner/empty-repo");
+    // Stale repo pruned (not in configRepoNames)
+    expect(viewState.expandedRepos.actions["owner/stale-repo"]).toBeUndefined();
+    expect(viewState.lockedRepos).not.toContain("owner/stale-repo");
+  });
+
+  it("falls back to item-derived names when configRepoNames not provided", () => {
+    render(() => (
+      <ActionsTab workflowRuns={[]} />
+    ));
+    // With empty items and no configRepoNames, guard returns early — no pruning
+    expect(viewState.lockedRepos).toEqual([]);
   });
 });

--- a/tests/components/dashboard/IssuesTab.test.tsx
+++ b/tests/components/dashboard/IssuesTab.test.tsx
@@ -29,8 +29,9 @@ vi.mock("../../../src/app/lib/url", () => ({
 
 // ── Imports ───────────────────────────────────────────────────────────────────
 
+import { produce } from "solid-js/store";
 import IssuesTab from "../../../src/app/components/dashboard/IssuesTab";
-import { viewState, setTabFilter, setAllExpanded, resetViewState, updateViewState } from "../../../src/app/stores/view";
+import { viewState, setViewState, setTabFilter, setAllExpanded, resetViewState, updateViewState } from "../../../src/app/stores/view";
 import { updateConfig, resetConfig } from "../../../src/app/stores/config";
 import type { TrackedUser } from "../../../src/app/stores/config";
 
@@ -705,5 +706,38 @@ describe("IssuesTab — pin button wiring", () => {
     await user.click(ignoreBtn);
 
     expect(viewState.trackedItems.some(t => t.id === 52 && t.type === "issue")).toBe(false);
+  });
+});
+
+describe("IssuesTab — empty-repo state preservation", () => {
+  it("preserves expand/lock state for empty repos in configRepoNames", () => {
+    setViewState(produce((s) => {
+      s.expandedRepos.issues["owner/empty-repo"] = true;
+      s.expandedRepos.issues["owner/stale-repo"] = true;
+      s.lockedRepos = ["owner/empty-repo", "owner/stale-repo"];
+    }));
+
+    render(() => (
+      <IssuesTab
+        issues={[makeIssue({ id: 1, repoFullName: "owner/active-repo", surfacedBy: ["me"] })]}
+        userLogin="me"
+        configRepoNames={["owner/active-repo", "owner/empty-repo"]}
+      />
+    ));
+
+    // Empty repo preserved (in configRepoNames but no items)
+    expect(viewState.expandedRepos.issues["owner/empty-repo"]).toBe(true);
+    expect(viewState.lockedRepos).toContain("owner/empty-repo");
+    // Stale repo pruned (not in configRepoNames)
+    expect(viewState.expandedRepos.issues["owner/stale-repo"]).toBeUndefined();
+    expect(viewState.lockedRepos).not.toContain("owner/stale-repo");
+  });
+
+  it("falls back to item-derived names when configRepoNames not provided", () => {
+    render(() => (
+      <IssuesTab issues={[]} userLogin="me" />
+    ));
+    // With empty items and no configRepoNames, guard returns early — no pruning
+    expect(viewState.lockedRepos).toEqual([]);
   });
 });

--- a/tests/components/dashboard/PullRequestsTab.test.tsx
+++ b/tests/components/dashboard/PullRequestsTab.test.tsx
@@ -29,8 +29,9 @@ vi.mock("../../../src/app/lib/url", () => ({
 
 // ── Imports ───────────────────────────────────────────────────────────────────
 
+import { produce } from "solid-js/store";
 import PullRequestsTab from "../../../src/app/components/dashboard/PullRequestsTab";
-import { viewState, setTabFilter, setAllExpanded, resetViewState, updateViewState } from "../../../src/app/stores/view";
+import { viewState, setViewState, setTabFilter, setAllExpanded, resetViewState, updateViewState } from "../../../src/app/stores/view";
 import type { TrackedUser } from "../../../src/app/stores/config";
 import { updateConfig, resetConfig } from "../../../src/app/stores/config";
 
@@ -676,5 +677,38 @@ describe("PullRequestsTab — pin button wiring", () => {
     await user.click(ignoreBtn);
 
     expect(viewState.trackedItems.some(t => t.id === 62 && t.type === "pullRequest")).toBe(false);
+  });
+});
+
+describe("PullRequestsTab — empty-repo state preservation", () => {
+  it("preserves expand/lock state for empty repos in configRepoNames", () => {
+    setViewState(produce((s) => {
+      s.expandedRepos.pullRequests["owner/empty-repo"] = true;
+      s.expandedRepos.pullRequests["owner/stale-repo"] = true;
+      s.lockedRepos = ["owner/empty-repo", "owner/stale-repo"];
+    }));
+
+    render(() => (
+      <PullRequestsTab
+        pullRequests={[makePullRequest({ id: 1, repoFullName: "owner/active-repo", surfacedBy: ["me"] })]}
+        userLogin="me"
+        configRepoNames={["owner/active-repo", "owner/empty-repo"]}
+      />
+    ));
+
+    // Empty repo preserved (in configRepoNames but no items)
+    expect(viewState.expandedRepos.pullRequests["owner/empty-repo"]).toBe(true);
+    expect(viewState.lockedRepos).toContain("owner/empty-repo");
+    // Stale repo pruned (not in configRepoNames)
+    expect(viewState.expandedRepos.pullRequests["owner/stale-repo"]).toBeUndefined();
+    expect(viewState.lockedRepos).not.toContain("owner/stale-repo");
+  });
+
+  it("falls back to item-derived names when configRepoNames not provided", () => {
+    render(() => (
+      <PullRequestsTab pullRequests={[]} userLogin="me" />
+    ));
+    // With empty items and no configRepoNames, guard returns early — no pruning
+    expect(viewState.lockedRepos).toEqual([]);
   });
 });

--- a/tests/components/shared/RepoLockControls.test.tsx
+++ b/tests/components/shared/RepoLockControls.test.tsx
@@ -10,15 +10,15 @@ beforeEach(() => {
 describe("RepoLockControls", () => {
   it("renders unlock (pin) icon when repo is not locked", () => {
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     expect(screen.getByLabelText("Pin owner/repo to top of list")).toBeTruthy();
   });
 
   it("renders lock icon + chevrons when repo IS locked", () => {
-    lockRepo("issues", "owner/repo");
+    lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     expect(screen.getByLabelText("Unpin owner/repo")).toBeTruthy();
     expect(screen.getByLabelText("Move owner/repo up")).toBeTruthy();
@@ -27,67 +27,67 @@ describe("RepoLockControls", () => {
 
   it("click pin icon → locks the repo", () => {
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
-    expect(viewState.lockedRepos.issues).toContain("owner/repo");
+    expect(viewState.lockedRepos).toContain("owner/repo");
   });
 
   it("click lock icon → unlocks the repo", () => {
-    lockRepo("issues", "owner/repo");
+    lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
-    expect(viewState.lockedRepos.issues).not.toContain("owner/repo");
+    expect(viewState.lockedRepos).not.toContain("owner/repo");
   });
 
   it("up button moves repo up in order", () => {
-    lockRepo("issues", "owner/a");
-    lockRepo("issues", "owner/b");
+    lockRepo("owner/a");
+    lockRepo("owner/b");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/b" />
+      <RepoLockControls repoFullName="owner/b" />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/b up"));
-    expect(viewState.lockedRepos.issues[0]).toBe("owner/b");
-    expect(viewState.lockedRepos.issues[1]).toBe("owner/a");
+    expect(viewState.lockedRepos[0]).toBe("owner/b");
+    expect(viewState.lockedRepos[1]).toBe("owner/a");
   });
 
   it("down button moves repo down in order", () => {
-    lockRepo("issues", "owner/a");
-    lockRepo("issues", "owner/b");
+    lockRepo("owner/a");
+    lockRepo("owner/b");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/a" />
+      <RepoLockControls repoFullName="owner/a" />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/a down"));
-    expect(viewState.lockedRepos.issues[0]).toBe("owner/b");
-    expect(viewState.lockedRepos.issues[1]).toBe("owner/a");
+    expect(viewState.lockedRepos[0]).toBe("owner/b");
+    expect(viewState.lockedRepos[1]).toBe("owner/a");
   });
 
   it("up button is disabled when repo is first in locked list", () => {
-    lockRepo("issues", "owner/repo");
+    lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     const upBtn = screen.getByLabelText("Move owner/repo up") as HTMLButtonElement;
     expect(upBtn.disabled).toBe(true);
   });
 
   it("down button is disabled when repo is last in locked list", () => {
-    lockRepo("issues", "owner/repo");
+    lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     const downBtn = screen.getByLabelText("Move owner/repo down") as HTMLButtonElement;
     expect(downBtn.disabled).toBe(true);
   });
 
   it("stopPropagation — parent click NOT triggered on locked button click", () => {
-    lockRepo("issues", "owner/repo");
+    lockRepo("owner/repo");
     const parentClick = vi.fn();
     render(() => (
       <div onClick={parentClick}>
-        <RepoLockControls tab="issues" repoFullName="owner/repo" />
+        <RepoLockControls repoFullName="owner/repo" />
       </div>
     ));
     fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
@@ -98,7 +98,7 @@ describe("RepoLockControls", () => {
     const parentClick = vi.fn();
     render(() => (
       <div onClick={parentClick}>
-        <RepoLockControls tab="issues" repoFullName="owner/repo" />
+        <RepoLockControls repoFullName="owner/repo" />
       </div>
     ));
     fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
@@ -123,36 +123,36 @@ describe("RepoLockControls — scroll preservation", () => {
 
   it("preserves scroll position when locking a repo", () => {
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
   });
 
   it("preserves scroll position when unlocking a repo", () => {
-    lockRepo("issues", "owner/repo");
+    lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" />
     ));
     fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
   });
 
   it("preserves scroll position when moving repo up", () => {
-    lockRepo("issues", "owner/a");
-    lockRepo("issues", "owner/b");
+    lockRepo("owner/a");
+    lockRepo("owner/b");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/b" />
+      <RepoLockControls repoFullName="owner/b" />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/b up"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
   });
 
   it("preserves scroll position when moving repo down", () => {
-    lockRepo("issues", "owner/a");
-    lockRepo("issues", "owner/b");
+    lockRepo("owner/a");
+    lockRepo("owner/b");
     render(() => (
-      <RepoLockControls tab="issues" repoFullName="owner/a" />
+      <RepoLockControls repoFullName="owner/a" />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/a down"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);

--- a/tests/stores/view-lock.test.ts
+++ b/tests/stores/view-lock.test.ts
@@ -6,6 +6,7 @@ import {
   unlockRepo,
   moveLockedRepo,
   pruneLockedRepos,
+  migrateLockedRepos,
   ViewStateSchema,
 } from "../../src/app/stores/view";
 
@@ -16,109 +17,107 @@ describe("view lock store", () => {
 
   describe("lockRepo", () => {
     it("locks a repo", () => {
-      lockRepo("issues", "org/repo-a");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
+      lockRepo("org/repo-a");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a"]);
     });
 
     it("appends to end", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("issues", "org/repo-b");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-b"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a", "org/repo-b"]);
     });
 
     it("deduplicates", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("issues", "org/repo-a");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-a");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a"]);
     });
 
-    it("locks per-tab independently", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("pullRequests", "org/repo-b");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
-      expect(viewState.lockedRepos.pullRequests).toEqual(["org/repo-b"]);
-      expect(viewState.lockedRepos.actions).toEqual([]);
+    it("accumulates locks from multiple lockRepo calls", () => {
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a", "org/repo-b"]);
     });
   });
 
   describe("unlockRepo", () => {
     it("removes from locked array", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("issues", "org/repo-b");
-      unlockRepo("issues", "org/repo-a");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-b"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      unlockRepo("org/repo-a");
+      expect(viewState.lockedRepos).toEqual(["org/repo-b"]);
     });
 
     it("no-op if not locked", () => {
-      unlockRepo("issues", "org/repo-a");
-      expect(viewState.lockedRepos.issues).toEqual([]);
+      unlockRepo("org/repo-a");
+      expect(viewState.lockedRepos).toEqual([]);
     });
   });
 
   describe("moveLockedRepo", () => {
     it("swaps with neighbor up", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("issues", "org/repo-b");
-      lockRepo("issues", "org/repo-c");
-      moveLockedRepo("issues", "org/repo-b", "up");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-b", "org/repo-a", "org/repo-c"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      lockRepo("org/repo-c");
+      moveLockedRepo("org/repo-b", "up");
+      expect(viewState.lockedRepos).toEqual(["org/repo-b", "org/repo-a", "org/repo-c"]);
     });
 
     it("swaps with neighbor down", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("issues", "org/repo-b");
-      lockRepo("issues", "org/repo-c");
-      moveLockedRepo("issues", "org/repo-b", "down");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-c", "org/repo-b"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      lockRepo("org/repo-c");
+      moveLockedRepo("org/repo-b", "down");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a", "org/repo-c", "org/repo-b"]);
     });
 
     it("no-op at top boundary", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("issues", "org/repo-b");
-      moveLockedRepo("issues", "org/repo-a", "up");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-b"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      moveLockedRepo("org/repo-a", "up");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a", "org/repo-b"]);
     });
 
     it("no-op at bottom boundary", () => {
-      lockRepo("issues", "org/repo-a");
-      lockRepo("issues", "org/repo-b");
-      moveLockedRepo("issues", "org/repo-b", "down");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a", "org/repo-b"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      moveLockedRepo("org/repo-b", "down");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a", "org/repo-b"]);
     });
 
     it("no-op if not locked", () => {
-      lockRepo("issues", "org/repo-a");
-      moveLockedRepo("issues", "org/repo-z", "up");
-      expect(viewState.lockedRepos.issues).toEqual(["org/repo-a"]);
+      lockRepo("org/repo-a");
+      moveLockedRepo("org/repo-z", "up");
+      expect(viewState.lockedRepos).toEqual(["org/repo-a"]);
     });
   });
 
   describe("pruneLockedRepos", () => {
     it("removes stale names", () => {
-      lockRepo("pullRequests", "org/repo-a");
-      lockRepo("pullRequests", "org/repo-b");
-      lockRepo("pullRequests", "org/repo-c");
-      pruneLockedRepos("pullRequests", ["org/repo-a", "org/repo-c"]);
-      expect(viewState.lockedRepos.pullRequests).toEqual(["org/repo-a", "org/repo-c"]);
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      lockRepo("org/repo-c");
+      pruneLockedRepos(["org/repo-a", "org/repo-c"]);
+      expect(viewState.lockedRepos).toEqual(["org/repo-a", "org/repo-c"]);
     });
 
     it("preserves order of active repos", () => {
-      lockRepo("pullRequests", "org/repo-c");
-      lockRepo("pullRequests", "org/repo-a");
-      lockRepo("pullRequests", "org/repo-b");
-      pruneLockedRepos("pullRequests", ["org/repo-b", "org/repo-c"]);
-      expect(viewState.lockedRepos.pullRequests).toEqual(["org/repo-c", "org/repo-b"]);
+      lockRepo("org/repo-c");
+      lockRepo("org/repo-a");
+      lockRepo("org/repo-b");
+      pruneLockedRepos(["org/repo-b", "org/repo-c"]);
+      expect(viewState.lockedRepos).toEqual(["org/repo-c", "org/repo-b"]);
     });
 
     it("no-op when empty", () => {
-      pruneLockedRepos("pullRequests", ["org/repo-a"]);
-      expect(viewState.lockedRepos.pullRequests).toEqual([]);
+      pruneLockedRepos(["org/repo-a"]);
+      expect(viewState.lockedRepos).toEqual([]);
     });
 
     it("no-op when all active", () => {
-      lockRepo("actions", "org/repo-a");
-      pruneLockedRepos("actions", ["org/repo-a", "org/repo-b"]);
-      expect(viewState.lockedRepos.actions).toEqual(["org/repo-a"]);
+      lockRepo("org/repo-a");
+      pruneLockedRepos(["org/repo-a", "org/repo-b"]);
+      expect(viewState.lockedRepos).toEqual(["org/repo-a"]);
     });
   });
 
@@ -127,11 +126,7 @@ describe("view lock store", () => {
       const result = ViewStateSchema.safeParse({});
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.lockedRepos).toEqual({
-          issues: [],
-          pullRequests: [],
-          actions: [],
-        });
+        expect(result.data.lockedRepos).toEqual([]);
       }
     });
 
@@ -143,12 +138,33 @@ describe("view lock store", () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.lastActiveTab).toBe("issues");
-        expect(result.data.lockedRepos).toEqual({
-          issues: [],
-          pullRequests: [],
-          actions: [],
-        });
+        expect(result.data.lockedRepos).toEqual([]);
       }
+    });
+  });
+
+  describe("migrateLockedRepos", () => {
+    it("deduplicates with issues-first default", () => {
+      expect(migrateLockedRepos({ issues: ["a"], pullRequests: ["b"], actions: ["a"] }))
+        .toEqual(["a", "b"]);
+    });
+
+    it("uses lastActiveTab for precedence", () => {
+      expect(migrateLockedRepos({ issues: ["a"], pullRequests: ["b"], actions: ["a"] }, "pullRequests"))
+        .toEqual(["b", "a"]);
+    });
+
+    it("handles partial object", () => {
+      expect(migrateLockedRepos({ issues: ["a"], pullRequests: ["b"] }))
+        .toEqual(["a", "b"]);
+    });
+
+    it("returns array unchanged", () => {
+      expect(migrateLockedRepos(["a", "b"])).toEqual(["a", "b"]);
+    });
+
+    it("returns undefined unchanged", () => {
+      expect(migrateLockedRepos(undefined)).toBeUndefined();
     });
   });
 });

--- a/tests/stores/view-lock.test.ts
+++ b/tests/stores/view-lock.test.ts
@@ -166,5 +166,41 @@ describe("view lock store", () => {
     it("returns undefined unchanged", () => {
       expect(migrateLockedRepos(undefined)).toBeUndefined();
     });
+
+    it("uses actions tab for precedence when lastActiveTab is actions", () => {
+      expect(migrateLockedRepos(
+        { issues: ["a"], pullRequests: ["b"], actions: ["c", "a"] },
+        "actions"
+      )).toEqual(["c", "a", "b"]);
+    });
+
+    it("caps output at LOCKED_REPOS_CAP when merging exceeds limit", () => {
+      // 20 unique per tab × 3 tabs = 60 unique entries, exceeds cap of 50
+      const issues = Array.from({ length: 20 }, (_, i) => `org/issue-${i}`);
+      const prs = Array.from({ length: 20 }, (_, i) => `org/pr-${i}`);
+      const actions = Array.from({ length: 20 }, (_, i) => `org/action-${i}`);
+      const result = migrateLockedRepos({ issues, pullRequests: prs, actions });
+      expect(Array.isArray(result)).toBe(true);
+      expect((result as string[]).length).toBe(50);
+      // First 20 should be issues (default preferred), then first 20 PRs, then first 10 actions
+      expect((result as string[])[0]).toBe("org/issue-0");
+      expect((result as string[])[20]).toBe("org/pr-0");
+      expect((result as string[])[40]).toBe("org/action-0");
+      expect((result as string[])[49]).toBe("org/action-9");
+    });
+  });
+
+  describe("lockRepo cap enforcement", () => {
+    it("silently no-ops when at LOCKED_REPOS_CAP", () => {
+      // Fill to cap
+      for (let i = 0; i < 50; i++) {
+        lockRepo(`org/repo-${i}`);
+      }
+      expect(viewState.lockedRepos.length).toBe(50);
+      // Attempt to add one more
+      lockRepo("org/repo-overflow");
+      expect(viewState.lockedRepos.length).toBe(50);
+      expect(viewState.lockedRepos).not.toContain("org/repo-overflow");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Flatten lockedRepos from per-tab object to unified shared array with backward-compatible migration
- Config-derived pruning preserves expand/lock state for repos with zero items
- Defense-in-depth: LOCKED_REPOS_CAP, non-object guard, pre-validation cap enforcement