### PR TITLE
fix(view): locked repos always visible, de-emphasized when empty

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -350,7 +350,7 @@ The Tracked tab lets you pin issues and PRs into a personal TODO list that you c
 
 ## Repo Pinning
 
-Each repo group header has a pin (lock) control, visible on hover on desktop and always visible on mobile. Pinning a repo keeps it at the top of the list on all tabs regardless of sort order or how recently it was updated.
+Each repo group header has a pin (lock) control, visible on hover on desktop and always visible on mobile. Pinning a repo keeps it at the top of the list on all tabs regardless of sort order or how recently it was updated. Pinned repos remain visible even when filters exclude all their items — they appear as compact, de-emphasized rows with the repo name and pin controls still accessible.
 
 - Click the pin icon to pin a repo to the top.
 - Click it again to unpin.

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -306,6 +306,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                   <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
                     <span class="h-3.5 w-3.5 shrink-0" />
                     <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                    <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
                     <RepoLockControls repoFullName={repoGroup.repoFullName} />
                   </div>
                 }

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -11,7 +11,7 @@ import RepoGroupHeader from "../shared/RepoGroupHeader";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
-import { orderRepoGroups } from "../../lib/grouping";
+import { orderRepoGroups, ensureLockedRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
 
@@ -201,9 +201,15 @@ export default function ActionsTab(props: ActionsTabProps) {
     });
   });
 
