### PR TITLE
fix(ui): compact age hover uses Kobalte Tooltip

### DIFF
--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -172,9 +172,11 @@ export default function ItemRow(props: ItemRowProps) {
         <span class="shrink-0 text-xs text-base-content/50 whitespace-nowrap">
           {props.author}
           {" · "}
-          <time datetime={props.updatedAt} title={staticDateInfo().updatedTitle} aria-label={dateDisplay().updatedLabel}>
-            {dateDisplay().updated || dateDisplay().created}
-          </time>
+          <Tooltip content={staticDateInfo().updatedTitle} class="relative z-10">
+            <time datetime={props.updatedAt} aria-label={dateDisplay().updatedLabel}>
+              {dateDisplay().updated || dateDisplay().created}
+            </time>
+          </Tooltip>
         </span>
 
       </Show>

--- a/src/app/components/dashboard/ItemRow.tsx
+++ b/src/app/components/dashboard/ItemRow.tsx
@@ -58,6 +58,13 @@ export default function ItemRow(props: ItemRowProps) {
     return created !== "" && updated !== "" && created !== updated;
   });
 
+  const compactDateTooltip = createMemo(() => {
+    if (shouldShowUpdated()) {
+      return `${staticDateInfo().updatedTitle}\n${staticDateInfo().createdTitle}`;
+    }
+    return staticDateInfo().createdTitle;
+  });
+
   const compactLabelTooltip = createMemo(() => {
     const parts: string[] = [];
     if (props.labels.length > 0) {
@@ -172,7 +179,7 @@ export default function ItemRow(props: ItemRowProps) {
         <span class="shrink-0 text-xs text-base-content/50 whitespace-nowrap">
           {props.author}
           {" · "}
-          <Tooltip content={staticDateInfo().updatedTitle} class="relative z-10">
+          <Tooltip content={compactDateTooltip()} contentClass="whitespace-pre-line" class="relative z-10">
             <time datetime={props.updatedAt} aria-label={dateDisplay().updatedLabel}>
               {dateDisplay().updated || dateDisplay().created}
             </time>

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -151,6 +151,25 @@ describe("ItemRow", () => {
       const timeEls = container.querySelectorAll("time");
       expect(timeEls.length).toBe(1);
     });
+
+    it("shows updated date tooltip content on hover in compact mode", () => {
+      vi.useFakeTimers();
+      const { container, unmount } = render(() => <ItemRow {...defaultProps} />);
+      const updatedTrigger = container.querySelector(
+        `time[datetime="${defaultProps.updatedAt}"]`
+      )?.closest("span.inline-flex");
+      expect(updatedTrigger).not.toBeNull();
+      expect(updatedTrigger!.className).toContain("z-10");
+      fireEvent.pointerEnter(updatedTrigger!);
+      vi.advanceTimersByTime(300);
+      expect(document.body.textContent).toContain(
+        `Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`
+      );
+      fireEvent.pointerLeave(updatedTrigger!);
+      vi.advanceTimersByTime(500);
+      unmount();
+      vi.useRealTimers();
+    });
   });
 
   it("renders no labels section when labels array is empty", () => {

--- a/tests/components/ItemRow.test.tsx
+++ b/tests/components/ItemRow.test.tsx
@@ -152,7 +152,7 @@ describe("ItemRow", () => {
       expect(timeEls.length).toBe(1);
     });
 
-    it("shows updated date tooltip content on hover in compact mode", () => {
+    it("shows both updated and created dates in tooltip on hover", () => {
       vi.useFakeTimers();
       const { container, unmount } = render(() => <ItemRow {...defaultProps} />);
       const updatedTrigger = container.querySelector(
@@ -164,6 +164,9 @@ describe("ItemRow", () => {
       vi.advanceTimersByTime(300);
       expect(document.body.textContent).toContain(
         `Updated: ${new Date(defaultProps.updatedAt).toLocaleString()}`
+      );
+      expect(document.body.textContent).toContain(
+        `Created: ${new Date(defaultProps.createdAt).toLocaleString()}`
       );
       fireEvent.pointerLeave(updatedTrigger!);
       vi.advanceTimersByTime(500);


### PR DESCRIPTION
## Summary
- Replaces native HTML `title` attribute on compact mode time element with Kobalte `<Tooltip>` and `relative z-10` positioning
- The native title was invisible because the full-row overlay `<a>` link intercepted pointer events