### PR TITLE
fix(view): locked-repo reorder skips invisible repos

### DIFF
--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -204,6 +204,10 @@ export default function ActionsTab(props: ActionsTabProps) {
   const repoGroups = createMemo(() =>
     orderRepoGroups(groupRuns(filteredRuns()), viewState.lockedRepos)
   );
+  const visibleLockedRepos = createMemo(() => {
+    const rendered = new Set(repoGroups().map(g => g.repoFullName));
+    return viewState.lockedRepos.filter(name => rendered.has(name));
+  });
 
   createEffect(() => {
     const names = activeRepoNames();
@@ -302,7 +306,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                   trailing={
                     <>
                       <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
-                      <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                      <RepoLockControls repoFullName={repoGroup.repoFullName} visibleLockedRepos={visibleLockedRepos()} />
                     </>
                   }
                   collapsedSummary={

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -194,6 +194,10 @@ export default function IssuesTab(props: IssuesTabProps) {
   const repoGroups = createMemo(() =>
     orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos)
   );
+  const visibleLockedRepos = createMemo(() => {
+    const rendered = new Set(repoGroups().map(g => g.repoFullName));
+    return viewState.lockedRepos.filter(name => rendered.has(name));
+  });
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
@@ -367,7 +371,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                       trailing={
                         <>
                           <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
-                          <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                          <RepoLockControls repoFullName={repoGroup.repoFullName} visibleLockedRepos={visibleLockedRepos()} />
                         </>
                       }
                       collapsedSummary={

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -291,6 +291,10 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const repoGroups = createMemo(() =>
     orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos)
   );
+  const visibleLockedRepos = createMemo(() => {
+    const rendered = new Set(repoGroups().map(g => g.repoFullName));
+    return viewState.lockedRepos.filter(name => rendered.has(name));
+  });
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
@@ -474,7 +478,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                       trailing={
                         <>
                           <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
-                          <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                          <RepoLockControls repoFullName={repoGroup.repoFullName} visibleLockedRepos={visibleLockedRepos()} />
                         </>
                       }
                       collapsedSummary={

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -9,6 +9,8 @@ interface RepoLockControlsProps {
 }
 
 export default function RepoLockControls(props: RepoLockControlsProps) {
+  const visibleSet = createMemo(() => new Set(props.visibleLockedRepos));
+
   const lockInfo = createMemo(() => {
     const isLocked = viewState.lockedRepos.indexOf(props.repoFullName) !== -1;
     const visIdx = props.visibleLockedRepos.indexOf(props.repoFullName);
@@ -53,7 +55,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isFirst ? "Already at top of pinned list" : "Move up"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "up", new Set(props.visibleLockedRepos)))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "up", visibleSet()))}
             disabled={lockInfo().isFirst}
             aria-label={`Move ${props.repoFullName} up`}
           >
@@ -66,7 +68,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isLast ? "Already at bottom of pinned list" : "Move down"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "down", new Set(props.visibleLockedRepos)))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "down", visibleSet()))}
             disabled={lockInfo().isLast}
             aria-label={`Move ${props.repoFullName} down`}
           >

--- a/src/app/components/shared/RepoLockControls.tsx
+++ b/src/app/components/shared/RepoLockControls.tsx
@@ -5,16 +5,17 @@ import { withFlipAnimation } from "../../lib/scroll";
 
 interface RepoLockControlsProps {
   repoFullName: string;
+  visibleLockedRepos: string[];
 }
 
 export default function RepoLockControls(props: RepoLockControlsProps) {
   const lockInfo = createMemo(() => {
-    const list = viewState.lockedRepos;
-    const idx = list.indexOf(props.repoFullName);
+    const isLocked = viewState.lockedRepos.indexOf(props.repoFullName) !== -1;
+    const visIdx = props.visibleLockedRepos.indexOf(props.repoFullName);
     return {
-      isLocked: idx !== -1,
-      isFirst: idx === 0,
-      isLast: idx !== -1 && idx === list.length - 1,
+      isLocked,
+      isFirst: visIdx === 0,
+      isLast: visIdx !== -1 && visIdx === props.visibleLockedRepos.length - 1,
     };
   });
 
@@ -52,7 +53,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isFirst ? "Already at top of pinned list" : "Move up"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "up"))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "up", new Set(props.visibleLockedRepos)))}
             disabled={lockInfo().isFirst}
             aria-label={`Move ${props.repoFullName} up`}
           >