-  const repoGroups = createMemo(() =>
-    orderRepoGroups(groupRuns(filteredRuns()), viewState.lockedRepos)
-  );
+  const repoGroups = createMemo(() => {
+    const groups = groupRuns(filteredRuns());
+    const withLocked = ensureLockedRepoGroups(
+      groups,
+      viewState.lockedRepos,
+      (name) => ({ repoFullName: name, workflows: [] }),
+    );
+    return orderRepoGroups(withLocked, viewState.lockedRepos);
+  });
 
   createEffect(() => {
     const names = activeRepoNames();
@@ -271,7 +277,8 @@ export default function ActionsTab(props: ActionsTabProps) {
       <Show when={repoGroups().length > 0}>
         <For each={repoGroups()}>
           {(repoGroup) => {
-            const isExpanded = () => !!viewState.expandedRepos.actions[repoGroup.repoFullName];
+            const isEmpty = () => repoGroup.workflows.length === 0;
+            const isExpanded = () => !isEmpty() && !!viewState.expandedRepos.actions[repoGroup.repoFullName];
 
             const sortedWorkflows = createMemo(() =>
               sortWorkflowsByStatus(repoGroup.workflows)
@@ -293,12 +300,12 @@ export default function ActionsTab(props: ActionsTabProps) {
             });
 
             return (
-              <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
+              <div class={`bg-base-100 ${isEmpty() ? "opacity-50" : ""}`} data-repo-group={repoGroup.repoFullName}>
                 <RepoGroupHeader
                   repoFullName={repoGroup.repoFullName}
                   isExpanded={isExpanded()}
                   isHighlighted={highlightedReposActions().has(repoGroup.repoFullName)}
-                  onToggle={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
+                  onToggle={() => { if (!isEmpty()) toggleExpandedRepo("actions", repoGroup.repoFullName); }}
                   trailing={
                     <>
                       <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
@@ -306,6 +313,14 @@ export default function ActionsTab(props: ActionsTabProps) {
                     </>
                   }
                   collapsedSummary={
+                    <Show
+                      when={!isEmpty()}
+                      fallback={
+                        <span class="ml-auto text-xs font-normal italic text-base-content/40">
+                          No items match current filters
+                        </span>
+                      }
+                    >
                     <span class="ml-auto text-xs font-normal text-base-content/60">
                       {workflowCounts().total} workflow{workflowCounts().total !== 1 ? "s" : ""}
                       <Show when={workflowCounts().passed > 0 || workflowCounts().failed > 0 || workflowCounts().running > 0}>
@@ -327,6 +342,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                         </Show>
                       </Show>
                     </span>
+                    </Show>
                   }
                 />
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -11,6 +11,7 @@ import RepoGroupHeader from "../shared/RepoGroupHeader";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
+import EmptyLockedRepoRow from "../shared/EmptyLockedRepoRow";
 import { orderRepoGroups, ensureLockedRepoGroups } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
@@ -303,89 +304,82 @@ export default function ActionsTab(props: ActionsTabProps) {
               <Show
                 when={!isEmpty()}
                 fallback={
-                  <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                    <span class="flex-1 flex items-center gap-2 px-4 py-1.5 compact:py-0.5">
-                      <span class="h-3.5 w-3.5 shrink-0" />
-                      <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
-                    </span>
-                    <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
-                    <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                  </div>
+                  <EmptyLockedRepoRow repoFullName={repoGroup.repoFullName} section="actions" />
                 }
               >
-              <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
-                <RepoGroupHeader
-                  repoFullName={repoGroup.repoFullName}
-                  isExpanded={isExpanded()}
-                  isHighlighted={highlightedReposActions().has(repoGroup.repoFullName)}
-                  onToggle={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
-                  trailing={
-                    <>
-                      <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
-                      <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                    </>
-                  }
-                  collapsedSummary={
-                    <span class="ml-auto text-xs font-normal text-base-content/60">
-                      {workflowCounts().total} workflow{workflowCounts().total !== 1 ? "s" : ""}
-                      <Show when={workflowCounts().passed > 0 || workflowCounts().failed > 0 || workflowCounts().running > 0}>
-                        {": "}
-                        <Show when={workflowCounts().passed > 0}>
-                          <span>{workflowCounts().passed} passed</span>
+                <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
+                  <RepoGroupHeader
+                    repoFullName={repoGroup.repoFullName}
+                    isExpanded={isExpanded()}
+                    isHighlighted={highlightedReposActions().has(repoGroup.repoFullName)}
+                    onToggle={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
+                    trailing={
+                      <>
+                        <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
+                        <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                      </>
+                    }
+                    collapsedSummary={
+                      <span class="ml-auto text-xs font-normal text-base-content/60">
+                        {workflowCounts().total} workflow{workflowCounts().total !== 1 ? "s" : ""}
+                        <Show when={workflowCounts().passed > 0 || workflowCounts().failed > 0 || workflowCounts().running > 0}>
+                          {": "}
+                          <Show when={workflowCounts().passed > 0}>
+                            <span>{workflowCounts().passed} passed</span>
+                          </Show>
+                          <Show when={workflowCounts().passed > 0 && (workflowCounts().failed > 0 || workflowCounts().running > 0)}>
+                            {", "}
+                          </Show>
+                          <Show when={workflowCounts().failed > 0}>
+                            <span class="text-error font-medium">{workflowCounts().failed} failed</span>
+                          </Show>
+                          <Show when={workflowCounts().failed > 0 && workflowCounts().running > 0}>
+                            {", "}
+                          </Show>
+                          <Show when={workflowCounts().running > 0}>
+                            <span>{workflowCounts().running} running</span>
+                          </Show>
                         </Show>
-                        <Show when={workflowCounts().passed > 0 && (workflowCounts().failed > 0 || workflowCounts().running > 0)}>
-                          {", "}
-                        </Show>
-                        <Show when={workflowCounts().failed > 0}>
-                          <span class="text-error font-medium">{workflowCounts().failed} failed</span>
-                        </Show>
-                        <Show when={workflowCounts().failed > 0 && workflowCounts().running > 0}>
-                          {", "}
-                        </Show>
-                        <Show when={workflowCounts().running > 0}>
-                          <span>{workflowCounts().running} running</span>
-                        </Show>
-                      </Show>
-                    </span>
-                  }
-                />
-                <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
-                  {(peek) => (
-                    <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
-                      <span class="loading loading-spinner loading-xs text-primary/60" />
-                      <span class="truncate flex-1">{peek().itemLabel}</span>
-                      <span class="badge badge-xs badge-primary">{peek().newStatus}</span>
+                      </span>
+                    }
+                  />
+                  <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
+                    {(peek) => (
+                      <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
+                        <span class="loading loading-spinner loading-xs text-primary/60" />
+                        <span class="truncate flex-1">{peek().itemLabel}</span>
+                        <span class="badge badge-xs badge-primary">{peek().newStatus}</span>
+                      </div>
+                    )}
+                  </Show>
+
+                  {/* Workflow cards grid */}
+                  <Show when={isExpanded()}>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-3">
+                      <For each={sortedWorkflows()}>
+                        {(wfGroup) => {
+                          const wfKey = `${repoGroup.repoFullName}:${wfGroup.workflowId}`;
+                          const isWfExpanded = () => !!expandedWorkflows[wfKey];
+
+                          return (
+                            <div class={isWfExpanded() ? "col-span-full" : ""}>
+                              <WorkflowSummaryCard
+                                workflowName={wfGroup.workflowName}
+                                runs={wfGroup.runs}
+                                expanded={isWfExpanded()}
+                                onToggle={() => toggleWorkflow(wfKey)}
+                                onIgnoreRun={handleIgnore}
+                                refreshTick={props.refreshTick}
+                                hotPollingRunIds={props.hotPollingRunIds}
+                                flashingRunIds={flashingRunIds()}
+                              />
+                            </div>
+                          );
+                        }}
+                      </For>
                     </div>
-                  )}
-                </Show>
-
-                {/* Workflow cards grid */}
-                <Show when={isExpanded()}>
-                  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-3">
-                    <For each={sortedWorkflows()}>
-                      {(wfGroup) => {
-                        const wfKey = `${repoGroup.repoFullName}:${wfGroup.workflowId}`;
-                        const isWfExpanded = () => !!expandedWorkflows[wfKey];
-
-                        return (
-                          <div class={isWfExpanded() ? "col-span-full" : ""}>
-                            <WorkflowSummaryCard
-                              workflowName={wfGroup.workflowName}
-                              runs={wfGroup.runs}
-                              expanded={isWfExpanded()}
-                              onToggle={() => toggleWorkflow(wfKey)}
-                              onIgnoreRun={handleIgnore}
-                              refreshTick={props.refreshTick}
-                              hotPollingRunIds={props.hotPollingRunIds}
-                              flashingRunIds={flashingRunIds()}
-                            />
-                          </div>
-                        );
-                      }}
-                    </For>
-                  </div>
-                </Show>
-              </div>
+                  </Show>
+                </div>
               </Show>
             );
           }}

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -303,7 +303,8 @@ export default function ActionsTab(props: ActionsTabProps) {
               <Show
                 when={!isEmpty()}
                 fallback={
-                  <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                  <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                    <span class="h-3.5 w-3.5 shrink-0" />
                     <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                     <RepoLockControls repoFullName={repoGroup.repoFullName} />
                   </div>

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -300,12 +300,21 @@ export default function ActionsTab(props: ActionsTabProps) {
             });
 
             return (
-              <div class={`bg-base-100 ${isEmpty() ? "opacity-50" : ""}`} data-repo-group={repoGroup.repoFullName}>
+              <Show
+                when={!isEmpty()}
+                fallback={
+                  <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                    <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                    <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                  </div>
+                }
+              >
+              <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
                 <RepoGroupHeader
                   repoFullName={repoGroup.repoFullName}
                   isExpanded={isExpanded()}
                   isHighlighted={highlightedReposActions().has(repoGroup.repoFullName)}
-                  onToggle={() => { if (!isEmpty()) toggleExpandedRepo("actions", repoGroup.repoFullName); }}
+                  onToggle={() => toggleExpandedRepo("actions", repoGroup.repoFullName)}
                   trailing={
                     <>
                       <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
@@ -313,14 +322,6 @@ export default function ActionsTab(props: ActionsTabProps) {
                     </>
                   }
                   collapsedSummary={
-                    <Show
-                      when={!isEmpty()}
-                      fallback={
-                        <span class="ml-auto text-xs font-normal italic text-base-content/40">
-                          No items match current filters
-                        </span>
-                      }
-                    >
                     <span class="ml-auto text-xs font-normal text-base-content/60">
                       {workflowCounts().total} workflow{workflowCounts().total !== 1 ? "s" : ""}
                       <Show when={workflowCounts().passed > 0 || workflowCounts().failed > 0 || workflowCounts().running > 0}>
@@ -342,7 +343,6 @@ export default function ActionsTab(props: ActionsTabProps) {
                         </Show>
                       </Show>
                     </span>
-                    </Show>
                   }
                 />
                 <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
@@ -382,6 +382,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                   </div>
                 </Show>
               </div>
+              </Show>
             );
           }}
         </For>

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -303,7 +303,7 @@ export default function ActionsTab(props: ActionsTabProps) {
               <Show
                 when={!isEmpty()}
                 fallback={
-                  <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                  <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
                     <span class="h-3.5 w-3.5 shrink-0" />
                     <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                     <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -303,9 +303,11 @@ export default function ActionsTab(props: ActionsTabProps) {
               <Show
                 when={!isEmpty()}
                 fallback={
-                  <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                    <span class="h-3.5 w-3.5 shrink-0" />
-                    <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                  <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                    <span class="flex-1 flex items-center gap-2 px-4 py-1">
+                      <span class="h-3.5 w-3.5 shrink-0" />
+                      <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                    </span>
                     <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="actions" />
                     <RepoLockControls repoFullName={repoGroup.repoFullName} />
                   </div>

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -263,10 +263,10 @@ export default function ActionsTab(props: ActionsTabProps) {
         <SkeletonRows label="Loading workflow runs" />
       </Show>
 
-      {/* Empty */}
+      {/* Empty — only when no groups exist at all (locked stubs are handled by EmptyLockedRepoRow) */}
       <Show
         when={
-          !props.loading && repoGroups().length === 0
+          (!props.loading || props.workflowRuns.length > 0) && repoGroups().length === 0
         }
       >
         <div class="p-8 text-center text-base-content/50">
@@ -275,7 +275,7 @@ export default function ActionsTab(props: ActionsTabProps) {
       </Show>
 
       {/* Repo groups */}
-      <Show when={repoGroups().length > 0}>
+      <Show when={(!props.loading || props.workflowRuns.length > 0) && repoGroups().length > 0}>
         <For each={repoGroups()}>
           {(repoGroup) => {
             const isEmpty = () => repoGroup.workflows.length === 0;

--- a/src/app/components/dashboard/ActionsTab.tsx
+++ b/src/app/components/dashboard/ActionsTab.tsx
@@ -304,7 +304,7 @@ export default function ActionsTab(props: ActionsTabProps) {
                 when={!isEmpty()}
                 fallback={
                   <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                    <span class="flex-1 flex items-center gap-2 px-4 py-1">
+                    <span class="flex-1 flex items-center gap-2 px-4 py-1.5 compact:py-0.5">
                       <span class="h-3.5 w-3.5 shrink-0" />
                       <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                     </span>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -361,7 +361,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                     when={!isEmpty()}
                     fallback={
                       <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                        <span class="flex-1 flex items-center gap-2 px-4 py-1">
+                        <span class="flex-1 flex items-center gap-2 px-4 py-1.5 compact:py-0.5">
                           <span class="h-3.5 w-3.5 shrink-0" />
                           <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                         </span>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -357,13 +357,22 @@ export default function IssuesTab(props: IssuesTabProps) {
                 });
 
                 return (
-                  <div class={`bg-base-100 ${isEmpty() ? "opacity-50" : ""}`} data-repo-group={repoGroup.repoFullName}>
+                  <Show
+                    when={!isEmpty()}
+                    fallback={
+                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                        <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                        <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                      </div>
+                    }
+                  >
+                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
                     <RepoGroupHeader
                       repoFullName={repoGroup.repoFullName}
                       starCount={repoGroup.starCount}
                       isExpanded={isExpanded()}
                       isHighlighted={highlightedReposIssues().has(repoGroup.repoFullName)}
-                      onToggle={() => { if (!isEmpty()) toggleExpandedRepo("issues", repoGroup.repoFullName); }}
+                      onToggle={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
                       badges={
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <Tooltip content="Showing all activity, not just yours" focusable>
@@ -378,29 +387,20 @@ export default function IssuesTab(props: IssuesTabProps) {
                         </>
                       }
                       collapsedSummary={
-                        <Show
-                          when={!isEmpty()}
-                          fallback={
-                            <span class="ml-auto text-xs font-normal italic text-base-content/40">
-                              No items match current filters
-                            </span>
-                          }
-                        >
-                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
-                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
-                            <For each={roleSummary()}>
-                              {([role, count]) => (
-                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                  role === "author" ? "bg-primary/10 text-primary" :
-                                  role === "assignee" ? "bg-secondary/10 text-secondary" :
-                                  "bg-base-300 text-base-content/70"
-                                }`}>
-                                  {role} ×{count}
-                                </span>
-                              )}
-                            </For>
-                          </span>
-                        </Show>
+                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
+                          <For each={roleSummary()}>
+                            {([role, count]) => (
+                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                role === "author" ? "bg-primary/10 text-primary" :
+                                role === "assignee" ? "bg-secondary/10 text-secondary" :
+                                "bg-base-300 text-base-content/70"
+                              }`}>
+                                {role} ×{count}
+                              </span>
+                            )}
+                          </For>
+                        </span>
                       }
                     />
                     <Show when={isExpanded()}>
@@ -444,6 +444,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                       </div>
                     </Show>
                   </div>
+                  </Show>
                 );
               }}
             </For>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -360,9 +360,11 @@ export default function IssuesTab(props: IssuesTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                        <span class="h-3.5 w-3.5 shrink-0" />
-                        <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                        <span class="flex-1 flex items-center gap-2 px-4 py-1">
+                          <span class="h-3.5 w-3.5 shrink-0" />
+                          <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                        </span>
                         <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
                         <RepoLockControls repoFullName={repoGroup.repoFullName} />
                       </div>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -360,7 +360,8 @@ export default function IssuesTab(props: IssuesTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                        <span class="h-3.5 w-3.5 shrink-0" />
                         <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                         <RepoLockControls repoFullName={repoGroup.repoFullName} />
                       </div>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -363,6 +363,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                       <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
                         <span class="h-3.5 w-3.5 shrink-0" />
                         <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                        <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
                         <RepoLockControls repoFullName={repoGroup.repoFullName} />
                       </div>
                     }

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -360,7 +360,7 @@ export default function IssuesTab(props: IssuesTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
                         <span class="h-3.5 w-3.5 shrink-0" />
                         <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                         <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -17,6 +17,7 @@ import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, ensur
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
+import EmptyLockedRepoRow from "../shared/EmptyLockedRepoRow";
 import { Tooltip } from "../shared/Tooltip";
 
 export interface IssuesTabProps {
@@ -306,40 +307,39 @@ export default function IssuesTab(props: IssuesTabProps) {
         <SkeletonRows label="Loading issues" />
       </Show>
 
+      {/* Empty — only when no groups exist at all (locked stubs are handled by EmptyLockedRepoRow) */}
+      <Show when={(!props.loading || props.issues.length > 0) && pageGroups().length === 0}>
+        <div class="flex flex-col items-center justify-center gap-2 py-16 text-base-content/50">
+          <svg
+            class="h-10 w-10 opacity-40"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
+          </svg>
+          <p class="text-sm font-medium">
+            {viewState.tabFilters.issues.scope === "all" ? "No open issues found" : "No open issues involving you"}
+          </p>
+          <p class="text-xs">
+            {viewState.tabFilters.issues.scope === "all"
+              ? "No issues match your current filters."
+              : "Issues where you are the author, assignee, or mentioned will appear here."}
+          </p>
+        </div>
+      </Show>
+
       {/* Issue rows */}
-      <Show when={!props.loading || props.issues.length > 0}>
-        <Show
-          when={pageGroups().length > 0}
-          fallback={
-            <div class="flex flex-col items-center justify-center gap-2 py-16 text-base-content/50">
-              <svg
-                class="h-10 w-10 opacity-40"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-                />
-              </svg>
-              <p class="text-sm font-medium">
-                {viewState.tabFilters.issues.scope === "all" ? "No open issues found" : "No open issues involving you"}
-              </p>
-              <p class="text-xs">
-                {viewState.tabFilters.issues.scope === "all"
-                  ? "No issues match your current filters."
-                  : "Issues where you are the author, assignee, or mentioned will appear here."}
-              </p>
-            </div>
-          }
-        >
-          <div class="divide-y divide-base-300">
-            <For each={pageGroups()}>
-              {(repoGroup) => {
+      <Show when={(!props.loading || props.issues.length > 0) && pageGroups().length > 0}>
+        <div class="divide-y divide-base-300">
+          <For each={pageGroups()}>
+            {(repoGroup) => {
                 const isEmpty = () => repoGroup.items.length === 0;
                 const isExpanded = () => !isEmpty() && !!viewState.expandedRepos.issues[repoGroup.repoFullName];
 
@@ -360,100 +360,92 @@ export default function IssuesTab(props: IssuesTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                        <span class="flex-1 flex items-center gap-2 px-4 py-1.5 compact:py-0.5">
-                          <span class="h-3.5 w-3.5 shrink-0" />
-                          <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
-                        </span>
-                        <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
-                        <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                      </div>
+                      <EmptyLockedRepoRow repoFullName={repoGroup.repoFullName} section="issues" />
                     }
                   >
-                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
-                    <RepoGroupHeader
-                      repoFullName={repoGroup.repoFullName}
-                      starCount={repoGroup.starCount}
-                      isExpanded={isExpanded()}
-                      isHighlighted={highlightedReposIssues().has(repoGroup.repoFullName)}
-                      onToggle={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
-                      badges={
-                        <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
-                          <Tooltip content="Showing all activity, not just yours" focusable>
-                            <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
-                          </Tooltip>
-                        </Show>
-                      }
-                      trailing={
-                        <>
-                          <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
-                          <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                        </>
-                      }
-                      collapsedSummary={
-                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
-                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
-                          <For each={roleSummary()}>
-                            {([role, count]) => (
-                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                role === "author" ? "bg-primary/10 text-primary" :
-                                role === "assignee" ? "bg-secondary/10 text-secondary" :
-                                "bg-base-300 text-base-content/70"
-                              }`}>
-                                {role} ×{count}
-                              </span>
+                    <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
+                      <RepoGroupHeader
+                        repoFullName={repoGroup.repoFullName}
+                        starCount={repoGroup.starCount}
+                        isExpanded={isExpanded()}
+                        isHighlighted={highlightedReposIssues().has(repoGroup.repoFullName)}
+                        onToggle={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
+                        badges={
+                          <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
+                            <Tooltip content="Showing all activity, not just yours" focusable>
+                              <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                            </Tooltip>
+                          </Show>
+                        }
+                        trailing={
+                          <>
+                            <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="issues" />
+                            <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                          </>
+                        }
+                        collapsedSummary={
+                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
+                            <For each={roleSummary()}>
+                              {([role, count]) => (
+                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                  role === "author" ? "bg-primary/10 text-primary" :
+                                  role === "assignee" ? "bg-secondary/10 text-secondary" :
+                                  "bg-base-300 text-base-content/70"
+                                }`}>
+                                  {role} ×{count}
+                                </span>
+                              )}
+                            </For>
+                          </span>
+                        }
+                      />
+                      <Show when={isExpanded()}>
+                        <div role="list" class="divide-y divide-base-300">
+                          <For each={repoGroup.items}>
+                            {(issue) => (
+                              <div role="listitem" class={
+                                viewState.tabFilters.issues.scope === "all" && isInvolvedItem(issue)
+                                  ? "border-l-2 border-l-primary"
+                                  : undefined
+                              }>
+                                <ItemRow
+                                  hideRepo={true}
+                                  repo={issue.repoFullName}
+                                  number={issue.number}
+                                  title={issue.title}
+                                  author={issue.userLogin}
+                                  createdAt={issue.createdAt}
+                                  updatedAt={issue.updatedAt}
+                                  refreshTick={props.refreshTick}
+                                  url={issue.htmlUrl}
+                                  labels={issue.labels}
+                                  onIgnore={() => handleIgnore(issue)}
+                                  onTrack={config.enableTracking ? () => handleTrack(issue) : undefined}
+                                  isTracked={config.enableTracking ? trackedIssueIds().has(issue.id) : undefined}
+                                  commentCount={issue.comments}
+                                  surfacedByBadge={
+                                    props.trackedUsers && props.trackedUsers.length > 0
+                                      ? <UserAvatarBadge
+                                          users={buildSurfacedByUsers(issue.surfacedBy, trackedUserMap())}
+                                          currentUserLogin={props.userLogin}
+                                        />
+                                      : undefined
+                                  }
+                                >
+                                  <RoleBadge roles={issueMeta().get(issue.id)?.roles ?? []} />
+                                </ItemRow>
+                              </div>
                             )}
                           </For>
-                        </span>
-                      }
-                    />
-                    <Show when={isExpanded()}>
-                      <div role="list" class="divide-y divide-base-300">
-                        <For each={repoGroup.items}>
-                          {(issue) => (
-                            <div role="listitem" class={
-                              viewState.tabFilters.issues.scope === "all" && isInvolvedItem(issue)
-                                ? "border-l-2 border-l-primary"
-                                : undefined
-                            }>
-                              <ItemRow
-                                hideRepo={true}
-                                repo={issue.repoFullName}
-                                number={issue.number}
-                                title={issue.title}
-                                author={issue.userLogin}
-                                createdAt={issue.createdAt}
-                                updatedAt={issue.updatedAt}
-                                refreshTick={props.refreshTick}
-                                url={issue.htmlUrl}
-                                labels={issue.labels}
-                                onIgnore={() => handleIgnore(issue)}
-                                onTrack={config.enableTracking ? () => handleTrack(issue) : undefined}
-                                isTracked={config.enableTracking ? trackedIssueIds().has(issue.id) : undefined}
-                                commentCount={issue.comments}
-                                surfacedByBadge={
-                                  props.trackedUsers && props.trackedUsers.length > 0
-                                    ? <UserAvatarBadge
-                                        users={buildSurfacedByUsers(issue.surfacedBy, trackedUserMap())}
-                                        currentUserLogin={props.userLogin}
-                                      />
-                                    : undefined
-                                }
-                              >
-                                <RoleBadge roles={issueMeta().get(issue.id)?.roles ?? []} />
-                              </ItemRow>
-                            </div>
-                          )}
-                        </For>
-                      </div>
-                    </Show>
-                  </div>
+                        </div>
+                      </Show>
+                    </div>
                   </Show>
                 );
-              }}
-            </For>
-          </div>
-        </Show>
+            }}
+          </For>
+        </div>
       </Show>
 
       <Show when={!props.loading || props.issues.length > 0}>

--- a/src/app/components/dashboard/IssuesTab.tsx
+++ b/src/app/components/dashboard/IssuesTab.tsx
@@ -13,7 +13,7 @@ import SkeletonRows from "../shared/SkeletonRows";
 import ExpandCollapseButtons from "../shared/ExpandCollapseButtons";
 import { deriveInvolvementRoles } from "../../lib/format";
 import RepoGroupHeader from "../shared/RepoGroupHeader";
-import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, isUserInvolved } from "../../lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, ensureLockedRepoGroups, isUserInvolved } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
@@ -191,9 +191,15 @@ export default function IssuesTab(props: IssuesTabProps) {
   const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
   const issueMeta = createMemo(() => filteredSortedWithMeta().meta);
 
-  const repoGroups = createMemo(() =>
-    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos)
-  );
+  const repoGroups = createMemo(() => {
+    const groups = groupByRepo(filteredSorted());
+    const withLocked = ensureLockedRepoGroups(
+      groups,
+      viewState.lockedRepos,
+      (name) => ({ repoFullName: name, items: [] as typeof groups[0]["items"] }),
+    );
+    return orderRepoGroups(withLocked, viewState.lockedRepos);
+  });
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
@@ -334,7 +340,8 @@ export default function IssuesTab(props: IssuesTabProps) {
           <div class="divide-y divide-base-300">
             <For each={pageGroups()}>
               {(repoGroup) => {
-                const isExpanded = () => !!viewState.expandedRepos.issues[repoGroup.repoFullName];
+                const isEmpty = () => repoGroup.items.length === 0;
+                const isExpanded = () => !isEmpty() && !!viewState.expandedRepos.issues[repoGroup.repoFullName];
 
                 const roleSummary = createMemo(() => {
                   const counts: Record<string, number> = {};
@@ -350,13 +357,13 @@ export default function IssuesTab(props: IssuesTabProps) {
                 });
 
                 return (
-                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
+                  <div class={`bg-base-100 ${isEmpty() ? "opacity-50" : ""}`} data-repo-group={repoGroup.repoFullName}>
                     <RepoGroupHeader
                       repoFullName={repoGroup.repoFullName}
                       starCount={repoGroup.starCount}
                       isExpanded={isExpanded()}
                       isHighlighted={highlightedReposIssues().has(repoGroup.repoFullName)}
-                      onToggle={() => toggleExpandedRepo("issues", repoGroup.repoFullName)}
+                      onToggle={() => { if (!isEmpty()) toggleExpandedRepo("issues", repoGroup.repoFullName); }}
                       badges={
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <Tooltip content="Showing all activity, not just yours" focusable>
@@ -371,20 +378,29 @@ export default function IssuesTab(props: IssuesTabProps) {
                         </>
                       }
                       collapsedSummary={
-                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
-                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
-                          <For each={roleSummary()}>
-                            {([role, count]) => (
-                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                role === "author" ? "bg-primary/10 text-primary" :
-                                role === "assignee" ? "bg-secondary/10 text-secondary" :
-                                "bg-base-300 text-base-content/70"
-                              }`}>
-                                {role} ×{count}
-                              </span>
-                            )}
-                          </For>
-                        </span>
+                        <Show
+                          when={!isEmpty()}
+                          fallback={
+                            <span class="ml-auto text-xs font-normal italic text-base-content/40">
+                              No items match current filters
+                            </span>
+                          }
+                        >
+                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60">
+                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "issue" : "issues"}</span>
+                            <For each={roleSummary()}>
+                              {([role, count]) => (
+                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                  role === "author" ? "bg-primary/10 text-primary" :
+                                  role === "assignee" ? "bg-secondary/10 text-secondary" :
+                                  "bg-base-300 text-base-content/70"
+                                }`}>
+                                  {role} ×{count}
+                                </span>
+                              )}
+                            </For>
+                          </span>
+                        </Show>
                       }
                     />
                     <Show when={isExpanded()}>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -468,7 +468,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                     when={!isEmpty()}
                     fallback={
                       <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                        <span class="flex-1 flex items-center gap-2 px-4 py-1">
+                        <span class="flex-1 flex items-center gap-2 px-4 py-1.5 compact:py-0.5">
                           <span class="h-3.5 w-3.5 shrink-0" />
                           <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                         </span>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -17,7 +17,7 @@ import SizeBadge from "../shared/SizeBadge";
 import RoleBadge from "../shared/RoleBadge";
 import SkeletonRows from "../shared/SkeletonRows";
 import RepoGroupHeader from "../shared/RepoGroupHeader";
-import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, isUserInvolved } from "../../lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, orderRepoGroups, ensureLockedRepoGroups, isUserInvolved } from "../../lib/grouping";
 import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
 import RepoLockControls from "../shared/RepoLockControls";
@@ -288,9 +288,15 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
   const filteredSorted = createMemo(() => filteredSortedWithMeta().items);
   const prMeta = createMemo(() => filteredSortedWithMeta().meta);
 
-  const repoGroups = createMemo(() =>
-    orderRepoGroups(groupByRepo(filteredSorted()), viewState.lockedRepos)
-  );
+  const repoGroups = createMemo(() => {
+    const groups = groupByRepo(filteredSorted());
+    const withLocked = ensureLockedRepoGroups(
+      groups,
+      viewState.lockedRepos,
+      (name) => ({ repoFullName: name, items: [] as typeof groups[0]["items"] }),
+    );
+    return orderRepoGroups(withLocked, viewState.lockedRepos);
+  });
   const pageLayout = createMemo(() => computePageLayout(repoGroups(), config.itemsPerPage));
   const pageCount = createMemo(() => pageLayout().pageCount);
   const pageGroups = createMemo(() =>
@@ -428,7 +434,8 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
           <div class="divide-y divide-base-300">
             <For each={pageGroups()}>
               {(repoGroup) => {
-                const isExpanded = () => !!viewState.expandedRepos.pullRequests[repoGroup.repoFullName];
+                const isEmpty = () => repoGroup.items.length === 0;
+                const isExpanded = () => !isEmpty() && !!viewState.expandedRepos.pullRequests[repoGroup.repoFullName];
 
                 const summaryMeta = createMemo(() => {
                   const checks = { success: 0, failure: 0, pending: 0, conflict: 0 };
@@ -457,13 +464,13 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                 });
 
                 return (
-                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
+                  <div class={`bg-base-100 ${isEmpty() ? "opacity-50" : ""}`} data-repo-group={repoGroup.repoFullName}>
                     <RepoGroupHeader
                       repoFullName={repoGroup.repoFullName}
                       starCount={repoGroup.starCount}
                       isExpanded={isExpanded()}
                       isHighlighted={highlightedReposPRs().has(repoGroup.repoFullName)}
-                      onToggle={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
+                      onToggle={() => { if (!isEmpty()) toggleExpandedRepo("pullRequests", repoGroup.repoFullName); }}
                       badges={
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <Tooltip content="Showing all activity, not just yours" focusable>
@@ -478,6 +485,14 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         </>
                       }
                       collapsedSummary={
+                        <Show
+                          when={!isEmpty()}
+                          fallback={
+                            <span class="ml-auto text-xs font-normal italic text-base-content/40">
+                              No items match current filters
+                            </span>
+                          }
+                        >
                         <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
                           <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
                           <Show when={summaryMeta().checks.success > 0}>
@@ -534,6 +549,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                             )}
                           </For>
                         </span>
+                        </Show>
                       }
                     />
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -464,13 +464,22 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                 });
 
                 return (
-                  <div class={`bg-base-100 ${isEmpty() ? "opacity-50" : ""}`} data-repo-group={repoGroup.repoFullName}>
+                  <Show
+                    when={!isEmpty()}
+                    fallback={
+                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                        <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                        <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                      </div>
+                    }
+                  >
+                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
                     <RepoGroupHeader
                       repoFullName={repoGroup.repoFullName}
                       starCount={repoGroup.starCount}
                       isExpanded={isExpanded()}
                       isHighlighted={highlightedReposPRs().has(repoGroup.repoFullName)}
-                      onToggle={() => { if (!isEmpty()) toggleExpandedRepo("pullRequests", repoGroup.repoFullName); }}
+                      onToggle={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
                       badges={
                         <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
                           <Tooltip content="Showing all activity, not just yours" focusable>
@@ -485,14 +494,6 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                         </>
                       }
                       collapsedSummary={
-                        <Show
-                          when={!isEmpty()}
-                          fallback={
-                            <span class="ml-auto text-xs font-normal italic text-base-content/40">
-                              No items match current filters
-                            </span>
-                          }
-                        >
                         <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
                           <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
                           <Show when={summaryMeta().checks.success > 0}>
@@ -549,7 +550,6 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                             )}
                           </For>
                         </span>
-                        </Show>
                       }
                     />
                     <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
@@ -667,6 +667,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                       </div>
                     </Show>
                   </div>
+                  </Show>
                 );
               }}
             </For>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -467,7 +467,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
                         <span class="h-3.5 w-3.5 shrink-0" />
                         <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                         <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -467,7 +467,8 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                      <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                        <span class="h-3.5 w-3.5 shrink-0" />
                         <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
                         <RepoLockControls repoFullName={repoGroup.repoFullName} />
                       </div>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -467,9 +467,11 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                        <span class="h-3.5 w-3.5 shrink-0" />
-                        <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
+                        <span class="flex-1 flex items-center gap-2 px-4 py-1">
+                          <span class="h-3.5 w-3.5 shrink-0" />
+                          <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                        </span>
                         <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
                         <RepoLockControls repoFullName={repoGroup.repoFullName} />
                       </div>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -22,6 +22,7 @@ import { createReorderHighlight } from "../../lib/reorderHighlight";
 import { createFlashDetection } from "../../lib/flashDetection";
 import RepoLockControls from "../shared/RepoLockControls";
 import RepoGitHubLink from "../shared/RepoGitHubLink";
+import EmptyLockedRepoRow from "../shared/EmptyLockedRepoRow";
 import { Tooltip } from "../shared/Tooltip";
 
 export interface PullRequestsTabProps {
@@ -400,40 +401,39 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
         <SkeletonRows label="Loading pull requests" />
       </Show>
 
+      {/* Empty — only when no groups exist at all (locked stubs are handled by EmptyLockedRepoRow) */}
+      <Show when={(!props.loading || props.pullRequests.length > 0) && pageGroups().length === 0}>
+        <div class="flex flex-col items-center justify-center gap-2 py-16 text-base-content/50">
+          <svg
+            class="h-10 w-10 opacity-40"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M8 7h8m-8 5h5m-5 5h8M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z"
+            />
+          </svg>
+          <p class="text-sm font-medium">
+            {viewState.tabFilters.pullRequests.scope === "all" ? "No open pull requests found" : "No open pull requests involving you"}
+          </p>
+          <p class="text-xs">
+            {viewState.tabFilters.pullRequests.scope === "all"
+              ? "No pull requests match your current filters."
+              : "PRs where you are the author, assignee, or reviewer will appear here."}
+          </p>
+        </div>
+      </Show>
+
       {/* PR rows */}
-      <Show when={!props.loading || props.pullRequests.length > 0}>
-        <Show
-          when={pageGroups().length > 0}
-          fallback={
-            <div class="flex flex-col items-center justify-center gap-2 py-16 text-base-content/50">
-              <svg
-                class="h-10 w-10 opacity-40"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                  d="M8 7h8m-8 5h5m-5 5h8M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z"
-                />
-              </svg>
-              <p class="text-sm font-medium">
-                {viewState.tabFilters.pullRequests.scope === "all" ? "No open pull requests found" : "No open pull requests involving you"}
-              </p>
-              <p class="text-xs">
-                {viewState.tabFilters.pullRequests.scope === "all"
-                  ? "No pull requests match your current filters."
-                  : "PRs where you are the author, assignee, or reviewer will appear here."}
-              </p>
-            </div>
-          }
-        >
-          <div class="divide-y divide-base-300">
-            <For each={pageGroups()}>
-              {(repoGroup) => {
+      <Show when={(!props.loading || props.pullRequests.length > 0) && pageGroups().length > 0}>
+        <div class="divide-y divide-base-300">
+          <For each={pageGroups()}>
+            {(repoGroup) => {
                 const isEmpty = () => repoGroup.items.length === 0;
                 const isExpanded = () => !isEmpty() && !!viewState.expandedRepos.pullRequests[repoGroup.repoFullName];
 
@@ -467,108 +467,101 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                   <Show
                     when={!isEmpty()}
                     fallback={
-                      <div class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40" data-repo-group={repoGroup.repoFullName}>
-                        <span class="flex-1 flex items-center gap-2 px-4 py-1.5 compact:py-0.5">
-                          <span class="h-3.5 w-3.5 shrink-0" />
-                          <span class="text-sm text-base-content/60">{repoGroup.repoFullName}</span>
-                        </span>
-                        <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
-                        <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                      </div>
+                      <EmptyLockedRepoRow repoFullName={repoGroup.repoFullName} section="pulls" />
                     }
                   >
-                  <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
-                    <RepoGroupHeader
-                      repoFullName={repoGroup.repoFullName}
-                      starCount={repoGroup.starCount}
-                      isExpanded={isExpanded()}
-                      isHighlighted={highlightedReposPRs().has(repoGroup.repoFullName)}
-                      onToggle={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
-                      badges={
-                        <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
-                          <Tooltip content="Showing all activity, not just yours" focusable>
-                            <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
-                          </Tooltip>
-                        </Show>
-                      }
-                      trailing={
-                        <>
-                          <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
-                          <RepoLockControls repoFullName={repoGroup.repoFullName} />
-                        </>
-                      }
-                      collapsedSummary={
-                        <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
-                          <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
-                          <Show when={summaryMeta().checks.success > 0}>
-                            <span class="flex items-center gap-0.5">
-                              <span class="inline-block w-2 h-2 rounded-full bg-success" />
-                              <span>{summaryMeta().checks.success}</span>
-                            </span>
+                    <div class="bg-base-100" data-repo-group={repoGroup.repoFullName}>
+                      <RepoGroupHeader
+                        repoFullName={repoGroup.repoFullName}
+                        starCount={repoGroup.starCount}
+                        isExpanded={isExpanded()}
+                        isHighlighted={highlightedReposPRs().has(repoGroup.repoFullName)}
+                        onToggle={() => toggleExpandedRepo("pullRequests", repoGroup.repoFullName)}
+                        badges={
+                          <Show when={monitoredRepoNameSet().has(repoGroup.repoFullName)}>
+                            <Tooltip content="Showing all activity, not just yours" focusable>
+                              <span class="badge badge-xs badge-ghost" aria-label="monitoring all activity">Monitoring all</span>
+                            </Tooltip>
                           </Show>
-                          <Show when={summaryMeta().checks.failure > 0}>
-                            <span class="flex items-center gap-0.5">
-                              <span class="inline-block w-2 h-2 rounded-full bg-error" />
-                              <span>{summaryMeta().checks.failure}</span>
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().checks.pending > 0}>
-                            <span class="flex items-center gap-0.5">
-                              <span class="inline-block w-2 h-2 rounded-full bg-warning" />
-                              <span>{summaryMeta().checks.pending}</span>
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().checks.conflict > 0}>
-                            <span class="badge badge-warning badge-sm gap-0.5">
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                              </svg>
-                              {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().reviews.APPROVED > 0}>
-                            <span class="badge badge-success badge-sm">
-                              {`Approved ×${summaryMeta().reviews.APPROVED}`}
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
-                            <span class="badge badge-warning badge-sm">
-                              {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
-                            </span>
-                          </Show>
-                          <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
-                            <span class="badge badge-info badge-sm">
-                              {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
-                            </span>
-                          </Show>
-                          <For each={summaryMeta().roles}>
-                            {([role, count]) => (
-                              <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                                role === "author" ? "bg-primary/10 text-primary" :
-                                role === "reviewer" ? "bg-secondary/10 text-secondary" :
-                                role === "assignee" ? "bg-accent/10 text-accent" :
-                                "bg-base-300 text-base-content/70"
-                              }`}>
-                                {`${role} ×${count}`}
+                        }
+                        trailing={
+                          <>
+                            <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
+                            <RepoLockControls repoFullName={repoGroup.repoFullName} />
+                          </>
+                        }
+                        collapsedSummary={
+                          <span class="ml-auto flex items-center gap-2 text-xs font-normal text-base-content/60 shrink-0">
+                            <span>{repoGroup.items.length} {repoGroup.items.length === 1 ? "PR" : "PRs"}</span>
+                            <Show when={summaryMeta().checks.success > 0}>
+                              <span class="flex items-center gap-0.5">
+                                <span class="inline-block w-2 h-2 rounded-full bg-success" />
+                                <span>{summaryMeta().checks.success}</span>
                               </span>
-                            )}
-                          </For>
-                        </span>
-                      }
-                    />
-                    <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
-                      {(peek) => (
-                        <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
-                          <span class="loading loading-spinner loading-xs text-primary/60" />
-                          <span class="truncate flex-1">{peek().itemLabel}</span>
-                          <span class="badge badge-xs badge-primary">{peek().newStatus}</span>
-                        </div>
-                      )}
-                    </Show>
-                    <Show when={isExpanded()}>
-                      <div role="list" class="divide-y divide-base-300">
-                        <For each={repoGroup.items}>
-                          {(pr) => (
+                            </Show>
+                            <Show when={summaryMeta().checks.failure > 0}>
+                              <span class="flex items-center gap-0.5">
+                                <span class="inline-block w-2 h-2 rounded-full bg-error" />
+                                <span>{summaryMeta().checks.failure}</span>
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().checks.pending > 0}>
+                              <span class="flex items-center gap-0.5">
+                                <span class="inline-block w-2 h-2 rounded-full bg-warning" />
+                                <span>{summaryMeta().checks.pending}</span>
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().checks.conflict > 0}>
+                              <span class="badge badge-warning badge-sm gap-0.5">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                  <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                                </svg>
+                                {summaryMeta().checks.conflict === 1 ? "Conflict" : `Conflicts ×${summaryMeta().checks.conflict}`}
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().reviews.APPROVED > 0}>
+                              <span class="badge badge-success badge-sm">
+                                {`Approved ×${summaryMeta().reviews.APPROVED}`}
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().reviews.CHANGES_REQUESTED > 0}>
+                              <span class="badge badge-warning badge-sm">
+                                {`Changes ×${summaryMeta().reviews.CHANGES_REQUESTED}`}
+                              </span>
+                            </Show>
+                            <Show when={summaryMeta().reviews.REVIEW_REQUIRED > 0}>
+                              <span class="badge badge-info badge-sm">
+                                {`Needs review ×${summaryMeta().reviews.REVIEW_REQUIRED}`}
+                              </span>
+                            </Show>
+                            <For each={summaryMeta().roles}>
+                              {([role, count]) => (
+                                <span class={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                                  role === "author" ? "bg-primary/10 text-primary" :
+                                  role === "reviewer" ? "bg-secondary/10 text-secondary" :
+                                  role === "assignee" ? "bg-accent/10 text-accent" :
+                                  "bg-base-300 text-base-content/70"
+                                }`}>
+                                  {`${role} ×${count}`}
+                                </span>
+                              )}
+                            </For>
+                          </span>
+                        }
+                      />
+                      <Show when={!isExpanded() && peekUpdates().get(repoGroup.repoFullName)}>
+                        {(peek) => (
+                          <div class="animate-flash flex items-center gap-2 text-xs text-base-content/70 px-4 py-1.5 border-b border-base-300 bg-base-100">
+                            <span class="loading loading-spinner loading-xs text-primary/60" />
+                            <span class="truncate flex-1">{peek().itemLabel}</span>
+                            <span class="badge badge-xs badge-primary">{peek().newStatus}</span>
+                          </div>
+                        )}
+                      </Show>
+                      <Show when={isExpanded()}>
+                        <div role="list" class="divide-y divide-base-300">
+                          <For each={repoGroup.items}>
+                            {(pr) => (
                             <div role="listitem" class={
                               viewState.tabFilters.pullRequests.scope === "all" && isInvolvedItem(pr)
                                 ? "border-l-2 border-l-primary"
@@ -666,17 +659,16 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                                 </Show>
                               </ItemRow>
                             </div>
-                          )}
-                        </For>
-                      </div>
-                    </Show>
-                  </div>
+                            )}
+                          </For>
+                        </div>
+                      </Show>
+                    </div>
                   </Show>
                 );
-              }}
-            </For>
-          </div>
-        </Show>
+            }}
+          </For>
+        </div>
       </Show>
 
       <Show when={!props.loading || props.pullRequests.length > 0}>

--- a/src/app/components/dashboard/PullRequestsTab.tsx
+++ b/src/app/components/dashboard/PullRequestsTab.tsx
@@ -470,6 +470,7 @@ export default function PullRequestsTab(props: PullRequestsTabProps) {
                       <div class="flex items-center border-y border-base-300 bg-base-200/30 px-4 py-1 gap-2 opacity-40" data-repo-group={repoGroup.repoFullName}>
                         <span class="h-3.5 w-3.5 shrink-0" />
                         <span class="flex-1 text-sm text-base-content/60">{repoGroup.repoFullName}</span>
+                        <RepoGitHubLink repoFullName={repoGroup.repoFullName} section="pulls" />
                         <RepoLockControls repoFullName={repoGroup.repoFullName} />
                       </div>
                     }

--- a/src/app/components/shared/EmptyLockedRepoRow.tsx
+++ b/src/app/components/shared/EmptyLockedRepoRow.tsx
@@ -1,0 +1,21 @@
+import RepoGitHubLink from "./RepoGitHubLink";
+import RepoLockControls from "./RepoLockControls";
+
+export default function EmptyLockedRepoRow(props: {
+  repoFullName: string;
+  section: "issues" | "pulls" | "actions";
+}) {
+  return (
+    <div
+      class="group/repo-header flex items-center border-y border-base-300 bg-base-200/30 opacity-40"
+      data-repo-group={props.repoFullName}
+    >
+      <span class="flex-1 flex items-center gap-2 px-4 py-1.5 compact:py-0.5">
+        <span class="h-3.5 w-3.5 shrink-0" />
+        <span class="text-sm text-base-content/60">{props.repoFullName}</span>
+      </span>
+      <RepoGitHubLink repoFullName={props.repoFullName} section={props.section} />
+      <RepoLockControls repoFullName={props.repoFullName} />
+    </div>
+  );
+}

--- a/src/app/lib/grouping.ts
+++ b/src/app/lib/grouping.ts
@@ -50,6 +50,12 @@ export function slicePageGroups<T>(
   return groups.slice(start, end);
 }
 
+/**
+ * Ensures every locked repo has a group entry, appending empty stubs for any
+ * that are absent from the current data. The stubs land at the tail on purpose:
+ * the caller must pipe the result through orderRepoGroups, which promotes all
+ * locked groups to the front in the correct order.
+ */
 export function ensureLockedRepoGroups<G extends { repoFullName: string }>(
   groups: G[],
   lockedOrder: readonly string[],

--- a/src/app/lib/grouping.ts
+++ b/src/app/lib/grouping.ts
@@ -50,6 +50,17 @@ export function slicePageGroups<T>(
   return groups.slice(start, end);
 }
 
+export function ensureLockedRepoGroups<G extends { repoFullName: string }>(
+  groups: G[],
+  lockedOrder: readonly string[],
+  emptyFactory: (repoFullName: string) => G,
+): G[] {
+  const present = new Set(groups.map(g => g.repoFullName));
+  const missing = lockedOrder.filter(name => !present.has(name));
+  if (missing.length === 0) return groups;
+  return [...groups, ...missing.map(emptyFactory)];
+}
+
 export function orderRepoGroups<G extends { repoFullName: string }>(
   groups: G[],
   lockedOrder: string[]

--- a/tests/components/dashboard/ActionsTab.test.tsx
+++ b/tests/components/dashboard/ActionsTab.test.tsx
@@ -104,6 +104,43 @@ describe("ActionsTab — empty-repo state preservation", () => {
     // With empty items and no configRepoNames, guard returns early — no pruning
     expect(viewState.lockedRepos).toEqual([]);
   });
+
+  it("renders compact stub row for a locked repo with no workflow runs", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+    }));
+
+    const { container } = render(() => (
+      <ActionsTab
+        workflowRuns={[makeWorkflowRun({ repoFullName: "owner/active-repo" })]}
+        configRepoNames={["owner/active-repo", "owner/locked-empty"]}
+      />
+    ));
+
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).not.toBeNull();
+    expect(stub?.textContent).toContain("owner/locked-empty");
+    const headerBtn = stub?.querySelector('[aria-expanded]');
+    expect(headerBtn).toBeNull();
+  });
+
+  it("does not expand a locked repo with no workflow runs even when expandedRepos is set", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+      s.expandedRepos.actions["owner/locked-empty"] = true;
+    }));
+
+    const { container } = render(() => (
+      <ActionsTab
+        workflowRuns={[makeWorkflowRun({ repoFullName: "owner/active-repo" })]}
+        configRepoNames={["owner/active-repo", "owner/locked-empty"]}
+      />
+    ));
+
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).not.toBeNull();
+    expect(stub?.querySelector('[aria-expanded]')).toBeNull();
+  });
 });
 
 // ── ActionsTab — RepoGroupHeader integration ──────────────────────────────────

--- a/tests/components/dashboard/ActionsTab.test.tsx
+++ b/tests/components/dashboard/ActionsTab.test.tsx
@@ -160,6 +160,26 @@ describe("ActionsTab — empty-repo state preservation", () => {
     // Empty-state message does NOT render alongside the stub
     expect(screen.queryByText("No workflow runs found.")).toBeNull();
   });
+
+  it("hides locked stubs during initial load (no skeleton + stub double render)", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+    }));
+
+    const { container } = render(() => (
+      <ActionsTab
+        workflowRuns={[]}
+        loading={true}
+        configRepoNames={["owner/locked-empty"]}
+      />
+    ));
+
+    // Loading skeleton shows (label is aria-label, not visible text)
+    screen.getByRole("status", { name: "Loading workflow runs" });
+    // Locked stub does NOT render alongside the skeleton
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).toBeNull();
+  });
 });
 
 // ── ActionsTab — RepoGroupHeader integration ──────────────────────────────────

--- a/tests/components/dashboard/ActionsTab.test.tsx
+++ b/tests/components/dashboard/ActionsTab.test.tsx
@@ -141,6 +141,25 @@ describe("ActionsTab — empty-repo state preservation", () => {
     expect(stub).not.toBeNull();
     expect(stub?.querySelector('[aria-expanded]')).toBeNull();
   });
+
+  it("hides empty-state message when only locked stubs exist (no double render)", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+    }));
+
+    const { container } = render(() => (
+      <ActionsTab
+        workflowRuns={[]}
+        configRepoNames={["owner/locked-empty"]}
+      />
+    ));
+
+    // Locked stub renders
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).not.toBeNull();
+    // Empty-state message does NOT render alongside the stub
+    expect(screen.queryByText("No workflow runs found.")).toBeNull();
+  });
 });
 
 // ── ActionsTab — RepoGroupHeader integration ──────────────────────────────────

