### PR TITLE
fix(deps): disable strictDepBuilds for pnpm 11 compatibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - "mcp"
+
+strictDepBuilds: false


### PR DESCRIPTION
## Summary
- pnpm 11 hard-fails `--frozen-lockfile` installs (`ERR_PNPM_IGNORED_BUILDS`) unless script-bearing dependencies are acknowledged in `pnpm-workspace.yaml`; this blocks PR #113's pnpm 10→11 security bump
- Adds `strictDepBuilds: false`; verified locally that install now only warns instead of failing under pnpm 11.5.3 (the version in #113)
- Unblocks the pnpm major bump in #113 once merged