@@ -65,7 +66,7 @@ export default function RepoLockControls(props: RepoLockControlsProps) {
         <Tooltip content={lockInfo().isLast ? "Already at bottom of pinned list" : "Move down"}>
           <button
             class="btn btn-ghost btn-xs"
-            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "down"))}
+            onClick={() => withFlipAnimation(() => moveLockedRepo(props.repoFullName, "down", new Set(props.visibleLockedRepos)))}
             disabled={lockInfo().isLast}
             aria-label={`Move ${props.repoFullName} down`}
           >

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -341,17 +341,42 @@ export function unlockRepo(repoFullName: string): void {
 
 export function moveLockedRepo(
   repoFullName: string,
-  direction: "up" | "down"
+  direction: "up" | "down",
+  visibleRepoNames?: ReadonlySet<string>
 ): void {
   setViewState(produce((draft) => {
     const arr = draft.lockedRepos;
     const idx = arr.indexOf(repoFullName);
     if (idx === -1) return;
-    const targetIdx = direction === "up" ? idx - 1 : idx + 1;
-    if (targetIdx < 0 || targetIdx >= arr.length) return;
-    const tmp = arr[idx];
-    arr[idx] = arr[targetIdx];
-    arr[targetIdx] = tmp;
+
+    if (!visibleRepoNames) {
+      // Backward-compatible adjacent swap
+      const targetIdx = direction === "up" ? idx - 1 : idx + 1;
+      if (targetIdx < 0 || targetIdx >= arr.length) return;
+      const tmp = arr[idx];
+      arr[idx] = arr[targetIdx];
+      arr[targetIdx] = tmp;
+      return;
+    }
+
+    // Find the next visible repo in the given direction
+    const step = direction === "up" ? -1 : 1;
+    let targetIdx = -1;
+    for (let i = idx + step; i >= 0 && i < arr.length; i += step) {
+      if (visibleRepoNames.has(arr[i])) {
+        targetIdx = i;
+        break;
+      }
+    }
+    if (targetIdx === -1) return;
+
+    // Remove from old position and insert adjacent to target
+    arr.splice(idx, 1);
+    // After removal, targetIdx shifts if source was before it
+    const insertIdx = direction === "up"
+      ? targetIdx - (idx < targetIdx ? 1 : 0)
+      : targetIdx - (idx < targetIdx ? 1 : 0) + 1;
+    arr.splice(insertIdx, 0, repoFullName);
   }));
 }
 

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -372,10 +372,9 @@ export function moveLockedRepo(
 
     // Remove from old position and insert adjacent to target
     arr.splice(idx, 1);
-    // After removal, targetIdx shifts if source was before it
-    const insertIdx = direction === "up"
-      ? targetIdx - (idx < targetIdx ? 1 : 0)
-      : targetIdx - (idx < targetIdx ? 1 : 0) + 1;
+    // After removal, target index shifts down by 1 if source preceded it
+    const adjustedTarget = targetIdx - (idx < targetIdx ? 1 : 0);
+    const insertIdx = direction === "up" ? adjustedTarget : adjustedTarget + 1;
     arr.splice(insertIdx, 0, repoFullName);
   }));
 }

