### PR TITLE
fix(app): auto-reload on stale chunk import failure

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,9 +12,25 @@ import OAuthCallback from "./pages/OAuthCallback";
 import JiraCallback from "./pages/JiraCallback";
 import PrivacyPage from "./pages/PrivacyPage";
 
-const DashboardPage = lazy(() => import("./components/dashboard/DashboardPage"));
-const OnboardingWizard = lazy(() => import("./components/onboarding/OnboardingWizard"));
-const SettingsPage = lazy(() => import("./components/settings/SettingsPage"));
+const CHUNK_RELOAD_KEY = "github-tracker:chunk-reload";
+const CHUNK_RELOAD_MAX_AGE = 10_000;
+
+function lazyWithReload(loader: Parameters<typeof lazy>[0]) {
+  return lazy(() =>
+    loader().catch((err) => {
+      const last = sessionStorage.getItem(CHUNK_RELOAD_KEY);
+      if (!last || Date.now() - Number(last) > CHUNK_RELOAD_MAX_AGE) {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
+        window.location.reload();
+      }
+      throw err;
+    }),
+  );
+}
+
+const DashboardPage = lazyWithReload(() => import("./components/dashboard/DashboardPage"));
+const OnboardingWizard = lazyWithReload(() => import("./components/onboarding/OnboardingWizard"));
+const SettingsPage = lazyWithReload(() => import("./components/settings/SettingsPage"));
 
 const SentryErrorBoundary = Sentry.withSentryErrorBoundary(ErrorBoundary);
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -22,6 +22,7 @@ function lazyWithReload(loader: Parameters<typeof lazy>[0]) {
       if (!last || Date.now() - Number(last) > CHUNK_RELOAD_MAX_AGE) {
         sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
         window.location.reload();
+        return new Promise<never>(() => {});
       }
       throw err;
     }),


### PR DESCRIPTION
## Summary
- Wraps lazy route imports with auto-reload on chunk load failure (stale hash after deployment)
- Uses sessionStorage cooldown (10s) to prevent infinite reload loops
- Returns never-resolving promise during reload to suppress Sentry noise
- Falls back to manual reload UI if auto-reload doesn't resolve the issue

Fixes GITHUB-TRACKER-4