--- a/tests/components/dashboard/IssuesTab.test.tsx
+++ b/tests/components/dashboard/IssuesTab.test.tsx
@@ -740,4 +740,43 @@ describe("IssuesTab — empty-repo state preservation", () => {
     // With empty items and no configRepoNames, guard returns early — no pruning
     expect(viewState.lockedRepos).toEqual([]);
   });
+
+  it("renders compact stub row for a locked repo with no issues", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+    }));
+
+    const { container } = render(() => (
+      <IssuesTab
+        issues={[makeIssue({ id: 1, repoFullName: "owner/active-repo", surfacedBy: ["me"] })]}
+        userLogin="me"
+        configRepoNames={["owner/active-repo", "owner/locked-empty"]}
+      />
+    ));
+
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).not.toBeNull();
+    expect(stub?.textContent).toContain("owner/locked-empty");
+    const headerBtn = stub?.querySelector('[aria-expanded]');
+    expect(headerBtn).toBeNull();
+  });
+
+  it("does not expand a locked repo with no issues even when expandedRepos is set", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+      s.expandedRepos.issues["owner/locked-empty"] = true;
+    }));
+
+    const { container } = render(() => (
+      <IssuesTab
+        issues={[makeIssue({ id: 1, repoFullName: "owner/active-repo", surfacedBy: ["me"] })]}
+        userLogin="me"
+        configRepoNames={["owner/active-repo", "owner/locked-empty"]}
+      />
+    ));
+
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).not.toBeNull();
+    expect(stub?.querySelector('[aria-expanded]')).toBeNull();
+  });
 });

