### PR TITLE
fix(jira): restores domain dropdown for self-hosted Jira

### DIFF
--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -221,13 +221,16 @@ export default function SettingsPage() {
   const [jiraApiEmail, setJiraApiEmail] = createSignal("");
   const [jiraApiToken, setJiraApiToken] = createSignal("");
   const [jiraApiSubdomain, setJiraApiSubdomain] = createSignal("");
+  const [jiraApiDomain, setJiraApiDomain] = createSignal("atlassian.net");
+  const [jiraApiCustomUrl, setJiraApiCustomUrl] = createSignal("");
   const [jiraApiConnecting, setJiraApiConnecting] = createSignal(false);
   const [jiraApiError, setJiraApiError] = createSignal<string | null>(null);
   const [jiraApiMode, setJiraApiMode] = createSignal(false);
 
   const jiraApiSiteUrl = () => {
+    if (jiraApiDomain() === "custom") return jiraApiCustomUrl().trim().replace(/\/$/, "");
     const sub = jiraApiSubdomain().trim();
-    return sub ? `https://${sub}.atlassian.net` : "";
+    return sub ? `https://${sub}.${jiraApiDomain()}` : "";
   };
 
   function handleJiraOAuthConnect() {
@@ -244,7 +247,9 @@ export default function SettingsPage() {
     const token = jiraApiToken().trim();
     const siteUrl = jiraApiSiteUrl();
     if (!email || !token || !siteUrl) {
-      setJiraApiError("Email, API token, and site name are all required.");
+      setJiraApiError(jiraApiDomain() === "custom"
+        ? "Email, API token, and site URL are all required."
+        : "Email, API token, and site name are all required.");
       return;
     }
     setJiraApiConnecting(true);
@@ -299,6 +304,8 @@ export default function SettingsPage() {
       setJiraApiEmail("");
       setJiraApiToken("");
       setJiraApiSubdomain("");
+      setJiraApiDomain("atlassian.net");
+      setJiraApiCustomUrl("");
       setJiraApiMode(false);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -917,16 +924,41 @@ export default function SettingsPage() {
                           aria-label="Atlassian API token"
                         />
                         <div class="flex items-center gap-1">
-                          <span class="text-sm text-base-content/60 shrink-0">https://</span>
-                          <input
-                            type="text"
-                            placeholder="yoursite"
-                            value={jiraApiSubdomain()}
-                            onInput={(e) => setJiraApiSubdomain(e.currentTarget.value)}
-                            class="input input-sm w-32"
-                            aria-label="Jira site name"
-                          />
-                          <span class="text-sm text-base-content/60">.atlassian.net</span>
+                          <Show when={jiraApiDomain() !== "custom"}>
+                            <span class="text-sm text-base-content/60 shrink-0">https://</span>
+                          </Show>
+                          <Show
+                            when={jiraApiDomain() !== "custom"}
+                            fallback={
+                              <input
+                                type="url"
+                                placeholder="https://jira.yourcompany.com"
+                                value={jiraApiCustomUrl()}
+                                onInput={(e) => setJiraApiCustomUrl(e.currentTarget.value)}
+                                class="input input-sm flex-1"
+                                aria-label="Jira site URL"
+                              />
+                            }
+                          >
+                            <input
+                              type="text"
+                              placeholder="yoursite"
+                              value={jiraApiSubdomain()}
+                              onInput={(e) => setJiraApiSubdomain(e.currentTarget.value)}
+                              class="input input-sm w-32"
+                              aria-label="Jira site name"
+                            />
+                            <span class="text-sm text-base-content/60">.</span>
+                          </Show>
+                          <select
+                            value={jiraApiDomain()}
+                            onChange={(e) => setJiraApiDomain(e.currentTarget.value)}
+                            class="select select-sm"
+                            aria-label="Jira domain"
+                          >
+                            <option value="atlassian.net">atlassian.net</option>
+                            <option value="custom">Custom domain</option>
+                          </select>
                         </div>
                         <Show when={jiraApiError()}>
                           <p class="text-xs text-error">{jiraApiError()}</p>
@@ -942,7 +974,7 @@ export default function SettingsPage() {
                           </button>
                           <button
                             type="button"
-                            onClick={() => { setJiraApiMode(false); setJiraApiError(null); setJiraApiSubdomain(""); }}
+                            onClick={() => { setJiraApiMode(false); setJiraApiError(null); setJiraApiSubdomain(""); setJiraApiDomain("atlassian.net"); setJiraApiCustomUrl(""); }}
                             class="btn btn-sm btn-ghost"
                           >
                             Cancel

--- a/src/app/lib/url.ts
+++ b/src/app/lib/url.ts
@@ -12,12 +12,10 @@ export function isSafeGitHubUrl(url: string): boolean {
   }
 }
 
-const ATLASSIAN_HOST_RE = /^[a-z0-9-]+\.atlassian\.net$/i;
-
 export function isSafeJiraSiteUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:" && ATLASSIAN_HOST_RE.test(parsed.hostname);
+    return parsed.protocol === "https:" && parsed.hostname.includes(".");
   } catch {
     return false;
   }

--- a/tests/lib/url.test.ts
+++ b/tests/lib/url.test.ts
@@ -56,16 +56,20 @@ describe("isSafeJiraSiteUrl", () => {
     expect(isSafeJiraSiteUrl("http://mysite.atlassian.net")).toBe(false);
   });
 
-  it("returns false for bare atlassian.net (no subdomain)", () => {
-    expect(isSafeJiraSiteUrl("https://atlassian.net")).toBe(false);
+  it("returns true for bare atlassian.net (valid HTTPS domain)", () => {
+    expect(isSafeJiraSiteUrl("https://atlassian.net")).toBe(true);
   });
 
-  it("returns false for a non-atlassian.net domain", () => {
-    expect(isSafeJiraSiteUrl("https://evil.com")).toBe(false);
+  it("returns true for a custom domain (self-hosted Jira)", () => {
+    expect(isSafeJiraSiteUrl("https://jira.mycompany.com")).toBe(true);
   });
 
-  it("returns false for a multi-level subdomain (evil.foo.atlassian.net)", () => {
-    expect(isSafeJiraSiteUrl("https://evil.foo.atlassian.net")).toBe(false);
+  it("returns true for a multi-level subdomain", () => {
+    expect(isSafeJiraSiteUrl("https://jira.internal.mycompany.com")).toBe(true);
+  });
+
+  it("returns false for a bare TLD (no dot in hostname)", () => {
+    expect(isSafeJiraSiteUrl("https://localhost")).toBe(false);
   });
 
   it("returns false for a javascript: URL", () => {


### PR DESCRIPTION
## Summary
- Restores the domain selector dropdown removed in f1b26bc during PR review
- Users can choose between atlassian.net (default) and a custom domain for self-hosted Jira
- Relaxes isSafeJiraSiteUrl to allow any HTTPS domain with a valid hostname