### PR TITLE
feat(settings): adds navigation TOC and section grouping

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -635,6 +635,14 @@ Jira uses rotating refresh tokens — each refresh invalidates the previous toke
 
 ---
 
+## Settings Navigation
+
+The Settings page organizes its sections into four groups: **Data Sources** (Orgs & Repos, Tracked Users, Refresh, API Usage), **Display** (Appearance, Tabs, Custom Tabs), **Integrations** (GitHub Actions, Notifications, MCP Relay, Jira), and **Account** (Data).
+
+On desktop (1024px+), a sticky sidebar on the left shows a table of contents with all sections grouped and highlighted as you scroll. Click any item to jump to that section. On smaller screens, a dropdown bar appears below the header showing the current section name — tap it to open a section picker.
+
+The header shrinks as you scroll to maximize content space.
+
 ## Settings Reference
 
 Settings are saved automatically to `localStorage` and persist across sessions. All settings can be exported as a JSON file via **Settings > Data > Export**.

--- a/src/app/components/settings/Section.tsx
+++ b/src/app/components/settings/Section.tsx
@@ -1,8 +1,8 @@
 import { JSX, Show } from "solid-js";
 
-export default function Section(props: { title: string; description?: string; children: JSX.Element }) {
+export default function Section(props: { id?: string; title: string; description?: string; children: JSX.Element }) {
   return (
-    <div class="card bg-base-100 border border-base-300">
+    <div id={props.id} class="card bg-base-100 border border-base-300">
       <div class="bg-base-200 px-4 py-2 rounded-t-lg border-b border-base-300">
         <h2 class="text-sm font-semibold text-base-content">{props.title}</h2>
         <Show when={props.description}>

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -85,7 +85,9 @@ export default function SettingsPage() {
   onMount(() => {
     const onScroll = () => {
       if (document.documentElement.dataset.scrollLock) return;
-      setScrolled(window.scrollY > 50);
+      const y = window.scrollY;
+      if (scrolled() && y < 10) setScrolled(false);
+      else if (!scrolled() && y > 50) setScrolled(true);
     };
     window.addEventListener("scroll", onScroll, { passive: true });
     onCleanup(() => window.removeEventListener("scroll", onScroll));

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -83,7 +83,10 @@ export default function SettingsPage() {
 
   const [scrolled, setScrolled] = createSignal(false);
   onMount(() => {
-    const onScroll = () => setScrolled(window.scrollY > 50);
+    const onScroll = () => {
+      if (document.documentElement.dataset.scrollLock) return;
+      setScrolled(window.scrollY > 50);
+    };
     window.addEventListener("scroll", onScroll, { passive: true });
     onCleanup(() => window.removeEventListener("scroll", onScroll));
   });

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -18,6 +18,7 @@ import { getUsageSnapshot, getUsageResetAt, resetUsageData, checkAndResetIfExpir
 import OrgSelector from "../onboarding/OrgSelector";
 import RepoSelector from "../onboarding/RepoSelector";
 import Section from "./Section";
+import SettingsTOC from "./SettingsTOC";
 import SettingRow from "./SettingRow";
 import ThemePicker from "./ThemePicker";
 import DensityPicker from "./DensityPicker";
@@ -30,6 +31,22 @@ import JiraScopePicker from "./JiraScopePicker";
 import type { RepoRef } from "../../services/api";
 
 const VALID_JIRA_CLIENT_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export const SETTINGS_PAGE_SECTION_IDS = [
+  "orgs-repos",
+  "tracked-users",
+  "refresh",
+  "api-usage",
+  "appearance",
+  "tabs",
+  "custom-tabs",
+  "actions",
+  "notifications",
+  "mcp-relay",
+  "jira",
+  "dependencies",
+  "data",
+] as const;
 
 export default function SettingsPage() {
   const navigate = useNavigate();
@@ -62,6 +79,13 @@ export default function SettingsPage() {
     if (pendingFocusHandler) {
       window.removeEventListener("focus", pendingFocusHandler);
     }
+  });
+
+  const [scrolled, setScrolled] = createSignal(false);
+  onMount(() => {
+    const onScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onCleanup(() => window.removeEventListener("scroll", onScroll));
   });
 
   onMount(() => checkAndResetIfExpired());
@@ -365,8 +389,8 @@ export default function SettingsPage() {
   return (
     <div class="bg-base-200 min-h-screen">
       {/* Page header */}
-      <div class="border-b border-base-300 bg-base-100">
-        <div class="mx-auto max-w-3xl px-4 py-6 sm:px-6">
+      <div class="settings-header sticky top-0 z-40 border-b border-base-300 bg-base-100">
+        <div class={`mx-auto max-w-5xl px-4 sm:px-6 transition-[padding] duration-200 ${scrolled() ? "py-2" : "py-6"}`}>
           <div class="flex items-center gap-3">
             <a
               href="/dashboard"
@@ -391,9 +415,14 @@ export default function SettingsPage() {
         </div>
       </div>
 
-      <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 flex flex-col gap-6">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+        <div class="flex flex-col lg:flex-row gap-6 lg:gap-8">
+          <SettingsTOC />
+          <div class="settings-content flex-1 min-w-0 flex flex-col gap-6 max-w-3xl">
+        {/* ── Data Sources ─────────────────────────────────────────────────── */}
+        <p class="text-xs font-semibold uppercase tracking-wider text-base-content/40 px-1">Data Sources</p>
         {/* Section 1: Orgs & Repos */}
-        <Section title="Organizations & Repositories">
+        <Section id="orgs-repos" title="Organizations & Repositories">
           <div class="flex flex-col gap-3 px-4 py-3">
             <div class="flex items-center justify-between">
               <div>
@@ -492,7 +521,7 @@ export default function SettingsPage() {
         </Section>
 
         {/* Section 2: Tracked Users */}
-        <Section title="Tracked Users">
+        <Section id="tracked-users" title="Tracked Users">
           <div class="flex flex-col gap-3 px-4 py-3">
             <p class="text-xs text-base-content/60">
               Track another GitHub user's issues and pull requests alongside yours.
@@ -505,7 +534,7 @@ export default function SettingsPage() {
         </Section>
 
         {/* Section 3: Refresh */}
-        <Section title="Refresh">
+        <Section id="refresh" title="Refresh">
           <SettingRow
             label="Refresh interval"
             description="How often to poll GitHub for new data"
@@ -544,7 +573,7 @@ export default function SettingsPage() {
         </Section>
 
         {/* Section 4: API Usage */}
-        <Section title="API Usage">
+        <Section id="api-usage" title="API Usage">
           <div class="px-4 py-3 flex flex-col gap-3">
             <Show
               when={usageSnapshot().length > 0}
@@ -608,8 +637,105 @@ export default function SettingsPage() {
           </div>
         </Section>
 
-        {/* Section 5: GitHub Actions */}
-        <Section title="GitHub Actions">
+        {/* ── Display ────────────────────────────────────────────────────── */}
+        <p class="text-xs font-semibold uppercase tracking-wider text-base-content/40 px-1">Display</p>
+        {/* Section 5: Appearance */}
+        <Section id="appearance" title="Appearance">
+          <div class="px-4 py-2 border-b border-base-300">
+            <p class="text-sm font-medium text-base-content mb-2">Theme</p>
+            <ThemePicker />
+          </div>
+          <div class="px-4 py-2 border-b border-base-300">
+            <p class="text-sm font-medium text-base-content mb-2">View density</p>
+            <DensityPicker />
+          </div>
+          <SettingRow
+            label="Items per page"
+            description="Number of items to show in each tab"
+          >
+            <select
+              value={String(config.itemsPerPage)}
+              onChange={(e) => {
+                saveWithFeedback({ itemsPerPage: Number(e.currentTarget.value) });
+              }}
+              class="select select-sm"
+            >
+              {itemsPerPageOptions.map((opt) => (
+                <option value={String(opt.value)}>{opt.label}</option>
+              ))}
+            </select>
+          </SettingRow>
+        </Section>
+
+        {/* Section 6: Tabs */}
+        <Section id="tabs" title="Tabs">
+          <SettingRow
+            label="Default tab"
+            description="Tab shown when opening the dashboard fresh"
+          >
+            <select
+              value={config.defaultTab}
+              onChange={(e) => {
+                saveWithFeedback({ defaultTab: e.currentTarget.value as Config["defaultTab"] });
+              }}
+              class="select select-sm"
+            >
+              {tabOptions().map((opt) => (
+                <option value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </SettingRow>
+          <SettingRow
+            label="Remember last tab"
+            description="Return to the last active tab on revisit"
+          >
+            <input
+              type="checkbox"
+              role="switch"
+              aria-checked={config.rememberLastTab}
+              aria-label="Remember last tab"
+              checked={config.rememberLastTab}
+              onChange={(e) => saveWithFeedback({ rememberLastTab: e.currentTarget.checked })}
+              class="toggle toggle-primary"
+            />
+          </SettingRow>
+          <SettingRow
+            label="Enable tracked items"
+            description="Show a Tracked tab to pin issues and PRs for quick access"
+          >
+            <input
+              type="checkbox"
+              role="switch"
+              aria-checked={config.enableTracking}
+              aria-label="Enable tracked items"
+              checked={config.enableTracking}
+              onChange={(e) => {
+                const val = e.currentTarget.checked;
+                saveWithFeedback({
+                  enableTracking: val,
+                  ...(!val && config.defaultTab === "tracked" ? { defaultTab: "issues" as const } : {}),
+                });
+                if (!val && viewState.lastActiveTab === "tracked") {
+                  updateViewState({ lastActiveTab: "issues" });
+                }
+              }}
+              class="toggle toggle-primary"
+            />
+          </SettingRow>
+        </Section>
+
+        {/* Section 7: Custom Tabs */}
+        <Section id="custom-tabs" title="Custom Tabs" description="Create custom views with saved filters and scoping">
+          <CustomTabsSection
+            availableOrgs={[...new Set(config.selectedRepos.map((r) => r.owner))]}
+            availableRepos={config.selectedRepos}
+          />
+        </Section>
+
+        {/* ── Integrations ──────────────────────────────────────────────── */}
+        <p class="text-xs font-semibold uppercase tracking-wider text-base-content/40 px-1">Integrations</p>
+        {/* Section 8: GitHub Actions */}
+        <Section id="actions" title="GitHub Actions">
           <SettingRow
             label="Show Actions tab"
             description="Show the Actions tab and track workflow runs. Disable to reduce API usage and simplify the dashboard."
@@ -676,8 +802,8 @@ export default function SettingsPage() {
           </SettingRow>
         </Section>
 
-        {/* Section 6: Notifications */}
-        <Section title="Notifications">
+        {/* Section 9: Notifications */}
+        <Section id="notifications" title="Notifications">
           <SettingRow
             label="Enable notifications"
             description="Show browser notifications for new activity"
@@ -771,101 +897,9 @@ export default function SettingsPage() {
           </SettingRow>
         </Section>
 
-        {/* Section 7: Appearance */}
-        <Section title="Appearance">
-          <div class="px-4 py-2 border-b border-base-300">
-            <p class="text-sm font-medium text-base-content mb-2">Theme</p>
-            <ThemePicker />
-          </div>
-          <div class="px-4 py-2 border-b border-base-300">
-            <p class="text-sm font-medium text-base-content mb-2">View density</p>
-            <DensityPicker />
-          </div>
-          <SettingRow
-            label="Items per page"
-            description="Number of items to show in each tab"
-          >
-            <select
-              value={String(config.itemsPerPage)}
-              onChange={(e) => {
-                saveWithFeedback({ itemsPerPage: Number(e.currentTarget.value) });
-              }}
-              class="select select-sm"
-            >
-              {itemsPerPageOptions.map((opt) => (
-                <option value={String(opt.value)}>{opt.label}</option>
-              ))}
-            </select>
-          </SettingRow>
-        </Section>
-
-        {/* Section 8: Tabs */}
-        <Section title="Tabs">
-          <SettingRow
-            label="Default tab"
-            description="Tab shown when opening the dashboard fresh"
-          >
-            <select
-              value={config.defaultTab}
-              onChange={(e) => {
-                saveWithFeedback({ defaultTab: e.currentTarget.value as Config["defaultTab"] });
-              }}
-              class="select select-sm"
-            >
-              {tabOptions().map((opt) => (
-                <option value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </SettingRow>
-          <SettingRow
-            label="Remember last tab"
-            description="Return to the last active tab on revisit"
-          >
-            <input
-              type="checkbox"
-              role="switch"
-              aria-checked={config.rememberLastTab}
-              aria-label="Remember last tab"
-              checked={config.rememberLastTab}
-              onChange={(e) => saveWithFeedback({ rememberLastTab: e.currentTarget.checked })}
-              class="toggle toggle-primary"
-            />
-          </SettingRow>
-          <SettingRow
-            label="Enable tracked items"
-            description="Show a Tracked tab to pin issues and PRs for quick access"
-          >
-            <input
-              type="checkbox"
-              role="switch"
-              aria-checked={config.enableTracking}
-              aria-label="Enable tracked items"
-              checked={config.enableTracking}
-              onChange={(e) => {
-                const val = e.currentTarget.checked;
-                saveWithFeedback({
-                  enableTracking: val,
-                  ...(!val && config.defaultTab === "tracked" ? { defaultTab: "issues" as const } : {}),
-                });
-                if (!val && viewState.lastActiveTab === "tracked") {
-                  updateViewState({ lastActiveTab: "issues" });
-                }
-              }}
-              class="toggle toggle-primary"
-            />
-          </SettingRow>
-        </Section>
-
-        {/* Section 9: Custom Tabs */}
-        <Section title="Custom Tabs" description="Create custom views with saved filters and scoping">
-          <CustomTabsSection
-            availableOrgs={[...new Set(config.selectedRepos.map((r) => r.owner))]}
-            availableRepos={config.selectedRepos}
-          />
-        </Section>
-
         {/* Section 10: MCP Server Relay */}
         <Section
+          id="mcp-relay"
           title="MCP Server Relay"
           description="Allow a local MCP server to read dashboard data. Enable this if you use Claude Code or another AI client with the GitHub Tracker MCP server."
         >
@@ -920,7 +954,7 @@ export default function SettingsPage() {
         </Section>
 
         {/* Section 11: Jira Cloud Integration */}
-        <Section title="Jira Cloud Integration">
+        <Section id="jira" title="Jira Cloud Integration">
             <Show
               when={isJiraAuthenticated()}
               fallback={
@@ -1132,8 +1166,8 @@ export default function SettingsPage() {
             </Show>
           </Section>
 
-        {/* Dependencies */}
-        <Section title="Dependencies">
+        {/* Section 12: Dependencies */}
+        <Section id="dependencies" title="Dependencies">
           <SettingRow
             label="Dependencies tab"
             description="Auto-show a Dependencies tab when dependency bot PRs are detected"
@@ -1162,8 +1196,10 @@ export default function SettingsPage() {
           </SettingRow>
         </Section>
 
-        {/* Data */}
-        <Section title="Data">
+        {/* ── Account ─────────────────────────────────────────────────── */}
+        <p class="text-xs font-semibold uppercase tracking-wider text-base-content/40 px-1">Account</p>
+        {/* Section 13: Data */}
+        <Section id="data" title="Data">
           {/* Authentication method */}
           <SettingRow
             label="Authentication"
@@ -1275,6 +1311,8 @@ export default function SettingsPage() {
             </button>
           </SettingRow>
         </Section>
+          </div>
+        </div>
 
         <footer class="mt-8 border-t border-base-300 pt-4 pb-8 text-xs text-base-content/50 text-center">
           <div class="flex items-center justify-center gap-3">

--- a/src/app/components/settings/SettingsTOC.tsx
+++ b/src/app/components/settings/SettingsTOC.tsx
@@ -83,27 +83,49 @@ export default function SettingsTOC() {
 
   let scrollEndCleanup: (() => void) | undefined;
 
+  function smoothScrollTo(targetY: number, onDone: () => void) {
+    const startY = window.scrollY;
+    const diff = targetY - startY;
+    if (Math.abs(diff) < 1) { onDone(); return; }
+    const duration = Math.min(500, Math.max(200, Math.abs(diff) * 0.3));
+    const startTime = performance.now();
+    let raf: number;
+    const step = (now: number) => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const ease = progress < 0.5
+        ? 2 * progress * progress
+        : 1 - Math.pow(-2 * progress + 2, 2) / 2;
+      window.scrollTo(0, startY + diff * ease);
+      if (progress < 1) {
+        raf = requestAnimationFrame(step);
+      } else {
+        onDone();
+      }
+    };
+    raf = requestAnimationFrame(step);
+    scrollEndCleanup = () => { cancelAnimationFrame(raf); onDone(); };
+  }
+
   function scrollToSection(id: string) {
     scrollEndCleanup?.();
     setScrollingTo(id);
+    const el = document.getElementById(id);
+    if (!el) { setScrollingTo(null); return; }
     const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    document.getElementById(id)?.scrollIntoView({
-      behavior: prefersReduced ? "instant" : "smooth",
-      block: "start",
-    });
     const clear = () => {
       setScrollingTo(null);
       scrollEndCleanup = undefined;
     };
     if (prefersReduced) {
+      el.scrollIntoView({ behavior: "instant", block: "start" });
       requestAnimationFrame(clear);
       scrollEndCleanup = undefined;
-    } else if ("onscrollend" in window) {
-      window.addEventListener("scrollend", clear, { once: true });
-      scrollEndCleanup = () => window.removeEventListener("scrollend", clear);
     } else {
-      const t = setTimeout(clear, 600);
-      scrollEndCleanup = () => clearTimeout(t);
+      const style = getComputedStyle(el);
+      const scrollMargin = parseFloat(style.scrollMarginTop) || 0;
+      const targetY = el.getBoundingClientRect().top + window.scrollY - scrollMargin;
+      smoothScrollTo(targetY, clear);
     }
   }
 

--- a/src/app/components/settings/SettingsTOC.tsx
+++ b/src/app/components/settings/SettingsTOC.tsx
@@ -110,11 +110,14 @@ export default function SettingsTOC() {
   function scrollToSection(id: string) {
     scrollEndCleanup?.();
     setScrollingTo(id);
+    document.documentElement.dataset.scrollLock = "1";
     const el = document.getElementById(id);
-    if (!el) { setScrollingTo(null); return; }
+    if (!el) { setScrollingTo(null); delete document.documentElement.dataset.scrollLock; return; }
     const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     const clear = () => {
       setScrollingTo(null);
+      delete document.documentElement.dataset.scrollLock;
+      window.dispatchEvent(new Event("scroll"));
       scrollEndCleanup = undefined;
     };
     if (prefersReduced) {

--- a/src/app/components/settings/SettingsTOC.tsx
+++ b/src/app/components/settings/SettingsTOC.tsx
@@ -16,10 +16,12 @@ export const SETTINGS_SECTIONS = [
   { id: "data", label: "Data", group: "Account" },
 ] as const;
 
-const SETTINGS_GROUPS = Array.from(
-  Map.groupBy(SETTINGS_SECTIONS, (s) => s.group),
-  ([name, items]) => ({ name, items })
-);
+const SETTINGS_GROUPS: { name: string; items: (typeof SETTINGS_SECTIONS)[number][] }[] = [];
+for (const s of SETTINGS_SECTIONS) {
+  const g = SETTINGS_GROUPS.find((x) => x.name === s.group);
+  if (g) g.items.push(s);
+  else SETTINGS_GROUPS.push({ name: s.group, items: [s] });
+}
 
 function useScrollSpy() {
   const [activeId, setActiveId] = createSignal<string>(SETTINGS_SECTIONS[0].id);
@@ -74,25 +76,35 @@ export default function SettingsTOC() {
   const [scrollingTo, setScrollingTo] = createSignal<string | null>(null);
   const [mobileOpen, setMobileOpen] = createSignal(false);
 
-  const displayedActiveId = () => scrollingTo() ?? activeId();
+  const displayedActiveId = createMemo(() => scrollingTo() ?? activeId());
   const activeLabel = createMemo(() =>
     SETTINGS_SECTIONS.find((s) => s.id === displayedActiveId())?.label ?? SETTINGS_SECTIONS[0].label
   );
 
+  let scrollEndCleanup: (() => void) | undefined;
+
   function scrollToSection(id: string) {
+    scrollEndCleanup?.();
     setScrollingTo(id);
     const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     document.getElementById(id)?.scrollIntoView({
       behavior: prefersReduced ? "instant" : "smooth",
       block: "start",
     });
-    const clear = () => setScrollingTo(null);
+    const clear = () => {
+      setScrollingTo(null);
+      scrollEndCleanup = undefined;
+    };
     if ("onscrollend" in window) {
       window.addEventListener("scrollend", clear, { once: true });
+      scrollEndCleanup = () => window.removeEventListener("scrollend", clear);
     } else {
-      setTimeout(clear, 600);
+      const t = setTimeout(clear, 600);
+      scrollEndCleanup = () => clearTimeout(t);
     }
   }
+
+  onCleanup(() => scrollEndCleanup?.());
 
   let mobileContainerRef: HTMLDivElement | undefined;
 
@@ -131,6 +143,7 @@ export default function SettingsTOC() {
                   <button
                     type="button"
                     onClick={() => scrollToSection(item.id)}
+                    aria-current={displayedActiveId() === item.id ? "location" : undefined}
                     class={`block w-full text-left text-sm px-2 py-1 rounded transition-colors ${
                       displayedActiveId() === item.id
                         ? "bg-primary/10 text-primary font-medium border-l-2 border-primary"
@@ -147,11 +160,12 @@ export default function SettingsTOC() {
       </nav>
 
       {/* Mobile dropdown */}
-      <div class="lg:hidden sticky top-20 z-30 bg-base-200 border-b border-base-300 shadow-sm relative" data-testid="mobile-toc" ref={(el) => (mobileContainerRef = el)}>
+      <div class="lg:hidden sticky top-20 z-30 bg-base-200 border-b border-base-300 shadow-sm" data-testid="mobile-toc" ref={(el) => (mobileContainerRef = el)}>
         <button
           type="button"
           onClick={() => setMobileOpen((v) => !v)}
-          class="btn btn-ghost btn-sm gap-1"
+          class="btn btn-ghost gap-1 w-full justify-start"
+          aria-label="Jump to section"
           aria-expanded={mobileOpen()}
           aria-controls="settings-toc-mobile"
         >
@@ -163,7 +177,7 @@ export default function SettingsTOC() {
         <Show when={mobileOpen()}>
           <div
             id="settings-toc-mobile"
-            class="absolute top-full left-0 right-0 bg-base-100 border-b border-base-300 shadow-lg z-30 px-4 py-2 max-h-[60vh] overflow-y-auto"
+            class="absolute top-full left-0 right-0 bg-base-100 border-b border-base-300 shadow-lg z-40 px-4 py-2 max-h-[60vh] overflow-y-auto"
           >
             <For each={SETTINGS_GROUPS}>
               {(group) => (
@@ -179,6 +193,7 @@ export default function SettingsTOC() {
                           scrollToSection(item.id);
                           setMobileOpen(false);
                         }}
+                        aria-current={displayedActiveId() === item.id ? "location" : undefined}
                         class={`block w-full text-left text-sm px-2 py-1 rounded transition-colors ${
                           displayedActiveId() === item.id
                             ? "bg-primary/10 text-primary font-medium"

--- a/src/app/components/settings/SettingsTOC.tsx
+++ b/src/app/components/settings/SettingsTOC.tsx
@@ -95,7 +95,10 @@ export default function SettingsTOC() {
       setScrollingTo(null);
       scrollEndCleanup = undefined;
     };
-    if ("onscrollend" in window) {
+    if (prefersReduced) {
+      requestAnimationFrame(clear);
+      scrollEndCleanup = undefined;
+    } else if ("onscrollend" in window) {
       window.addEventListener("scrollend", clear, { once: true });
       scrollEndCleanup = () => window.removeEventListener("scrollend", clear);
     } else {

--- a/src/app/components/settings/SettingsTOC.tsx
+++ b/src/app/components/settings/SettingsTOC.tsx
@@ -1,0 +1,200 @@
+import { createSignal, createMemo, createEffect, onMount, onCleanup, For, Show } from "solid-js";
+
+export const SETTINGS_SECTIONS = [
+  { id: "orgs-repos", label: "Orgs & Repos", group: "Data Sources" },
+  { id: "tracked-users", label: "Tracked Users", group: "Data Sources" },
+  { id: "refresh", label: "Refresh", group: "Data Sources" },
+  { id: "api-usage", label: "API Usage", group: "Data Sources" },
+  { id: "appearance", label: "Appearance", group: "Display" },
+  { id: "tabs", label: "Tabs", group: "Display" },
+  { id: "custom-tabs", label: "Custom Tabs", group: "Display" },
+  { id: "actions", label: "Actions", group: "Integrations" },
+  { id: "notifications", label: "Notifications", group: "Integrations" },
+  { id: "mcp-relay", label: "MCP Relay", group: "Integrations" },
+  { id: "jira", label: "Jira", group: "Integrations" },
+  { id: "dependencies", label: "Dependencies", group: "Integrations" },
+  { id: "data", label: "Data", group: "Account" },
+] as const;
+
+const SETTINGS_GROUPS = Array.from(
+  Map.groupBy(SETTINGS_SECTIONS, (s) => s.group),
+  ([name, items]) => ({ name, items })
+);
+
+function useScrollSpy() {
+  const [activeId, setActiveId] = createSignal<string>(SETTINGS_SECTIONS[0].id);
+
+  onMount(() => {
+    const intersecting = new Map<string, IntersectionObserverEntry>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            intersecting.set(entry.target.id, entry);
+          } else {
+            intersecting.delete(entry.target.id);
+          }
+        }
+
+        if (intersecting.size > 0) {
+          const atBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+          if (atBottom) {
+            setActiveId(SETTINGS_SECTIONS[SETTINGS_SECTIONS.length - 1].id);
+          } else {
+            let nearest: string | null = null;
+            let nearestDist = Infinity;
+            for (const [id, entry] of intersecting) {
+              const dist = Math.abs(entry.boundingClientRect.top);
+              if (dist < nearestDist) {
+                nearestDist = dist;
+                nearest = id;
+              }
+            }
+            if (nearest) setActiveId(nearest);
+          }
+        }
+      },
+      { rootMargin: "-80px 0px -60% 0px", threshold: [0, 1] }
+    );
+
+    for (const section of SETTINGS_SECTIONS) {
+      const el = document.getElementById(section.id);
+      if (el) observer.observe(el);
+    }
+
+    onCleanup(() => observer.disconnect());
+  });
+
+  return activeId;
+}
+
+export default function SettingsTOC() {
+  const activeId = useScrollSpy();
+  const [scrollingTo, setScrollingTo] = createSignal<string | null>(null);
+  const [mobileOpen, setMobileOpen] = createSignal(false);
+
+  const displayedActiveId = () => scrollingTo() ?? activeId();
+  const activeLabel = createMemo(() =>
+    SETTINGS_SECTIONS.find((s) => s.id === displayedActiveId())?.label ?? SETTINGS_SECTIONS[0].label
+  );
+
+  function scrollToSection(id: string) {
+    setScrollingTo(id);
+    const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    document.getElementById(id)?.scrollIntoView({
+      behavior: prefersReduced ? "instant" : "smooth",
+      block: "start",
+    });
+    const clear = () => setScrollingTo(null);
+    if ("onscrollend" in window) {
+      window.addEventListener("scrollend", clear, { once: true });
+    } else {
+      setTimeout(clear, 600);
+    }
+  }
+
+  let mobileContainerRef: HTMLDivElement | undefined;
+
+  createEffect(() => {
+    if (!mobileOpen()) return;
+    const handleClickOutside = (e: PointerEvent) => {
+      if (mobileContainerRef && !mobileContainerRef.contains(e.target as Node)) {
+        setMobileOpen(false);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMobileOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    onCleanup(() => {
+      document.removeEventListener("pointerdown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    });
+  });
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <nav aria-label="Settings navigation" class="hidden lg:block w-44 shrink-0 sticky top-20 self-start">
+        <For each={SETTINGS_GROUPS}>
+          {(group) => (
+            <div class="mt-4 first:mt-0">
+              <p class="text-xs font-semibold uppercase tracking-wider text-base-content/40 mb-1 px-2">
+                {group.name}
+              </p>
+              <For each={group.items}>
+                {(item) => (
+                  <button
+                    type="button"
+                    onClick={() => scrollToSection(item.id)}
+                    class={`block w-full text-left text-sm px-2 py-1 rounded transition-colors ${
+                      displayedActiveId() === item.id
+                        ? "bg-primary/10 text-primary font-medium border-l-2 border-primary"
+                        : "text-base-content/60 hover:text-base-content hover:bg-base-200 border-l-2 border-transparent"
+                    }`}
+                  >
+                    {item.label}
+                  </button>
+                )}
+              </For>
+            </div>
+          )}
+        </For>
+      </nav>
+
+      {/* Mobile dropdown */}
+      <div class="lg:hidden sticky top-20 z-30 bg-base-200 border-b border-base-300 shadow-sm relative" data-testid="mobile-toc" ref={(el) => (mobileContainerRef = el)}>
+        <button
+          type="button"
+          onClick={() => setMobileOpen((v) => !v)}
+          class="btn btn-ghost btn-sm gap-1"
+          aria-expanded={mobileOpen()}
+          aria-controls="settings-toc-mobile"
+        >
+          <span class="text-xs text-base-content/60">{activeLabel()}</span>
+          <svg class={`h-3 w-3 transition-transform ${mobileOpen() ? "rotate-180" : ""}`} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+          </svg>
+        </button>
+        <Show when={mobileOpen()}>
+          <div
+            id="settings-toc-mobile"
+            class="absolute top-full left-0 right-0 bg-base-100 border-b border-base-300 shadow-lg z-30 px-4 py-2 max-h-[60vh] overflow-y-auto"
+          >
+            <For each={SETTINGS_GROUPS}>
+              {(group) => (
+                <div class="mt-3 first:mt-0">
+                  <p class="text-xs font-semibold uppercase tracking-wider text-base-content/40 mb-1">
+                    {group.name}
+                  </p>
+                  <For each={group.items}>
+                    {(item) => (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          scrollToSection(item.id);
+                          setMobileOpen(false);
+                        }}
+                        class={`block w-full text-left text-sm px-2 py-1 rounded transition-colors ${
+                          displayedActiveId() === item.id
+                            ? "bg-primary/10 text-primary font-medium"
+                            : "text-base-content/60 hover:text-base-content hover:bg-base-200"
+                        }`}
+                      >
+                        {item.label}
+                      </button>
+                    )}
+                  </For>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </>
+  );
+}

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -131,6 +131,27 @@
   animation: popover-fade-out 0.15s ease-in forwards;
 }
 
+/* ── Settings page: scroll-margin, sticky header ────────────────────────── */
+
+.settings-content > [id] {
+  scroll-margin-top: 7.5rem;
+}
+@media (min-width: 1024px) {
+  .settings-content > [id] {
+    scroll-margin-top: 6rem;
+  }
+}
+
+.settings-header {
+  padding-right: var(--scrollbar-width, 0px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-header * {
+    transition: none;
+  }
+}
+
 /* ── Fixed-element scrollbar compensation ────────────────────────────────── */
 /* solid-prevent-scroll sets --scrollbar-width on body when scroll is locked;
    fixed elements don't inherit body padding-right, so compensate explicitly.

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -201,7 +201,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-slow-pulse,
+  .animate-slow-pulse, .animate-pulse,
   .animate-toast-in, .animate-toast-out,
   .drawer-content[data-expanded], .drawer-content[data-closed],
   .drawer-overlay[data-expanded], .drawer-overlay[data-closed],

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -179,7 +179,7 @@ describe("SettingsPage — rendering", () => {
 
   it("renders Refresh section", () => {
     renderSettings();
-    screen.getByText("Refresh");
+    screen.getByRole("heading", { name: "Refresh" });
   });
 
   it("renders GitHub Actions section", () => {
@@ -190,22 +190,22 @@ describe("SettingsPage — rendering", () => {
 
   it("renders Notifications section", () => {
     renderSettings();
-    screen.getByText("Notifications");
+    screen.getByRole("heading", { name: "Notifications" });
   });
 
   it("renders Appearance section", () => {
     renderSettings();
-    screen.getByText("Appearance");
+    screen.getByRole("heading", { name: "Appearance" });
   });
 
   it("renders Tabs section", () => {
     renderSettings();
-    screen.getByText("Tabs");
+    screen.getByRole("heading", { name: "Tabs" });
   });
 
   it("renders Data section", () => {
     renderSettings();
-    screen.getByText("Data");
+    screen.getByRole("heading", { name: "Data" });
   });
 
   it("renders Manage Organizations and Manage Repositories buttons", () => {

--- a/tests/components/settings/SettingsTOC.test.tsx
+++ b/tests/components/settings/SettingsTOC.test.tsx
@@ -36,8 +36,8 @@ afterEach(() => {
 });
 
 describe("SettingsTOC — section registry", () => {
-  it("has exactly 12 entries", () => {
-    expect(SETTINGS_SECTIONS).toHaveLength(12);
+  it("has exactly 13 entries", () => {
+    expect(SETTINGS_SECTIONS).toHaveLength(13);
   });
 
   it("has all 4 groups", () => {

--- a/tests/components/settings/SettingsTOC.test.tsx
+++ b/tests/components/settings/SettingsTOC.test.tsx
@@ -156,9 +156,10 @@ describe("SettingsTOC — scroll to section", () => {
 describe("SettingsTOC — mobile dropdown", () => {
   it("toggles dropdown on button click", () => {
     render(() => <SettingsTOC />);
-    const toggle = screen.getByRole("button", { expanded: false });
+    const mobileToc = screen.getByTestId("mobile-toc");
+    const toggle = within(mobileToc).getByRole("button", { expanded: false });
     fireEvent.click(toggle);
-    expect(screen.getByTestId("mobile-toc").querySelector("#settings-toc-mobile")).toBeTruthy();
+    expect(mobileToc.querySelector("#settings-toc-mobile")).toBeTruthy();
   });
 
   it("closes dropdown when a TOC item is clicked", () => {

--- a/tests/components/settings/SettingsTOC.test.tsx
+++ b/tests/components/settings/SettingsTOC.test.tsx
@@ -151,6 +151,25 @@ describe("SettingsTOC — scroll to section", () => {
       block: "start",
     });
   });
+
+  it("clears scrollingTo via rAF for instant scroll", async () => {
+    const mockScrollIntoView = vi.fn();
+    vi.spyOn(document, "getElementById").mockReturnValue({
+      scrollIntoView: mockScrollIntoView,
+    } as unknown as HTMLElement);
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
+
+    const rAFSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+
+    render(() => <SettingsTOC />);
+    const nav = screen.getByRole("navigation", { name: "Settings navigation" });
+    fireEvent.click(within(nav).getByText("API Usage"));
+
+    expect(rAFSpy).toHaveBeenCalled();
+  });
 });
 
 describe("SettingsTOC — mobile dropdown", () => {

--- a/tests/components/settings/SettingsTOC.test.tsx
+++ b/tests/components/settings/SettingsTOC.test.tsx
@@ -86,6 +86,16 @@ describe("SettingsTOC — desktop rendering", () => {
 });
 
 describe("SettingsTOC — active highlighting", () => {
+  const origInnerHeight = window.innerHeight;
+  const origScrollY = window.scrollY;
+  const origScrollHeight = document.documentElement.scrollHeight;
+
+  afterEach(() => {
+    Object.defineProperty(window, "innerHeight", { value: origInnerHeight, configurable: true });
+    Object.defineProperty(window, "scrollY", { value: origScrollY, configurable: true, writable: true });
+    Object.defineProperty(document.documentElement, "scrollHeight", { value: origScrollHeight, configurable: true });
+  });
+
   it("highlights the active section", async () => {
     Object.defineProperty(window, "innerHeight", { value: 768, configurable: true });
     Object.defineProperty(window, "scrollY", { value: 200, configurable: true });

--- a/tests/components/settings/SettingsTOC.test.tsx
+++ b/tests/components/settings/SettingsTOC.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, within, cleanup } from "@solidjs/testing-library";
+import SettingsTOC, { SETTINGS_SECTIONS } from "../../../src/app/components/settings/SettingsTOC";
+import { SETTINGS_PAGE_SECTION_IDS } from "../../../src/app/components/settings/SettingsPage";
+
+let observerCallback: IntersectionObserverCallback;
+const mockObserve = vi.fn();
+const mockDisconnect = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(cb: IntersectionObserverCallback) {
+        observerCallback = cb;
+      }
+      observe = mockObserve;
+      disconnect = mockDisconnect;
+      unobserve = vi.fn();
+    }
+  );
+
+  for (const s of SETTINGS_SECTIONS) {
+    const el = document.createElement("div");
+    el.id = s.id;
+    document.body.appendChild(el);
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  for (const s of SETTINGS_SECTIONS) {
+    document.getElementById(s.id)?.remove();
+  }
+});
+
+describe("SettingsTOC — section registry", () => {
+  it("has exactly 12 entries", () => {
+    expect(SETTINGS_SECTIONS).toHaveLength(12);
+  });
+
+  it("has all 4 groups", () => {
+    const groups = [...new Set(SETTINGS_SECTIONS.map((s) => s.group))];
+    expect(groups).toEqual(["Data Sources", "Display", "Integrations", "Account"]);
+  });
+
+  it("has non-empty id, label, and group for every entry", () => {
+    for (const s of SETTINGS_SECTIONS) {
+      expect(s.id).toBeTruthy();
+      expect(s.label).toBeTruthy();
+      expect(s.group).toBeTruthy();
+    }
+  });
+});
+
+describe("SettingsTOC — registry-DOM sync", () => {
+  it("SETTINGS_SECTIONS IDs match SETTINGS_PAGE_SECTION_IDS", () => {
+    expect(SETTINGS_SECTIONS.map((s) => s.id)).toEqual(SETTINGS_PAGE_SECTION_IDS);
+  });
+});
+
+describe("SettingsTOC — desktop rendering", () => {
+  it("renders all groups and sections in the desktop nav", () => {
+    render(() => <SettingsTOC />);
+    const nav = screen.getByRole("navigation", { name: "Settings navigation" });
+
+    within(nav).getByText("Data Sources");
+    within(nav).getByText("Display");
+    within(nav).getByText("Integrations");
+    within(nav).getByText("Account");
+
+    for (const s of SETTINGS_SECTIONS) {
+      within(nav).getByText(s.label);
+    }
+  });
+
+  it("renders sections in correct group order", () => {
+    render(() => <SettingsTOC />);
+    const nav = screen.getByRole("navigation", { name: "Settings navigation" });
+    const buttons = within(nav).getAllByRole("button");
+    const labels = buttons.map((b) => b.textContent);
+
+    expect(labels).toEqual(SETTINGS_SECTIONS.map((s) => s.label));
+  });
+});
+
+describe("SettingsTOC — active highlighting", () => {
+  it("highlights the active section", async () => {
+    Object.defineProperty(window, "innerHeight", { value: 768, configurable: true });
+    Object.defineProperty(window, "scrollY", { value: 200, configurable: true });
+    Object.defineProperty(document.documentElement, "scrollHeight", { value: 5000, configurable: true });
+
+    render(() => <SettingsTOC />);
+    const nav = screen.getByRole("navigation", { name: "Settings navigation" });
+
+    const refreshEl = document.getElementById("refresh")!;
+    observerCallback(
+      [
+        {
+          target: refreshEl,
+          isIntersecting: true,
+          boundingClientRect: { top: 10 } as DOMRect,
+          intersectionRatio: 1,
+          intersectionRect: {} as DOMRect,
+          rootBounds: null,
+          time: 0,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver
+    );
+
+    await vi.waitFor(() => {
+      const refreshBtn = within(nav).getByText("Refresh");
+      expect(refreshBtn.className).toContain("bg-primary/10");
+    });
+  });
+});
+
+describe("SettingsTOC — scroll to section", () => {
+  it("calls scrollIntoView with smooth behavior on click", () => {
+    const mockScrollIntoView = vi.fn();
+    vi.spyOn(document, "getElementById").mockReturnValue({
+      scrollIntoView: mockScrollIntoView,
+    } as unknown as HTMLElement);
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+
+    render(() => <SettingsTOC />);
+    const nav = screen.getByRole("navigation", { name: "Settings navigation" });
+    fireEvent.click(within(nav).getByText("API Usage"));
+
+    expect(mockScrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+  });
+
+  it("uses instant scroll with prefers-reduced-motion", () => {
+    const mockScrollIntoView = vi.fn();
+    vi.spyOn(document, "getElementById").mockReturnValue({
+      scrollIntoView: mockScrollIntoView,
+    } as unknown as HTMLElement);
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
+
+    render(() => <SettingsTOC />);
+    const nav = screen.getByRole("navigation", { name: "Settings navigation" });
+    fireEvent.click(within(nav).getByText("API Usage"));
+
+    expect(mockScrollIntoView).toHaveBeenCalledWith({
+      behavior: "instant",
+      block: "start",
+    });
+  });
+});
+
+describe("SettingsTOC — mobile dropdown", () => {
+  it("toggles dropdown on button click", () => {
+    render(() => <SettingsTOC />);
+    const toggle = screen.getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("mobile-toc").querySelector("#settings-toc-mobile")).toBeTruthy();
+  });
+
+  it("closes dropdown when a TOC item is clicked", () => {
+    render(() => <SettingsTOC />);
+    const mobileToc = screen.getByTestId("mobile-toc");
+    const toggle = within(mobileToc).getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+
+    const dropdown = document.getElementById("settings-toc-mobile")!;
+    const refreshBtn = within(dropdown).getByText("Refresh");
+
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    const origGetById = document.getElementById.bind(document);
+    vi.spyOn(document, "getElementById").mockImplementation((id: string) => {
+      if (id === "settings-toc-mobile") return origGetById(id);
+      const el = origGetById(id);
+      if (el) {
+        el.scrollIntoView = vi.fn();
+        return el;
+      }
+      return null;
+    });
+
+    fireEvent.click(refreshBtn);
+
+    expect(origGetById("settings-toc-mobile")).toBeNull();
+  });
+
+  it("closes dropdown on Escape key", () => {
+    render(() => <SettingsTOC />);
+    const mobileToc = screen.getByTestId("mobile-toc");
+    const toggle = within(mobileToc).getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+
+    expect(document.getElementById("settings-toc-mobile")).toBeTruthy();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(document.getElementById("settings-toc-mobile")).toBeNull();
+  });
+
+  it("closes dropdown on click outside", () => {
+    render(() => <SettingsTOC />);
+    const mobileToc = screen.getByTestId("mobile-toc");
+    const toggle = within(mobileToc).getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+
+    expect(document.getElementById("settings-toc-mobile")).toBeTruthy();
+    fireEvent.pointerDown(document.body);
+    expect(document.getElementById("settings-toc-mobile")).toBeNull();
+  });
+});
+
+describe("SettingsTOC — cleanup", () => {
+  it("disconnects IntersectionObserver on unmount", () => {
+    const { unmount } = render(() => <SettingsTOC />);
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it("removes event listeners on unmount when dropdown is open", () => {
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    const { unmount } = render(() => <SettingsTOC />);
+    const mobileToc = screen.getByTestId("mobile-toc");
+    const toggle = within(mobileToc).getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+
+    unmount();
+
+    const removedTypes = removeSpy.mock.calls.map((c) => c[0]);
+    expect(removedTypes).toContain("pointerdown");
+    expect(removedTypes).toContain("keydown");
+  });
+});

--- a/tests/components/settings/SettingsTOC.test.tsx
+++ b/tests/components/settings/SettingsTOC.test.tsx
@@ -128,24 +128,39 @@ describe("SettingsTOC — active highlighting", () => {
 });
 
 describe("SettingsTOC — scroll to section", () => {
-  it("calls scrollIntoView with smooth behavior on click", () => {
-    const mockScrollIntoView = vi.fn();
-    vi.spyOn(document, "getElementById").mockReturnValue({
-      scrollIntoView: mockScrollIntoView,
-    } as unknown as HTMLElement);
+  it("uses JS-driven smooth scroll on click", () => {
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    const scrollToSpy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    const targetEl = document.getElementById("api-usage")!;
+    vi.spyOn(targetEl, "getBoundingClientRect").mockReturnValue({
+      top: 800, bottom: 900, left: 0, right: 0, width: 0, height: 100, x: 0, y: 800, toJSON: () => {},
+    });
+    const origGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, "getComputedStyle").mockImplementation((el, pseudo?) => {
+      const style = origGetComputedStyle(el, pseudo);
+      if (el === targetEl) {
+        return { ...style, scrollMarginTop: "96px", getPropertyValue: style.getPropertyValue.bind(style) } as CSSStyleDeclaration;
+      }
+      return style;
+    });
+
+    let time = 0;
+    const rAFSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      time += 600;
+      cb(time);
+      return 0;
+    });
 
     render(() => <SettingsTOC />);
     const nav = screen.getByRole("navigation", { name: "Settings navigation" });
     fireEvent.click(within(nav).getByText("API Usage"));
 
-    expect(mockScrollIntoView).toHaveBeenCalledWith({
-      behavior: "smooth",
-      block: "start",
-    });
+    expect(rAFSpy).toHaveBeenCalled();
+    expect(scrollToSpy).toHaveBeenCalled();
   });
 
-  it("uses instant scroll with prefers-reduced-motion", () => {
+  it("uses instant scrollIntoView with prefers-reduced-motion", () => {
     const mockScrollIntoView = vi.fn();
     vi.spyOn(document, "getElementById").mockReturnValue({
       scrollIntoView: mockScrollIntoView,
@@ -192,6 +207,10 @@ describe("SettingsTOC — mobile dropdown", () => {
   });
 
   it("closes dropdown when a TOC item is clicked", () => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => { cb(1000); return 0; });
+
     render(() => <SettingsTOC />);
     const mobileToc = screen.getByTestId("mobile-toc");
     const toggle = within(mobileToc).getByRole("button", { expanded: false });
@@ -199,22 +218,9 @@ describe("SettingsTOC — mobile dropdown", () => {
 
     const dropdown = document.getElementById("settings-toc-mobile")!;
     const refreshBtn = within(dropdown).getByText("Refresh");
-
-    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
-    const origGetById = document.getElementById.bind(document);
-    vi.spyOn(document, "getElementById").mockImplementation((id: string) => {
-      if (id === "settings-toc-mobile") return origGetById(id);
-      const el = origGetById(id);
-      if (el) {
-        el.scrollIntoView = vi.fn();
-        return el;
-      }
-      return null;
-    });
-
     fireEvent.click(refreshBtn);
 
-    expect(origGetById("settings-toc-mobile")).toBeNull();
+    expect(document.getElementById("settings-toc-mobile")).toBeNull();
   });
 
   it("closes dropdown on Escape key", () => {


### PR DESCRIPTION
## Summary
- Adds sticky shrinking header, IntersectionObserver scroll-spy TOC sidebar (desktop) and dropdown (mobile)
- Reorganizes 12 settings sections into 4 logical groups: Data Sources, Display, Integrations, Account
- Uses JS-driven smooth scroll (rAF) for browser compatibility (Vivaldi, Chromium forks)
- Hysteresis on header threshold prevents layout feedback oscillation

Closes #105