--- a/tests/components/dashboard/IssuesTab.test.tsx
+++ b/tests/components/dashboard/IssuesTab.test.tsx
@@ -779,4 +779,20 @@ describe("IssuesTab — empty-repo state preservation", () => {
     expect(stub).not.toBeNull();
     expect(stub?.querySelector('[aria-expanded]')).toBeNull();
   });
+
+  it("hides empty-state message when only locked stubs exist (no double render)", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+    }));
+
+    render(() => (
+      <IssuesTab
+        issues={[]}
+        userLogin="me"
+        configRepoNames={["owner/locked-empty"]}
+      />
+    ));
+
+    expect(screen.queryByText(/No open issues/i)).toBeNull();
+  });
 });

--- a/tests/components/dashboard/PullRequestsTab.test.tsx
+++ b/tests/components/dashboard/PullRequestsTab.test.tsx
@@ -750,4 +750,20 @@ describe("PullRequestsTab — empty-repo state preservation", () => {
     expect(stub).not.toBeNull();
     expect(stub?.querySelector('[aria-expanded]')).toBeNull();
   });
+
+  it("hides empty-state message when only locked stubs exist (no double render)", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+    }));
+
+    render(() => (
+      <PullRequestsTab
+        pullRequests={[]}
+        userLogin="me"
+        configRepoNames={["owner/locked-empty"]}
+      />
+    ));
+
+    expect(screen.queryByText(/No open pull requests/i)).toBeNull();
+  });
 });