--- a/tests/components/shared/RepoLockControls.test.tsx
+++ b/tests/components/shared/RepoLockControls.test.tsx
@@ -10,7 +10,7 @@ beforeEach(() => {
 describe("RepoLockControls", () => {
   it("renders unlock (pin) icon when repo is not locked", () => {
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={[]} />
     ));
     expect(screen.getByLabelText("Pin owner/repo to top of list")).toBeTruthy();
   });
@@ -18,7 +18,7 @@ describe("RepoLockControls", () => {
   it("renders lock icon + chevrons when repo IS locked", () => {
     lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={["owner/repo"]} />
     ));
     expect(screen.getByLabelText("Unpin owner/repo")).toBeTruthy();
     expect(screen.getByLabelText("Move owner/repo up")).toBeTruthy();
@@ -27,7 +27,7 @@ describe("RepoLockControls", () => {
 
   it("click pin icon → locks the repo", () => {
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={[]} />
     ));
     fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
     expect(viewState.lockedRepos).toContain("owner/repo");
@@ -36,7 +36,7 @@ describe("RepoLockControls", () => {
   it("click lock icon → unlocks the repo", () => {
     lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={["owner/repo"]} />
     ));
     fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
     expect(viewState.lockedRepos).not.toContain("owner/repo");
@@ -46,7 +46,7 @@ describe("RepoLockControls", () => {
     lockRepo("owner/a");
     lockRepo("owner/b");
     render(() => (
-      <RepoLockControls repoFullName="owner/b" />
+      <RepoLockControls repoFullName="owner/b" visibleLockedRepos={["owner/a", "owner/b"]} />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/b up"));
     expect(viewState.lockedRepos[0]).toBe("owner/b");
@@ -57,7 +57,7 @@ describe("RepoLockControls", () => {
     lockRepo("owner/a");
     lockRepo("owner/b");
     render(() => (
-      <RepoLockControls repoFullName="owner/a" />
+      <RepoLockControls repoFullName="owner/a" visibleLockedRepos={["owner/a", "owner/b"]} />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/a down"));
     expect(viewState.lockedRepos[0]).toBe("owner/b");
@@ -67,7 +67,7 @@ describe("RepoLockControls", () => {
   it("up button is disabled when repo is first in locked list", () => {
     lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={["owner/repo"]} />
     ));
     const upBtn = screen.getByLabelText("Move owner/repo up") as HTMLButtonElement;
     expect(upBtn.disabled).toBe(true);
@@ -76,10 +76,45 @@ describe("RepoLockControls", () => {
   it("down button is disabled when repo is last in locked list", () => {
     lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={["owner/repo"]} />
     ));
     const downBtn = screen.getByLabelText("Move owner/repo down") as HTMLButtonElement;
     expect(downBtn.disabled).toBe(true);
+  });
+
+  it("up button disabled when first in visibleLockedRepos even if hidden repos precede it", () => {
+    lockRepo("owner/hidden");
+    lockRepo("owner/a");
+    lockRepo("owner/b");
+    render(() => (
+      <RepoLockControls repoFullName="owner/a" visibleLockedRepos={["owner/a", "owner/b"]} />
+    ));
+    const upBtn = screen.getByLabelText("Move owner/a up") as HTMLButtonElement;
+    expect(upBtn.disabled).toBe(true);
+  });
+
+  it("down button disabled when last in visibleLockedRepos even if hidden repos follow it", () => {
+    lockRepo("owner/a");
+    lockRepo("owner/b");
+    lockRepo("owner/hidden");
+    render(() => (
+      <RepoLockControls repoFullName="owner/b" visibleLockedRepos={["owner/a", "owner/b"]} />
+    ));
+    const downBtn = screen.getByLabelText("Move owner/b down") as HTMLButtonElement;
+    expect(downBtn.disabled).toBe(true);
+  });
+
+  it("up/down buttons enabled when repo has visible neighbors", () => {
+    lockRepo("owner/a");
+    lockRepo("owner/b");
+    lockRepo("owner/c");
+    render(() => (
+      <RepoLockControls repoFullName="owner/b" visibleLockedRepos={["owner/a", "owner/b", "owner/c"]} />
+    ));
+    const upBtn = screen.getByLabelText("Move owner/b up") as HTMLButtonElement;
+    const downBtn = screen.getByLabelText("Move owner/b down") as HTMLButtonElement;
+    expect(upBtn.disabled).toBe(false);
+    expect(downBtn.disabled).toBe(false);
   });
 
   it("stopPropagation — parent click NOT triggered on locked button click", () => {
@@ -87,7 +122,7 @@ describe("RepoLockControls", () => {
     const parentClick = vi.fn();
     render(() => (
       <div onClick={parentClick}>
-        <RepoLockControls repoFullName="owner/repo" />
+        <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={["owner/repo"]} />
       </div>
     ));
     fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
@@ -98,7 +133,7 @@ describe("RepoLockControls", () => {
     const parentClick = vi.fn();
     render(() => (
       <div onClick={parentClick}>
-        <RepoLockControls repoFullName="owner/repo" />
+        <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={[]} />
       </div>
     ));
     fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
@@ -123,7 +158,7 @@ describe("RepoLockControls — scroll preservation", () => {
 
   it("preserves scroll position when locking a repo", () => {
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={[]} />
     ));
     fireEvent.click(screen.getByLabelText("Pin owner/repo to top of list"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
@@ -132,7 +167,7 @@ describe("RepoLockControls — scroll preservation", () => {
   it("preserves scroll position when unlocking a repo", () => {
     lockRepo("owner/repo");
     render(() => (
-      <RepoLockControls repoFullName="owner/repo" />
+      <RepoLockControls repoFullName="owner/repo" visibleLockedRepos={["owner/repo"]} />
     ));
     fireEvent.click(screen.getByLabelText("Unpin owner/repo"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
@@ -142,7 +177,7 @@ describe("RepoLockControls — scroll preservation", () => {
     lockRepo("owner/a");
     lockRepo("owner/b");
     render(() => (
-      <RepoLockControls repoFullName="owner/b" />
+      <RepoLockControls repoFullName="owner/b" visibleLockedRepos={["owner/a", "owner/b"]} />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/b up"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
@@ -152,7 +187,7 @@ describe("RepoLockControls — scroll preservation", () => {
     lockRepo("owner/a");
     lockRepo("owner/b");
     render(() => (
-      <RepoLockControls repoFullName="owner/a" />
+      <RepoLockControls repoFullName="owner/a" visibleLockedRepos={["owner/a", "owner/b"]} />
     ));
     fireEvent.click(screen.getByLabelText("Move owner/a down"));
     expect(window.scrollTo).toHaveBeenCalledWith(0, 500);

--- a/tests/stores/view-lock.test.ts
+++ b/tests/stores/view-lock.test.ts
@@ -108,13 +108,22 @@ describe("view lock store", () => {
         expect(viewState.lockedRepos).toEqual(["org/hidden", "org/c", "org/a"]);
       });
 
-      it("skips multiple invisible repos", () => {
+      it("skips multiple invisible repos when moving up", () => {
         lockRepo("org/a");
         lockRepo("org/h1");
         lockRepo("org/h2");
         lockRepo("org/d");
         moveLockedRepo("org/d", "up", new Set(["org/a", "org/d"]));
         expect(viewState.lockedRepos).toEqual(["org/d", "org/a", "org/h1", "org/h2"]);
+      });
+
+      it("skips multiple invisible repos when moving down", () => {
+        lockRepo("org/a");
+        lockRepo("org/h1");
+        lockRepo("org/h2");
+        lockRepo("org/d");
+        moveLockedRepo("org/a", "down", new Set(["org/a", "org/d"]));
+        expect(viewState.lockedRepos).toEqual(["org/h1", "org/h2", "org/d", "org/a"]);
       });
 
       it("no-op when already first visible and moving up", () => {

--- a/tests/stores/view-lock.test.ts
+++ b/tests/stores/view-lock.test.ts
@@ -90,6 +90,64 @@ describe("view lock store", () => {
       moveLockedRepo("org/repo-z", "up");
       expect(viewState.lockedRepos).toEqual(["org/repo-a"]);
     });
+
+    describe("with visibleRepoNames", () => {
+      it("skips one invisible repo when moving up", () => {
+        lockRepo("org/a");
+        lockRepo("org/hidden");
+        lockRepo("org/c");
+        moveLockedRepo("org/c", "up", new Set(["org/a", "org/c"]));
+        expect(viewState.lockedRepos).toEqual(["org/c", "org/a", "org/hidden"]);
+      });
+
+      it("skips one invisible repo when moving down", () => {
+        lockRepo("org/a");
+        lockRepo("org/hidden");
+        lockRepo("org/c");
+        moveLockedRepo("org/a", "down", new Set(["org/a", "org/c"]));
+        expect(viewState.lockedRepos).toEqual(["org/hidden", "org/c", "org/a"]);
+      });
+
+      it("skips multiple invisible repos", () => {
+        lockRepo("org/a");
+        lockRepo("org/h1");
+        lockRepo("org/h2");
+        lockRepo("org/d");
+        moveLockedRepo("org/d", "up", new Set(["org/a", "org/d"]));
+        expect(viewState.lockedRepos).toEqual(["org/d", "org/a", "org/h1", "org/h2"]);
+      });
+
+      it("no-op when already first visible and moving up", () => {
+        lockRepo("org/h1");
+        lockRepo("org/a");
+        lockRepo("org/b");
+        moveLockedRepo("org/a", "up", new Set(["org/a", "org/b"]));
+        expect(viewState.lockedRepos).toEqual(["org/h1", "org/a", "org/b"]);
+      });
+
+      it("no-op when already last visible and moving down", () => {
+        lockRepo("org/a");
+        lockRepo("org/b");
+        lockRepo("org/h1");
+        moveLockedRepo("org/b", "down", new Set(["org/a", "org/b"]));
+        expect(viewState.lockedRepos).toEqual(["org/a", "org/b", "org/h1"]);
+      });
+
+      it("falls back to adjacent swap when visibleRepoNames is undefined", () => {
+        lockRepo("org/a");
+        lockRepo("org/b");
+        lockRepo("org/c");
+        moveLockedRepo("org/c", "up");
+        expect(viewState.lockedRepos).toEqual(["org/a", "org/c", "org/b"]);
+      });
+
+      it("no-op when visibleRepoNames is empty set", () => {
+        lockRepo("org/a");
+        lockRepo("org/b");
+        moveLockedRepo("org/a", "down", new Set());
+        expect(viewState.lockedRepos).toEqual(["org/a", "org/b"]);
+      });
+    });
   });
 
   describe("pruneLockedRepos", () => {


### PR DESCRIPTION
## Summary
- moveLockedRepo gains optional visibleRepoNames param to skip invisible locked repos during reorder
- RepoLockControls uses visible subset for isFirst/isLast disable states
- Each tab derives visibleLockedRepos from its repoGroups memo

Closes #71