### PR TITLE
fix(deps): strips version specifiers from cached dep metadata

### DIFF
--- a/src/app/components/dashboard/DependenciesTab.tsx
+++ b/src/app/components/dashboard/DependenciesTab.tsx
@@ -8,6 +8,7 @@ import type { AbandonedDependency } from "../../lib/dependency-dashboard";
 import {
   classifyDepStatus,
   extractVersionInfo,
+  stripVersionSpecifier,
   ALL_DEP_STATUSES,
   isKnownDepBot,
   DEP_TOOL_LABEL_NAMES,
@@ -174,8 +175,8 @@ export default function DependenciesTab(props: DependenciesTabProps) {
         if (cached && (!titleInfo?.updateType || !titleInfo?.from)) {
           versionInfo = {
             packageName: titleInfo?.packageName ?? cached.packageName,
-            from: cached.from ?? titleInfo?.from,
-            to: cached.to ?? titleInfo?.to,
+            from: stripVersionSpecifier(cached.from ?? titleInfo?.from ?? "") || undefined,
+            to: stripVersionSpecifier(cached.to ?? titleInfo?.to ?? "") || undefined,
             updateType: cached.updateType ?? titleInfo?.updateType,
           };
         }

--- a/src/app/lib/dependency-detection.ts
+++ b/src/app/lib/dependency-detection.ts
@@ -74,7 +74,7 @@ export function isDependencyPr(pr: PullRequest, trackedBotLogins: Set<string>): 
 
 const VERSION_SPECIFIER_RE = /^[><=!~^]+/;
 
-function stripVersionSpecifier(v: string): string {
+export function stripVersionSpecifier(v: string): string {
   return v.replace(VERSION_SPECIFIER_RE, "");
 }
 

--- a/tests/lib/dependency-detection.test.ts
+++ b/tests/lib/dependency-detection.test.ts
@@ -8,6 +8,7 @@ import {
   isRebasing,
   isKnownDepBot,
   expandBotLogins,
+  stripVersionSpecifier,
   KNOWN_DEP_BOT_LOGINS,
   DEP_BRANCH_PREFIXES,
   DEP_TITLE_PATTERN,
@@ -207,6 +208,37 @@ describe("extractVersionInfo", () => {
   it("returns null updateType when from and to are identical versions", () => {
     const result = extractVersionInfo("Bump lodash from 4.17.21 to 4.17.21");
     expect(result).toEqual({ packageName: "lodash", from: "4.17.21", to: "4.17.21", updateType: undefined });
+  });
+});
+
+describe("stripVersionSpecifier", () => {
+  it("strips == prefix", () => {
+    expect(stripVersionSpecifier("==9.0.2")).toBe("9.0.2");
+  });
+
+  it("strips >= prefix", () => {
+    expect(stripVersionSpecifier(">=1.5.0")).toBe("1.5.0");
+  });
+
+  it("strips ~= prefix", () => {
+    expect(stripVersionSpecifier("~=1.15.0")).toBe("1.15.0");
+  });
+
+  it("strips ^ prefix (npm caret)", () => {
+    expect(stripVersionSpecifier("^1.2.3")).toBe("1.2.3");
+  });
+
+  it("strips <= prefix", () => {
+    expect(stripVersionSpecifier("<=2.0.0")).toBe("2.0.0");
+  });
+
+  it("leaves plain versions unchanged", () => {
+    expect(stripVersionSpecifier("4.17.21")).toBe("4.17.21");
+    expect(stripVersionSpecifier("v2.0.0")).toBe("v2.0.0");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripVersionSpecifier("")).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary
- Strips `==`, `>=`, `~=` prefixes from cached body-parsed version metadata when merging into display
- Exports `stripVersionSpecifier` from dependency-detection module
- Fixes stale localStorage cache showing raw pip specifiers like `==9.0.2 → ==9.0.3`