--- a/tests/components/dashboard/PullRequestsTab.test.tsx
+++ b/tests/components/dashboard/PullRequestsTab.test.tsx
@@ -711,4 +711,43 @@ describe("PullRequestsTab — empty-repo state preservation", () => {
     // With empty items and no configRepoNames, guard returns early — no pruning
     expect(viewState.lockedRepos).toEqual([]);
   });
+
+  it("renders compact stub row for a locked repo with no pull requests", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+    }));
+
+    const { container } = render(() => (
+      <PullRequestsTab
+        pullRequests={[makePullRequest({ id: 1, repoFullName: "owner/active-repo", surfacedBy: ["me"] })]}
+        userLogin="me"
+        configRepoNames={["owner/active-repo", "owner/locked-empty"]}
+      />
+    ));
+
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).not.toBeNull();
+    expect(stub?.textContent).toContain("owner/locked-empty");
+    const headerBtn = stub?.querySelector('[aria-expanded]');
+    expect(headerBtn).toBeNull();
+  });
+
+  it("does not expand a locked repo with no pull requests even when expandedRepos is set", () => {
+    setViewState(produce((s) => {
+      s.lockedRepos = ["owner/locked-empty"];
+      s.expandedRepos.pullRequests["owner/locked-empty"] = true;
+    }));
+
+    const { container } = render(() => (
+      <PullRequestsTab
+        pullRequests={[makePullRequest({ id: 1, repoFullName: "owner/active-repo", surfacedBy: ["me"] })]}
+        userLogin="me"
+        configRepoNames={["owner/active-repo", "owner/locked-empty"]}
+      />
+    ));
+
+    const stub = container.querySelector('[data-repo-group="owner/locked-empty"]');
+    expect(stub).not.toBeNull();
+    expect(stub?.querySelector('[aria-expanded]')).toBeNull();
+  });
 });

--- a/tests/components/shared/EmptyLockedRepoRow.test.tsx
+++ b/tests/components/shared/EmptyLockedRepoRow.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@solidjs/testing-library";
+import EmptyLockedRepoRow from "../../../src/app/components/shared/EmptyLockedRepoRow";
+
+describe("EmptyLockedRepoRow", () => {
+  it("renders the repo name", () => {
+    const { getByText } = render(() => (
+      <EmptyLockedRepoRow repoFullName="owner/repo" section="issues" />
+    ));
+    expect(getByText("owner/repo")).toBeTruthy();
+  });
+
+  it("sets data-repo-group attribute", () => {
+    const { container } = render(() => (
+      <EmptyLockedRepoRow repoFullName="owner/repo" section="issues" />
+    ));
+    const row = container.querySelector('[data-repo-group="owner/repo"]');
+    expect(row).not.toBeNull();
+  });
+
+  it("applies de-emphasis styling", () => {
+    const { container } = render(() => (
+      <EmptyLockedRepoRow repoFullName="owner/repo" section="pulls" />
+    ));
+    const row = container.querySelector('[data-repo-group="owner/repo"]');
+    expect(row?.className).toContain("opacity-40");
+  });
+
+  it("has no aria-expanded attribute (non-interactive)", () => {
+    const { container } = render(() => (
+      <EmptyLockedRepoRow repoFullName="owner/repo" section="actions" />
+    ));
+    expect(container.querySelector("[aria-expanded]")).toBeNull();
+  });
+});

--- a/tests/lib/grouping.test.ts
+++ b/tests/lib/grouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { groupByRepo, computePageLayout, slicePageGroups, isUserInvolved, type RepoGroup } from "../../src/app/lib/grouping";
+import { groupByRepo, computePageLayout, slicePageGroups, isUserInvolved, ensureLockedRepoGroups, type RepoGroup } from "../../src/app/lib/grouping";
 
 interface Item {
   repoFullName: string;
@@ -222,5 +222,68 @@ describe("slicePageGroups", () => {
     expect(result).toHaveLength(2);
     expect(result[0].repoFullName).toBe("org/a");
     expect(result[1].repoFullName).toBe("org/b");
+  });
+});
+
+describe("ensureLockedRepoGroups", () => {
+  const emptyFactory = (name: string): RepoGroup<Item> => ({
+    repoFullName: name,
+    items: [],
+  });
+
+  it("returns groups unchanged when all locked repos are present", () => {
+    const groups = [makeGroup("org/a", 3), makeGroup("org/b", 2)];
+    const result = ensureLockedRepoGroups(groups, ["org/a", "org/b"], emptyFactory);
+    expect(result).toBe(groups); // same reference — no copy
+  });
+
+  it("injects empty stubs for missing locked repos", () => {
+    const groups = [makeGroup("org/a", 3)];
+    const result = ensureLockedRepoGroups(groups, ["org/a", "org/b", "org/c"], emptyFactory);
+    expect(result).toHaveLength(3);
+    expect(result[0].repoFullName).toBe("org/a");
+    expect(result[0].items).toHaveLength(3);
+    expect(result[1].repoFullName).toBe("org/b");
+    expect(result[1].items).toHaveLength(0);
+    expect(result[2].repoFullName).toBe("org/c");
+    expect(result[2].items).toHaveLength(0);
+  });
+
+  it("preserves existing groups in original order with stubs appended", () => {
+    const groups = [makeGroup("org/x", 1), makeGroup("org/y", 2)];
+    const result = ensureLockedRepoGroups(groups, ["org/missing"], emptyFactory);
+    expect(result).toHaveLength(3);
+    expect(result[0].repoFullName).toBe("org/x");
+    expect(result[1].repoFullName).toBe("org/y");
+    expect(result[2].repoFullName).toBe("org/missing");
+  });
+
+  it("no-op when lockedOrder is empty", () => {
+    const groups = [makeGroup("org/a", 3)];
+    const result = ensureLockedRepoGroups(groups, [], emptyFactory);
+    expect(result).toBe(groups);
+  });
+
+  it("no-op when groups is empty and lockedOrder is empty", () => {
+    const result = ensureLockedRepoGroups([], [], emptyFactory);
+    expect(result).toEqual([]);
+  });
+
+  it("injects all locked repos when groups is empty", () => {
+    const result = ensureLockedRepoGroups([], ["org/a", "org/b"], emptyFactory);
+    expect(result).toHaveLength(2);
+    expect(result[0].repoFullName).toBe("org/a");
+    expect(result[0].items).toHaveLength(0);
+    expect(result[1].repoFullName).toBe("org/b");
+    expect(result[1].items).toHaveLength(0);
+  });
+
+  it("works with custom factory for different group shapes", () => {
+    interface WfGroup { repoFullName: string; workflows: string[] }
+    const wfFactory = (name: string): WfGroup => ({ repoFullName: name, workflows: [] });
+    const groups: WfGroup[] = [{ repoFullName: "org/a", workflows: ["ci"] }];
+    const result = ensureLockedRepoGroups(groups, ["org/a", "org/b"], wfFactory);
+    expect(result).toHaveLength(2);
+    expect(result[1].workflows).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Locked repos remain in group list even when filters exclude all items
- Empty locked repos render as minimal compact rows (repo name + lock controls)
- Eliminates invisible-repo reorder bugs by keeping all locked repos present

Supersedes #73. Closes #71