### PR TITLE
feat(dependencies): exclude repos/orgs from Dependencies tab

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -317,7 +317,7 @@ Go to **Settings > Dependencies** to configure:
 |---------|---------|-------------|
 | Enable Dependencies tab | On | Show or hide the tab. When disabled, dependency PRs appear in the standard Pull Requests tab. |
 | Rebase label | `rebase` | PRs with this label are shown with a "Rebasing" indicator in the Dependencies tab. Change to match the label name your dependency bot uses to signal rebase-needed status. |
-| Excluded repos/orgs | (none) | Hide specific repos or entire orgs from the Dependencies tab — including their Renovate Dashboard "Abandoned" package badges. Picked from your selected, upstream, and monitored repos. Excluding an org covers all repos under it, including ones added later. Excluded items still appear normally in Issues, Pull Requests, and Actions. |
+| Excluded repos/orgs | (none) | Hide specific repos or entire orgs from the Dependencies tab — including their Renovate Dashboard "Abandoned" package badges. Picked from your selected, upstream, and monitored repos. Excluding an org covers all repos under it, including ones added later. Regular issues, pull requests, and workflow runs for excluded repos are unaffected — only their dependency-bot PRs are hidden, and those don't reappear in Pull Requests either. |
 
 ### Dependencies Filters
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -288,7 +288,7 @@ The tab uses a multi-layer detection pipeline to identify dependency PRs:
 4. **Title pattern** — PR titles matching common dependency update patterns (e.g., "Bump X from Y to Z", "chore(deps): ...", "[Snyk] ...") are detected.
 5. **Label match** — PRs with the `dependencies` label are included.
 
-Dependency PRs claimed by the Dependencies tab are excluded from the standard Pull Requests tab and any custom tabs with exclusivity enabled. The tab title shows the current count of open dependency PRs.
+Dependency PRs claimed by the Dependencies tab are excluded from the standard Pull Requests tab and any custom tabs with exclusivity enabled. The tab title shows the current count of open dependency PRs. This exclusivity still applies to repos you've excluded from the Dependencies tab — their dependency PRs disappear entirely rather than reappearing in Pull Requests.
 
 ### Status Grouping
 
@@ -307,7 +307,7 @@ Within each group, PRs are sorted by repository name, then update category (main
 
 If a Renovate Dashboard issue is detected in one of your tracked repos, abandoned dependency entries from its "Abandoned" section are shown as pill badges on matching PR rows. Each pill links directly to the Renovate Dashboard issue so you can investigate further.
 
-The parser reads the Renovate Dashboard issue body to extract package names from the abandoned dependencies table.
+The parser reads the Renovate Dashboard issue body to extract package names from the abandoned dependencies table. Repos excluded from the Dependencies tab (see Dependencies Settings below) are skipped for abandoned-package detection too — their Renovate Dashboard issue is never checked.
 
 ### Dependencies Settings
 
@@ -317,6 +317,7 @@ Go to **Settings > Dependencies** to configure:
 |---------|---------|-------------|
 | Enable Dependencies tab | On | Show or hide the tab. When disabled, dependency PRs appear in the standard Pull Requests tab. |
 | Rebase label | `rebase` | PRs with this label are shown with a "Rebasing" indicator in the Dependencies tab. Change to match the label name your dependency bot uses to signal rebase-needed status. |
+| Excluded repos/orgs | (none) | Hide specific repos or entire orgs from the Dependencies tab — including their Renovate Dashboard "Abandoned" package badges. Picked from your selected, upstream, and monitored repos. Excluding an org covers all repos under it, including ones added later. Excluded items still appear normally in Issues, Pull Requests, and Actions. |
 
 ### Dependencies Filters
 

--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -12,6 +12,7 @@ import { config, setConfig, getCustomTab, isBuiltinTab, isActionsBasedTab, isTab
 import { viewState, updateViewState, setSortPreference, pruneClosedTrackedItems, removeCustomTabState, untrackJiraItem, setTabFilter, IssueFiltersSchema, PullRequestFiltersSchema, ActionsFiltersSchema } from "../../stores/view";
 import DependenciesTab from "./DependenciesTab";
 import { isDependencyPr, expandBotLogins, needsBodyFallback, parseRenovateBody, type VersionInfo } from "../../lib/dependency-detection";
+import { isRepoExcludedFromDependencies } from "../../lib/dependency-exclusion";
 import { findDashboardIssues, parseAbandonedSection, resetAbandonedPatternCache, type AbandonedDependency } from "../../lib/dependency-dashboard";
 import { fetchDashboardIssueBodies, fetchDepPRBodies } from "../../services/api";
 import type { SortOption } from "../shared/SortDropdown";
@@ -857,10 +858,22 @@ export default function DashboardPage() {
   const trackedBotLogins = createMemo(() =>
     expandBotLogins(config.trackedUsers.filter((u) => u.type === "bot").map((u) => u.login.toLowerCase()))
   );
+  // Unfiltered classification — for rendering/counting use visibleDependencyPullRequests below.
   const dependencyPullRequests = createMemo(() => {
     if (!config.dependencies.enabled) return [];
     return dashboardData.pullRequests.filter((pr) => pr.state === "OPEN" && isDependencyPr(pr, trackedBotLogins()));
   });
+
+  // Dependencies-tab display filter — applied on top of the unfiltered
+  // dependencyPullRequests classification above. dependencyPrIds (below) and
+  // exclusiveOwnership deliberately keep using the UNFILTERED memo, so an
+  // excluded repo's bot PRs still don't leak into the main Pull Requests tab —
+  // they vanish entirely instead of reappearing elsewhere.
+  const visibleDependencyPullRequests = createMemo(() =>
+    dependencyPullRequests().filter(
+      (pr) => !isRepoExcludedFromDependencies(pr.repoFullName, config.dependencies.excludedOrgs, config.dependencies.excludedRepos)
+    )
+  );
   const dependencyPrIds = createMemo(() =>
     new Set(dependencyPullRequests().map((pr) => pr.id))
   );
@@ -917,7 +930,7 @@ export default function DashboardPage() {
   }
 
   const enableDependencies = createMemo(() =>
-    config.dependencies.enabled && dependencyPullRequests().length > 0
+    config.dependencies.enabled && visibleDependencyPullRequests().length > 0
   );
 
   // Visible data for built-in tabs — filters out exclusively-owned items
@@ -1070,7 +1083,7 @@ export default function DashboardPage() {
           return true;
         }).length };
       })() : {}),
-      ...(enableDependencies() ? { dependencies: dependencyPullRequests().filter((p) => !ignoredPRs.has(p.id)).length } : {}),
+      ...(enableDependencies() ? { dependencies: visibleDependencyPullRequests().filter((p) => !ignoredPRs.has(p.id)).length } : {}),
       ...customCounts,
     };
   });
@@ -1163,7 +1176,7 @@ export default function DashboardPage() {
       void (async () => {
         try {
           const dashboardIssues = findDashboardIssues(dashboardData.issues, trackedBotLogins());
-          const depRepos = new Set(dependencyPullRequests().map((pr) => pr.repoFullName));
+          const depRepos = new Set(visibleDependencyPullRequests().map((pr) => pr.repoFullName));
           const relevant = dashboardIssues.filter((di) => depRepos.has(di.repoFullName));
           if (relevant.length === 0) return;
 
@@ -1202,7 +1215,8 @@ export default function DashboardPage() {
 
     const meta = depMeta();
     const depPrs = dependencyPullRequests();
-    const toFetch = depPrs.filter((pr) => !meta.has(pr.id) && needsBodyFallback(pr));
+    const visibleDepPrs = visibleDependencyPullRequests();
+    const toFetch = visibleDepPrs.filter((pr) => !meta.has(pr.id) && needsBodyFallback(pr));
     if (toFetch.length === 0) return;
 
     _fetchingDepBodies = true;
@@ -1323,7 +1337,7 @@ export default function DashboardPage() {
               </Match>
               <Match when={activeTab() === "dependencies"}>
                 <DependenciesTab
-                  pullRequests={dependencyPullRequests()}
+                  pullRequests={visibleDependencyPullRequests()}
                   depMeta={depMeta()}
                   loading={dashboardData.loading}
                   abandonedDepsMap={abandonedDepsMap()}
@@ -1338,7 +1352,7 @@ export default function DashboardPage() {
               </Match>
               <Match when={activeTab() === "dependencies"}>
                 <DependenciesTab
-                  pullRequests={dependencyPullRequests()}
+                  pullRequests={visibleDependencyPullRequests()}
                   loading={dashboardData.loading}
                   abandonedDepsMap={abandonedDepsMap()}
                   dashboardIssueUrls={dashboardIssueUrls()}

--- a/src/app/components/settings/DependencyExclusionModal.tsx
+++ b/src/app/components/settings/DependencyExclusionModal.tsx
@@ -1,0 +1,134 @@
+import { createSignal, createEffect } from "solid-js";
+import { Dialog } from "@kobalte/core/dialog";
+import type { RepoRef } from "../../services/api";
+import OrgRepoCheckboxTree from "../shared/OrgRepoCheckboxTree";
+
+interface DependencyExclusionModalProps {
+  open: boolean;
+  onClose: () => void;
+  availableOrgs: string[];
+  availableRepos: RepoRef[];
+  excludedOrgs: string[];
+  excludedRepos: RepoRef[];
+  onSave: (excludedOrgs: string[], excludedRepos: RepoRef[]) => void;
+}
+
+export default function DependencyExclusionModal(props: DependencyExclusionModalProps) {
+  const [excludedOrgs, setExcludedOrgs] = createSignal<Set<string>>(new Set(props.excludedOrgs));
+  const [excludedRepos, setExcludedRepos] = createSignal<Set<string>>(
+    new Set(props.excludedRepos.map((r) => r.fullName))
+  );
+
+  // Reinitialize when the modal reopens — mirrors CustomTabModal's reinit effect
+  // (props.open false→true), so stale in-progress edits don't leak between opens.
+  createEffect(() => {
+    if (!props.open) return;
+    setExcludedOrgs(new Set(props.excludedOrgs));
+    setExcludedRepos(new Set(props.excludedRepos.map((r) => r.fullName)));
+  });
+
+  function toggleOrg(org: string) {
+    setExcludedOrgs((prev) => {
+      const next = new Set(prev);
+      if (next.has(org)) {
+        next.delete(org);
+        // Also remove repos in this org from the repo-exclusion set — mirrors
+        // CustomTabModal's toggleOrg cleanup on DESELECT exactly: deselecting
+        // an org clears its repos; selecting an org never touches the repo set
+        // (OrgRepoCheckboxTree's checked-attribute OR handles display without
+        // needing individual repo entries).
+        setExcludedRepos((prevRepos) => {
+          const next2 = new Set(prevRepos);
+          for (const r of props.availableRepos) {
+            if (r.owner === org) next2.delete(r.fullName);
+          }
+          return next2;
+        });
+      } else {
+        next.add(org);
+      }
+      return next;
+    });
+  }
+
+  function toggleRepo(repoFullName: string) {
+    setExcludedRepos((prev) => {
+      const next = new Set(prev);
+      if (next.has(repoFullName)) {
+        next.delete(repoFullName);
+      } else {
+        next.add(repoFullName);
+      }
+      return next;
+    });
+  }
+
+  function buildExcludedRepos(): RepoRef[] {
+    return props.availableRepos.filter((r) => excludedRepos().has(r.fullName));
+  }
+
+  function handleSave() {
+    props.onSave([...excludedOrgs()], buildExcludedRepos());
+    props.onClose();
+  }
+
+  return (
+    <Dialog open={props.open} onOpenChange={(open) => !open && props.onClose()} modal>
+      <Dialog.Portal>
+        <Dialog.Overlay class="fixed inset-0 bg-black/50 z-[70]" />
+        <Dialog.Content class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg bg-base-100 rounded-xl shadow-xl z-[71] flex flex-col max-h-[90vh]">
+          <Dialog.Description class="sr-only">
+            Manage repos and orgs excluded from the Dependencies tab
+          </Dialog.Description>
+
+          {/* Header */}
+          <div class="flex items-center gap-2 px-5 py-4 border-b border-base-300 shrink-0">
+            <Dialog.Title class="text-lg font-semibold flex-1">
+              Exclude from Dependencies
+            </Dialog.Title>
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm btn-circle"
+              aria-label="Close"
+              onClick={props.onClose}
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Scrollable body */}
+          <div class="overflow-y-auto flex-1 px-5 py-4 space-y-3">
+            <p class="text-xs text-base-content/50">
+              Repos and orgs checked below are hidden from the Dependencies tab only — they'll still appear in Issues, Pull Requests, and Actions.
+            </p>
+            <div class="overflow-y-auto max-h-[400px] space-y-3">
+              <OrgRepoCheckboxTree
+                availableOrgs={props.availableOrgs}
+                availableRepos={props.availableRepos}
+                checkedOrgs={excludedOrgs()}
+                checkedRepos={excludedRepos()}
+                onToggleOrg={toggleOrg}
+                onToggleRepo={toggleRepo}
+                emptyMessage="No repos tracked yet."
+              />
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div class="flex items-center justify-end gap-2 px-5 py-4 border-t border-base-300 shrink-0">
+            <button type="button" class="btn btn-ghost btn-sm" onClick={props.onClose}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              onClick={handleSave}
+            >
+              Save
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  );
+}

--- a/src/app/components/settings/DependencyExclusionModal.tsx
+++ b/src/app/components/settings/DependencyExclusionModal.tsx
@@ -1,6 +1,6 @@
-import { createSignal, createEffect } from "solid-js";
 import { Dialog } from "@kobalte/core/dialog";
 import type { RepoRef } from "../../services/api";
+import { createOrgRepoSelection } from "../../lib/orgRepoSelection";
 import OrgRepoCheckboxTree from "../shared/OrgRepoCheckboxTree";
 
 interface DependencyExclusionModalProps {
@@ -14,58 +14,18 @@ interface DependencyExclusionModalProps {
 }
 
 export default function DependencyExclusionModal(props: DependencyExclusionModalProps) {
-  const [excludedOrgs, setExcludedOrgs] = createSignal<Set<string>>(new Set(props.excludedOrgs));
-  const [excludedRepos, setExcludedRepos] = createSignal<Set<string>>(
-    new Set(props.excludedRepos.map((r) => r.fullName))
-  );
-
-  // Reinitialize when the modal reopens — mirrors CustomTabModal's reinit effect
-  // (props.open false→true), so stale in-progress edits don't leak between opens.
-  createEffect(() => {
-    if (!props.open) return;
-    setExcludedOrgs(new Set(props.excludedOrgs));
-    setExcludedRepos(new Set(props.excludedRepos.map((r) => r.fullName)));
+  const {
+    selectedOrgs: excludedOrgs,
+    selectedRepos: excludedRepos,
+    toggleOrg,
+    toggleRepo,
+    buildRepoList: buildExcludedRepos,
+  } = createOrgRepoSelection({
+    getOpen: () => props.open,
+    getAvailableRepos: () => props.availableRepos,
+    getInitialOrgs: () => props.excludedOrgs,
+    getInitialRepos: () => props.excludedRepos.map((r) => r.fullName),
   });
-
-  function toggleOrg(org: string) {
-    setExcludedOrgs((prev) => {
-      const next = new Set(prev);
-      if (next.has(org)) {
-        next.delete(org);
-        // Also remove repos in this org from the repo-exclusion set — mirrors
-        // CustomTabModal's toggleOrg cleanup on DESELECT exactly: deselecting
-        // an org clears its repos; selecting an org never touches the repo set
-        // (OrgRepoCheckboxTree's checked-attribute OR handles display without
-        // needing individual repo entries).
-        setExcludedRepos((prevRepos) => {
-          const next2 = new Set(prevRepos);
-          for (const r of props.availableRepos) {
-            if (r.owner === org) next2.delete(r.fullName);
-          }
-          return next2;
-        });
-      } else {
-        next.add(org);
-      }
-      return next;
-    });
-  }
-
-  function toggleRepo(repoFullName: string) {
-    setExcludedRepos((prev) => {
-      const next = new Set(prev);
-      if (next.has(repoFullName)) {
-        next.delete(repoFullName);
-      } else {
-        next.add(repoFullName);
-      }
-      return next;
-    });
-  }
-
-  function buildExcludedRepos(): RepoRef[] {
-    return props.availableRepos.filter((r) => excludedRepos().has(r.fullName));
-  }
 
   function handleSave() {
     props.onSave([...excludedOrgs()], buildExcludedRepos());
@@ -101,7 +61,7 @@ export default function DependencyExclusionModal(props: DependencyExclusionModal
             <p class="text-xs text-base-content/50">
               Repos and orgs checked below are hidden from the Dependencies tab only — their dependency-bot PRs won't reappear in Pull Requests, but regular issues, pull requests, and workflow runs are unaffected.
             </p>
-            <div class="overflow-y-auto max-h-[400px] space-y-3">
+            <div class="space-y-3">
               <OrgRepoCheckboxTree
                 availableOrgs={props.availableOrgs}
                 availableRepos={props.availableRepos}

--- a/src/app/components/settings/DependencyExclusionModal.tsx
+++ b/src/app/components/settings/DependencyExclusionModal.tsx
@@ -99,7 +99,7 @@ export default function DependencyExclusionModal(props: DependencyExclusionModal
           {/* Scrollable body */}
           <div class="overflow-y-auto flex-1 px-5 py-4 space-y-3">
             <p class="text-xs text-base-content/50">
-              Repos and orgs checked below are hidden from the Dependencies tab only — they'll still appear in Issues, Pull Requests, and Actions.
+              Repos and orgs checked below are hidden from the Dependencies tab only — their dependency-bot PRs won't reappear in Pull Requests, but regular issues, pull requests, and workflow runs are unaffected.
             </p>
             <div class="overflow-y-auto max-h-[400px] space-y-3">
               <OrgRepoCheckboxTree

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -153,6 +153,10 @@ export default function SettingsPage() {
   const dependencyExclusionOrgs = createMemo(() =>
     [...new Set(dependencyExclusionPool().map((r) => r.owner))]
   );
+  const excludedCounts = createMemo(() => ({
+    orgs: (config.dependencies?.excludedOrgs ?? []).length,
+    repos: (config.dependencies?.excludedRepos ?? []).length,
+  }));
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -1375,9 +1379,9 @@ export default function SettingsPage() {
           >
             <div class="flex items-center gap-3">
               <span class="text-xs text-base-content/60">
-                {(config.dependencies?.excludedOrgs ?? []).length === 0 && (config.dependencies?.excludedRepos ?? []).length === 0
+                {excludedCounts().orgs === 0 && excludedCounts().repos === 0
                   ? "None excluded"
-                  : formatScopeSummary((config.dependencies?.excludedOrgs ?? []).length, (config.dependencies?.excludedRepos ?? []).length, true)}
+                  : formatScopeSummary(excludedCounts().orgs, excludedCounts().repos, true)}
               </span>
               <button
                 type="button"

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1371,7 +1371,7 @@ export default function SettingsPage() {
           </SettingRow>
           <SettingRow
             label="Excluded repos/orgs"
-            description="Hide specific repos or entire orgs from the Dependencies tab only — they still appear in Issues, Pull Requests, and Actions"
+            description="Hide specific repos or entire orgs from the Dependencies tab only — their dependency-bot PRs won't reappear in Pull Requests, but regular issues, pull requests, and workflow runs for those repos are unaffected"
           >
             <div class="flex items-center gap-3">
               <span class="text-xs text-base-content/60">

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -14,7 +14,7 @@ import { pushNotification } from "../../lib/errors";
 import { buildOrgAccessUrl, buildJiraAuthorizeUrl } from "../../lib/oauth";
 import { sealApiToken } from "../../lib/proxy";
 import { isSafeGitHubUrl, openGitHubUrl } from "../../lib/url";
-import { relativeTime } from "../../lib/format";
+import { relativeTime, formatScopeSummary } from "../../lib/format";
 import { fetchOrgs } from "../../services/api";
 import { getClient } from "../../services/github";
 import { getUsageSnapshot, getUsageResetAt, resetUsageData, checkAndResetIfExpired, SOURCE_LABELS } from "../../services/api-usage";
@@ -27,6 +27,7 @@ import ThemePicker from "./ThemePicker";
 import DensityPicker from "./DensityPicker";
 import TrackedUsersSection from "./TrackedUsersSection";
 import CustomTabsSection from "./CustomTabsSection";
+import DependencyExclusionModal from "./DependencyExclusionModal";
 import { InfoTooltip } from "../shared/Tooltip";
 import { createJiraClient } from "../../lib/jira-utils";
 import JiraFieldPicker from "./JiraFieldPicker";
@@ -140,6 +141,17 @@ export default function SettingsPage() {
 
   const monitoredRepoNames = createMemo(() =>
     config.monitoredRepos.map(r => r.fullName).join(", ")
+  );
+
+  const dependencyExclusionPool = createMemo(() => {
+    const seen = new Map<string, RepoRef>();
+    for (const r of [...config.selectedRepos, ...config.upstreamRepos, ...config.monitoredRepos]) {
+      seen.set(r.fullName.toLowerCase(), r);
+    }
+    return [...seen.values()];
+  });
+  const dependencyExclusionOrgs = createMemo(() =>
+    [...new Set(dependencyExclusionPool().map((r) => r.owner))]
   );
 
   // ── Helpers ──────────────────────────────────────────────────────────────
@@ -352,6 +364,7 @@ export default function SettingsPage() {
   const [jiraApiMode, setJiraApiMode] = createSignal(false);
   const [showFieldPicker, setShowFieldPicker] = createSignal(false);
   const [showScopePicker, setShowScopePicker] = createSignal(false);
+  const [showDependencyExclusionModal, setShowDependencyExclusionModal] = createSignal(false);
 
   const jiraClient = createMemo(() => createJiraClient(config.jira?.authMethod));
 
@@ -1356,6 +1369,25 @@ export default function SettingsPage() {
               onInput={(e) => saveWithFeedback({ dependencies: { ...config.dependencies, rebaseLabel: e.currentTarget.value || "rebase" } })}
             />
           </SettingRow>
+          <SettingRow
+            label="Excluded repos/orgs"
+            description="Hide specific repos or entire orgs from the Dependencies tab only — they still appear in Issues, Pull Requests, and Actions"
+          >
+            <div class="flex items-center gap-3">
+              <span class="text-xs text-base-content/60">
+                {(config.dependencies?.excludedOrgs ?? []).length === 0 && (config.dependencies?.excludedRepos ?? []).length === 0
+                  ? "None excluded"
+                  : formatScopeSummary((config.dependencies?.excludedOrgs ?? []).length, (config.dependencies?.excludedRepos ?? []).length, true)}
+              </span>
+              <button
+                type="button"
+                class="btn btn-sm btn-outline"
+                onClick={() => setShowDependencyExclusionModal(true)}
+              >
+                Manage
+              </button>
+            </div>
+          </SettingRow>
         </Section>
 
         {/* ── Account ─────────────────────────────────────────────────── */}
@@ -1538,6 +1570,18 @@ export default function SettingsPage() {
         </Section>
           </div>
         </div>
+
+        <DependencyExclusionModal
+          open={showDependencyExclusionModal()}
+          onClose={() => setShowDependencyExclusionModal(false)}
+          availableOrgs={dependencyExclusionOrgs()}
+          availableRepos={dependencyExclusionPool()}
+          excludedOrgs={config.dependencies?.excludedOrgs ?? []}
+          excludedRepos={config.dependencies?.excludedRepos ?? []}
+          onSave={(orgs, repos) =>
+            saveWithFeedback({ dependencies: { ...config.dependencies, excludedOrgs: orgs, excludedRepos: repos } })
+          }
+        />
 
         <footer class="mt-8 border-t border-base-300 pt-4 pb-8 text-xs text-base-content/50 text-center">
           <div class="flex items-center justify-center gap-3">

--- a/src/app/components/shared/CustomTabModal.tsx
+++ b/src/app/components/shared/CustomTabModal.tsx
@@ -5,6 +5,7 @@ import type { CustomTab } from "../../stores/config";
 import { resetCustomTabFilters } from "../../stores/view";
 import type { RepoRef } from "../../services/api";
 import { formatScopeSummary } from "../../lib/format";
+import { createOrgRepoSelection } from "../../lib/orgRepoSelection";
 import OrgRepoCheckboxTree from "./OrgRepoCheckboxTree";
 import {
   scopeFilterGroup,
@@ -37,12 +38,12 @@ export default function CustomTabModal(props: CustomTabModalProps) {
   const [baseType, setBaseType] = createSignal<"issues" | "pullRequests" | "actions">(
     props.editingTab?.baseType ?? "issues"
   );
-  const [selectedOrgs, setSelectedOrgs] = createSignal<Set<string>>(
-    new Set(props.editingTab?.orgScope ?? [])
-  );
-  const [selectedRepos, setSelectedRepos] = createSignal<Set<string>>(
-    new Set((props.editingTab?.repoScope ?? []).map((r) => r.fullName))
-  );
+  const { selectedOrgs, selectedRepos, toggleOrg, toggleRepo, buildRepoList: buildRepoScope } = createOrgRepoSelection({
+    getOpen: () => props.open,
+    getAvailableRepos: () => props.availableRepos,
+    getInitialOrgs: () => props.editingTab?.orgScope ?? [],
+    getInitialRepos: () => (props.editingTab?.repoScope ?? []).map((r) => r.fullName),
+  });
   // filterPreset: field → value. Only set keys are stored.
   const [filterPreset, setFilterPreset] = createSignal<Record<string, string>>(
     { ...(props.editingTab?.filterPreset ?? {}) }
@@ -54,13 +55,12 @@ export default function CustomTabModal(props: CustomTabModalProps) {
   // Reinitialize form state when the modal opens with a different editingTab.
   // Signals are initialized at mount; without this, switching from "edit tab A" to
   // "edit tab B" (open=false then open=true) would show stale values from tab A.
+  // Org/repo scope reset is handled by createOrgRepoSelection's own reinit effect.
   createEffect(() => {
     if (!props.open) return;
     const tab = props.editingTab;
     setName(tab?.name ?? "");
     setBaseType(tab?.baseType ?? "issues");
-    setSelectedOrgs(new Set(tab?.orgScope ?? []));
-    setSelectedRepos(new Set((tab?.repoScope ?? []).map((r) => r.fullName)));
     setFilterPreset({ ...(tab?.filterPreset ?? {}) });
     setExclusive(tab?.exclusive ?? false);
     setScopeOpen(false);
@@ -90,38 +90,6 @@ export default function CustomTabModal(props: CustomTabModalProps) {
     return base;
   });
 
-  function toggleOrg(org: string) {
-    setSelectedOrgs((prev) => {
-      const next = new Set(prev);
-      if (next.has(org)) {
-        next.delete(org);
-        // Also remove repos in this org from repo selection
-        setSelectedRepos((prevRepos) => {
-          const nextRepos = new Set(prevRepos);
-          for (const r of props.availableRepos) {
-            if (r.owner === org) nextRepos.delete(r.fullName);
-          }
-          return nextRepos;
-        });
-      } else {
-        next.add(org);
-      }
-      return next;
-    });
-  }
-
-  function toggleRepo(repoFullName: string) {
-    setSelectedRepos((prev) => {
-      const next = new Set(prev);
-      if (next.has(repoFullName)) {
-        next.delete(repoFullName);
-      } else {
-        next.add(repoFullName);
-      }
-      return next;
-    });
-  }
-
   function handleBaseTypeChange(bt: "issues" | "pullRequests" | "actions") {
     setBaseType(bt);
     // Clear filter preset when base type changes — keys are type-specific
@@ -141,10 +109,6 @@ export default function CustomTabModal(props: CustomTabModalProps) {
       }
       return next;
     });
-  }
-
-  function buildRepoScope(): RepoRef[] {
-    return props.availableRepos.filter((r) => selectedRepos().has(r.fullName));
   }
 
   function handleSave() {

--- a/src/app/components/shared/CustomTabModal.tsx
+++ b/src/app/components/shared/CustomTabModal.tsx
@@ -5,6 +5,7 @@ import type { CustomTab } from "../../stores/config";
 import { resetCustomTabFilters } from "../../stores/view";
 import type { RepoRef } from "../../services/api";
 import { formatScopeSummary } from "../../lib/format";
+import OrgRepoCheckboxTree from "./OrgRepoCheckboxTree";
 import {
   scopeFilterGroup,
   issueFilterGroups,
@@ -275,53 +276,17 @@ export default function CustomTabModal(props: CustomTabModalProps) {
                   <p class="text-xs text-base-content/50">
                     Leave empty to match no repos — the tab will show a warning icon until scoped. Org selection includes all repos in that org.
                   </p>
-                  <Show
-                    when={props.availableOrgs.length > 0}
-                    fallback={<p class="text-xs text-base-content/40">No orgs available.</p>}
-                  >
-                    <div class="overflow-y-auto max-h-[300px] space-y-3">
-                      <For each={props.availableOrgs}>
-                        {(org) => {
-                          const orgRepos = createMemo(() =>
-                            props.availableRepos.filter((r) => r.owner === org)
-                          );
-                          return (
-                            <div>
-                              {/* Org header checkbox */}
-                              <label class="flex items-center gap-2 cursor-pointer py-1">
-                                <input
-                                  type="checkbox"
-                                  class="checkbox checkbox-sm checkbox-primary"
-                                  checked={selectedOrgs().has(org)}
-                                  onChange={() => toggleOrg(org)}
-                                />
-                                <span class="text-sm font-semibold">{org}</span>
-                              </label>
-                              {/* Repo checkboxes under org */}
-                              <Show when={orgRepos().length > 0}>
-                                <div class="ml-6 space-y-0.5">
-                                  <For each={orgRepos()}>
-                                    {(repo) => (
-                                      <label class="flex items-center gap-2 cursor-pointer py-0.5">
-                                        <input
-                                          type="checkbox"
-                                          class="checkbox checkbox-xs checkbox-primary"
-                                          checked={selectedRepos().has(repo.fullName) || selectedOrgs().has(org)}
-                                          disabled={selectedOrgs().has(org)}
-                                          onChange={() => toggleRepo(repo.fullName)}
-                                        />
-                                        <span class="text-xs text-base-content/70">{repo.name}</span>
-                                      </label>
-                                    )}
-                                  </For>
-                                </div>
-                              </Show>
-                            </div>
-                          );
-                        }}
-                      </For>
-                    </div>
-                  </Show>
+                  <div class="overflow-y-auto max-h-[300px] space-y-3">
+                    <OrgRepoCheckboxTree
+                      availableOrgs={props.availableOrgs}
+                      availableRepos={props.availableRepos}
+                      checkedOrgs={selectedOrgs()}
+                      checkedRepos={selectedRepos()}
+                      onToggleOrg={toggleOrg}
+                      onToggleRepo={toggleRepo}
+                      emptyMessage="No orgs available."
+                    />
+                  </div>
                 </div>
               </Show>
             </div>

--- a/src/app/components/shared/OrgRepoCheckboxTree.tsx
+++ b/src/app/components/shared/OrgRepoCheckboxTree.tsx
@@ -1,0 +1,58 @@
+import { createMemo, For, Show } from "solid-js";
+import type { RepoRef } from "../../services/api";
+
+export interface OrgRepoCheckboxTreeProps {
+  availableOrgs: string[];
+  availableRepos: RepoRef[];
+  checkedOrgs: Set<string>;
+  checkedRepos: Set<string>;
+  onToggleOrg: (org: string) => void;
+  onToggleRepo: (repoFullName: string) => void;
+  emptyMessage?: string;
+}
+
+export default function OrgRepoCheckboxTree(props: OrgRepoCheckboxTreeProps) {
+  return (
+    <Show
+      when={props.availableOrgs.length > 0}
+      fallback={<p class="text-xs text-base-content/40">{props.emptyMessage ?? "No orgs available."}</p>}
+    >
+      <For each={props.availableOrgs}>
+        {(org) => {
+          const orgRepos = createMemo(() => props.availableRepos.filter((r) => r.owner === org));
+          return (
+            <div>
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm checkbox-primary"
+                  checked={props.checkedOrgs.has(org)}
+                  onChange={() => props.onToggleOrg(org)}
+                />
+                <span class="text-sm font-semibold">{org}</span>
+              </label>
+              <Show when={orgRepos().length > 0}>
+                <div class="ml-6 space-y-0.5">
+                  <For each={orgRepos()}>
+                    {(repo) => (
+                      <label class="flex items-center gap-2 cursor-pointer py-0.5">
+                        <input
+                          type="checkbox"
+                          class="checkbox checkbox-xs checkbox-primary"
+                          checked={props.checkedRepos.has(repo.fullName) || props.checkedOrgs.has(org)}
+                          disabled={props.checkedOrgs.has(org)}
+                          onChange={() => props.onToggleRepo(repo.fullName)}
+                        />
+                        <span class="text-xs text-base-content/70">{repo.name}</span>
+                      </label>
+                    )}
+                  </For>
+                </div>
+              </Show>
+            </div>
+          );
+        }}
+      </For>
+    </Show>
+  );
+}

--- a/src/app/lib/dependency-exclusion.ts
+++ b/src/app/lib/dependency-exclusion.ts
@@ -1,0 +1,12 @@
+import type { RepoRef } from "../../shared/types.js";
+
+export function isRepoExcludedFromDependencies(
+  repoFullName: string,
+  excludedOrgs: readonly string[],
+  excludedRepos: readonly Pick<RepoRef, "fullName">[]
+): boolean {
+  const lower = repoFullName.toLowerCase();
+  if (excludedRepos.some((r) => r.fullName.toLowerCase() === lower)) return true;
+  const org = lower.split("/")[0];
+  return excludedOrgs.some((o) => o.toLowerCase() === org);
+}

--- a/src/app/lib/orgRepoSelection.ts
+++ b/src/app/lib/orgRepoSelection.ts
@@ -1,0 +1,68 @@
+import { createSignal, createEffect, type Accessor } from "solid-js";
+import type { RepoRef } from "../services/api";
+
+export interface OrgRepoSelection {
+  selectedOrgs: Accessor<Set<string>>;
+  selectedRepos: Accessor<Set<string>>;
+  toggleOrg: (org: string) => void;
+  toggleRepo: (repoFullName: string) => void;
+  buildRepoList: () => RepoRef[];
+}
+
+export interface OrgRepoSelectionOptions {
+  getOpen: Accessor<boolean>;
+  getAvailableRepos: Accessor<RepoRef[]>;
+  getInitialOrgs: Accessor<string[]>;
+  getInitialRepos: Accessor<string[]>;
+}
+
+// Deselecting an org clears its member repos from the repo selection Set;
+// selecting an org never touches the repo set (OrgRepoCheckboxTree's
+// checked-attribute OR handles display without needing individual repo entries).
+export function createOrgRepoSelection(opts: OrgRepoSelectionOptions): OrgRepoSelection {
+  const [selectedOrgs, setSelectedOrgs] = createSignal<Set<string>>(new Set(opts.getInitialOrgs()));
+  const [selectedRepos, setSelectedRepos] = createSignal<Set<string>>(new Set(opts.getInitialRepos()));
+
+  createEffect(() => {
+    if (!opts.getOpen()) return;
+    setSelectedOrgs(new Set(opts.getInitialOrgs()));
+    setSelectedRepos(new Set(opts.getInitialRepos()));
+  });
+
+  function toggleOrg(org: string) {
+    setSelectedOrgs((prev) => {
+      const next = new Set(prev);
+      if (next.has(org)) {
+        next.delete(org);
+        setSelectedRepos((prevRepos) => {
+          const nextRepos = new Set(prevRepos);
+          for (const r of opts.getAvailableRepos()) {
+            if (r.owner === org) nextRepos.delete(r.fullName);
+          }
+          return nextRepos;
+        });
+      } else {
+        next.add(org);
+      }
+      return next;
+    });
+  }
+
+  function toggleRepo(repoFullName: string) {
+    setSelectedRepos((prev) => {
+      const next = new Set(prev);
+      if (next.has(repoFullName)) {
+        next.delete(repoFullName);
+      } else {
+        next.add(repoFullName);
+      }
+      return next;
+    });
+  }
+
+  function buildRepoList(): RepoRef[] {
+    return opts.getAvailableRepos().filter((r) => selectedRepos().has(r.fullName));
+  }
+
+  return { selectedOrgs, selectedRepos, toggleOrg, toggleRepo, buildRepoList };
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -86,6 +86,8 @@ export type JiraConfig = z.infer<typeof JiraConfigSchema>;
 export const DependencyConfigSchema = z.object({
   enabled: z.boolean().default(true),
   rebaseLabel: z.string().min(1).max(50).default("rebase"),
+  excludedOrgs: z.array(z.string().regex(REPO_SEGMENT)).max(100).default([]),
+  excludedRepos: z.array(RepoRefSchema).max(100).default([]),
 });
 export type DependencyConfig = z.infer<typeof DependencyConfigSchema>;
 
@@ -121,7 +123,7 @@ export const ConfigSchema = z.object({
   mcpRelayPort: z.number().int().min(1024).max(65535).default(9876),
   // Explicit defaults (NOT .default({})) — inner field defaults don't apply with .default({}) per BUG-001
   jira: JiraConfigSchema.default({ enabled: false, authMethod: "oauth", issueKeyDetection: true, expandIssueDetails: false, customFields: [], customScopes: [] }),
-  dependencies: DependencyConfigSchema.default({ enabled: true, rebaseLabel: "rebase" }),
+  dependencies: DependencyConfigSchema.default({ enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] }),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/tests/acceptance/dependency-exclusions.feature
+++ b/tests/acceptance/dependency-exclusions.feature
@@ -1,0 +1,75 @@
+Feature: Exclude repos and orgs from the Dependencies tab
+
+  Users can exclude specific repos or entire orgs from the Dependencies tab
+  (dependency-bot PRs and Renovate Dashboard "Abandoned" package badges) via
+  a checkbox-tree modal in Settings -> Dependencies. Exclusion is scoped to
+  the Dependencies tab only -- Issues, Pull Requests, and Actions are
+  unaffected, and an excluded repo's dependency-bot PRs disappear entirely
+  rather than reappearing in Pull Requests. Org-level exclusion is dynamic:
+  it matches on repo ownership, so repos added under an excluded org later
+  are excluded automatically with no resync needed.
+
+  Background:
+    Given the user is authenticated with a GitHub account
+
+  Scenario: S1 - Excluding a repo hides its dependency PR from the Dependencies tab
+    Given the user has two tracked repos, each with one open PR authored by a dependency bot (e.g. "dependabot[bot]" on a "dependabot/npm_and_yarn/..." branch), and one of those two repos is listed under Settings -> Dependencies -> Excluded repos/orgs
+    When the user opens the Dependencies tab
+    Then only the non-excluded repo's dependency-bot PR is shown in the list
+    And the Dependencies tab badge count reads "1"
+
+  Scenario: S2 - Excluding a repo leaves Issues/Pull Requests/Actions untouched for that repo
+    Given a repo is excluded from the Dependencies tab and has one open non-bot issue, one open non-bot pull request, and one workflow run, all visible before the exclusion was set
+    When the user views the Issues, Pull Requests, and Actions tabs after excluding the repo
+    Then the same issue, pull request, and workflow run are still listed exactly as before exclusion, with the same titles, same tab, and same counts
+
+  Scenario: S3 - Excluded repo's bot PR does not leak into the Pull Requests tab
+    Given a repo has an open dependency-bot PR, and that PR does not currently appear on the standard Pull Requests tab
+    When the user excludes that repo from Dependencies in Settings
+    Then the bot PR disappears from the Dependencies tab
+    And the bot PR still does not appear on the standard Pull Requests tab
+
+  Scenario: S4 - Excluding a repo also hides its Renovate abandoned-package badges
+    Given a repo has an open "Dependency Dashboard" issue whose body lists one package under "Ignored or Blocked", rendered as an "Abandoned" badge on that repo's entry in the Dependencies tab
+    When the user excludes that repo from Dependencies in Settings and returns to the Dependencies tab
+    Then the "Abandoned" badge for that repo is no longer shown anywhere on the tab
+
+  Scenario: S5 - Excluding an org via the checkbox tree hides all its repos' dependency PRs
+    Given the user tracks 3 repos under one org, 2 of which have an open dependency-bot PR
+    When the user opens the Manage Dependencies-Exclusions modal and checks that org's checkbox
+    Then all 3 of that org's nested repo checkboxes immediately show as checked and disabled
+    When the user then clicks Save
+    Then neither of the org's dependency-bot PRs appears in the Dependencies tab
+
+  Scenario: S6 - Org-level exclusion automatically covers a repo added to that org later
+    Given the user has excluded an entire org from Dependencies, with no further changes made to the exclusion settings afterward
+    When a repo under that same org is subsequently added to the user's tracked repos and that repo has an open dependency-bot PR
+    Then that repo's dependency-bot PR does not appear in the Dependencies tab
+    And the Manage modal, if reopened, shows that repo's checkbox as checked and disabled without the user having touched it directly
+
+  Scenario: S7 - Un-excluding a repo restores its dependency PRs and abandoned-package badges
+    Given a repo was excluded at the repo level, not inherited from an org exclusion, and it has an open dependency-bot PR and an "Abandoned" badge
+    When the user opens the Manage modal, unchecks that repo's checkbox, and clicks Save
+    Then the repo's dependency-bot PR reappears in the Dependencies tab
+    And its "Abandoned" badge is shown again
+
+  Scenario: S8 - Exclusion picker's available pool spans selected, upstream, and monitored repos
+    Given the user has one repo added directly in Repository Selection, one repo reachable only via an upstream fork relationship, and one repo added via Monitor-All, each under a different org
+    When the user opens Settings -> Dependencies -> Manage
+    Then all three repos and their three orgs appear as unchecked, checkable options in the tree
+
+  Scenario: S9 - Settings summary text shows "None excluded" with no exclusions configured
+    Given the user has no dependency exclusions configured
+    When the user views Settings -> Dependencies
+    Then the "Excluded repos/orgs" row reads "None excluded"
+
+  Scenario: S10 - Settings summary text updates to reflect a saved exclusion count
+    Given the user has no dependency exclusions configured
+    When the user opens the Manage modal, checks 1 org's checkbox and 2 individual repo checkboxes under different orgs, and clicks Save
+    Then the "Excluded repos/orgs" row on the Settings page reads "1 org, 2 repos"
+
+  Scenario: S11 - Canceling the exclusion modal discards unsaved changes
+    Given a repo is not excluded and has an open dependency-bot PR visible on the Dependencies tab
+    When the user opens the Manage modal, checks that repo's checkbox, and clicks Cancel instead of Save
+    Then the repo's dependency-bot PR still appears on the Dependencies tab
+    And reopening the Manage modal shows that repo's checkbox unchecked again

--- a/tests/acceptance/steps/dependency-exclusions.steps.tsx
+++ b/tests/acceptance/steps/dependency-exclusions.steps.tsx
@@ -134,7 +134,7 @@ import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { render, screen, waitFor, fireEvent, cleanup } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
-import { makeIssue, makePullRequest, makeWorkflowRun } from "../../helpers/index";
+import { makeIssue, makePullRequest, makeWorkflowRun, findCheckboxByLabelText } from "../../helpers/index";
 
 import DashboardPage from "../../../src/app/components/dashboard/DashboardPage";
 import SettingsPage from "../../../src/app/components/settings/SettingsPage";
@@ -161,14 +161,6 @@ function renderSettings() {
 
 function openManageModal() {
   fireEvent.click(screen.getByRole("button", { name: "Manage" }));
-}
-
-function findCheckboxByLabelText(text: string): HTMLInputElement {
-  const checkbox = screen
-    .getAllByRole("checkbox")
-    .find((cb) => cb.closest("label")?.textContent?.includes(text));
-  if (!checkbox) throw new Error(`No checkbox found for label text "${text}"`);
-  return checkbox as HTMLInputElement;
 }
 
 function depBotPR(overrides: Parameters<typeof makePullRequest>[0] = {}) {

--- a/tests/acceptance/steps/dependency-exclusions.steps.tsx
+++ b/tests/acceptance/steps/dependency-exclusions.steps.tsx
@@ -1,0 +1,798 @@
+import { vi, expect, afterAll } from "vitest";
+
+// vitest-cucumber maps each Given/When/Then to a separate test(). The DOM must
+// persist across steps within a scenario, but @solidjs/testing-library registers
+// afterEach(cleanup) at import time — vi.hoisted ensures the env var is set
+// BEFORE that import evaluates. Manual cleanup in AfterEachScenario replaces it.
+vi.hoisted(() => {
+  process.env.STL_SKIP_AUTO_CLEANUP = "true";
+});
+
+// happy-dom's localStorage lacks .clear()/.removeItem() reliably — same shim
+// as SettingsPage.test.tsx, needed because stores/config and stores/auth read
+// localStorage at module-evaluation time.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, val: string) => { store[key] = val; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});
+
+// ── Mocks — union of what DashboardPage.test.tsx and SettingsPage.test.tsx
+// each mock, since this file renders both DashboardPage and SettingsPage. ────
+
+vi.mock("@solidjs/router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../../../src/app/stores/auth", () => ({
+  clearAuth: vi.fn(),
+  expireToken: vi.fn(),
+  token: () => "fake-token",
+  user: () => ({ login: "testuser", avatar_url: "", name: "Test User" }),
+  isAuthenticated: () => true,
+  onAuthCleared: vi.fn(),
+  DASHBOARD_STORAGE_KEY: "github-tracker:dashboard",
+  DEP_META_STORAGE_KEY: "github-tracker:dep-meta",
+  jiraAuth: vi.fn(() => null),
+  isJiraAuthenticated: vi.fn(() => false),
+  setJiraAuth: vi.fn(),
+  clearJiraAuth: vi.fn(),
+  clearJiraConfigFull: vi.fn(),
+  ensureJiraTokenValid: vi.fn().mockResolvedValue(false),
+  setAuthFromPat: vi.fn(),
+}));
+
+vi.mock("@sentry/solid", () => ({
+  captureException: vi.fn(),
+  withSentryErrorBoundary: vi.fn((c: unknown) => c),
+}));
+
+vi.mock("../../../src/app/stores/cache", () => ({
+  clearCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/app/services/jira-client", () => ({
+  JiraClient: vi.fn(),
+  JiraProxyClient: vi.fn(),
+}));
+
+vi.mock("../../../src/app/services/jira-keys", () => ({
+  detectAndLookupJiraKeys: vi.fn().mockResolvedValue(new Map()),
+  clearJiraKeyCache: vi.fn(),
+}));
+
+vi.mock("../../../src/app/services/github", () => ({
+  getCoreRateLimit: () => null,
+  getGraphqlRateLimit: () => null,
+  getClient: vi.fn(() => null),
+  fetchRateLimitDetails: vi.fn(),
+  onApiRequest: vi.fn(),
+}));
+
+// Real fetchDashboardIssueBodies/fetchDepPRBodies are kept (S4/S7 exercise them
+// through a mocked octokit.graphql) — only the org/repo discovery calls are
+// stubbed, matching org-order-stability.steps.tsx's partial-mock convention.
+vi.mock("../../../src/app/services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/app/services/api")>();
+  return {
+    ...actual,
+    fetchOrgs: vi.fn().mockResolvedValue([]),
+    fetchRepos: vi.fn().mockResolvedValue([]),
+    discoverUpstreamRepos: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock("../../../src/app/services/poll", () => ({
+  fetchAllData: vi.fn(),
+  createPollCoordinator: vi.fn(),
+  createHotPollCoordinator: vi.fn(),
+  createEventsPollCoordinator: vi.fn(),
+  rebuildHotSets: vi.fn(),
+  seedHotSetsFromTargeted: vi.fn(),
+  clearHotSets: vi.fn(),
+  getHotPollGeneration: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock("../../../src/app/lib/notifications", () => ({
+  detectNewItems: vi.fn(() => []),
+  dispatchNotifications: vi.fn(),
+  _resetNotificationState: vi.fn(),
+}));
+
+vi.mock("../../../src/app/lib/errors", () => ({
+  getErrors: vi.fn().mockReturnValue([]),
+  getNotifications: vi.fn().mockReturnValue([]),
+  getUnreadCount: vi.fn().mockReturnValue(0),
+  markAllAsRead: vi.fn(),
+  dismissError: vi.fn(),
+  dismissNotificationBySource: vi.fn(),
+  pushError: vi.fn(),
+  pushNotification: vi.fn(),
+  clearErrors: vi.fn(),
+  clearNotifications: vi.fn(),
+  addMutedSource: vi.fn(),
+  isMuted: vi.fn(() => false),
+  clearMutedSources: vi.fn(),
+}));
+
+vi.mock("../../../src/app/lib/url", () => ({
+  isSafeGitHubUrl: vi.fn(() => true),
+  openGitHubUrl: vi.fn(),
+}));
+
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { render, screen, waitFor, fireEvent, cleanup } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
+import { makeIssue, makePullRequest, makeWorkflowRun } from "../../helpers/index";
+
+import DashboardPage from "../../../src/app/components/dashboard/DashboardPage";
+import SettingsPage from "../../../src/app/components/settings/SettingsPage";
+import * as pollService from "../../../src/app/services/poll";
+import * as configStore from "../../../src/app/stores/config";
+import * as viewStore from "../../../src/app/stores/view";
+import * as githubService from "../../../src/app/services/github";
+
+const feature = await loadFeature("../dependency-exclusions.feature");
+
+afterAll(() => {
+  delete process.env.STL_SKIP_AUTO_CLEANUP;
+});
+
+// ── Render helpers ────────────────────────────────────────────────────────────
+
+function renderDashboard() {
+  return render(() => <DashboardPage />);
+}
+
+function renderSettings() {
+  return render(() => <SettingsPage />);
+}
+
+function openManageModal() {
+  fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+}
+
+function findCheckboxByLabelText(text: string): HTMLInputElement {
+  const checkbox = screen
+    .getAllByRole("checkbox")
+    .find((cb) => cb.closest("label")?.textContent?.includes(text));
+  if (!checkbox) throw new Error(`No checkbox found for label text "${text}"`);
+  return checkbox as HTMLInputElement;
+}
+
+function depBotPR(overrides: Parameters<typeof makePullRequest>[0] = {}) {
+  return makePullRequest({
+    userLogin: "dependabot[bot]",
+    headRef: "dependabot/npm_and_yarn/pkg-1.0.0",
+    ...overrides,
+  });
+}
+
+describeFeature(feature, ({ Scenario, Background, BeforeEachScenario, AfterEachScenario }) => {
+  BeforeEachScenario(() => {
+    vi.clearAllMocks();
+    configStore.resetConfig();
+    viewStore.resetViewState();
+
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [],
+      workflowRuns: [],
+      errors: [],
+    });
+    vi.mocked(pollService.createPollCoordinator).mockImplementation(
+      (_getInterval: unknown, fetchAll: () => Promise<unknown>) => {
+        void fetchAll().catch(() => {});
+        return {
+          isRefreshing: () => false,
+          lastRefreshAt: () => null,
+          manualRefresh: vi.fn(),
+          destroy: vi.fn(),
+        };
+      }
+    );
+    vi.mocked(pollService.createHotPollCoordinator).mockImplementation(() => ({ destroy: vi.fn() }));
+    vi.mocked(pollService.createEventsPollCoordinator).mockImplementation(() => ({ destroy: vi.fn() }));
+    vi.mocked(githubService.getClient).mockReturnValue(null);
+  });
+
+  AfterEachScenario(() => {
+    cleanup();
+  });
+
+  Background(({ Given }) => {
+    Given("the user is authenticated with a GitHub account", () => {
+      // Auth mock is set at module level — nothing to do here.
+    });
+  });
+
+  // ── S1: Excluding a repo hides its dependency PR from the Dependencies tab ──
+  Scenario(
+    "S1 - Excluding a repo hides its dependency PR from the Dependencies tab",
+    ({ Given, When, Then, And }) => {
+      Given(
+        'the user has two tracked repos, each with one open PR authored by a dependency bot (e.g. "dependabot[bot]" on a "dependabot/npm_and_yarn/..." branch), and one of those two repos is listed under Settings -> Dependencies -> Excluded repos/orgs',
+        () => {
+          configStore.updateConfig({
+            dependencies: {
+              ...configStore.config.dependencies,
+              excludedRepos: [{ owner: "owner", name: "excluded-repo", fullName: "owner/excluded-repo" }],
+            },
+          });
+          vi.mocked(pollService.fetchAllData).mockResolvedValue({
+            issues: [],
+            pullRequests: [
+              depBotPR({
+                repoFullName: "owner/excluded-repo",
+                title: "Bump lodash from 4.1 to 4.2",
+                headRef: "dependabot/npm_and_yarn/lodash-4.2",
+              }),
+              depBotPR({
+                repoFullName: "owner/other-repo",
+                title: "Bump axios from 0.27 to 1.0",
+                headRef: "dependabot/npm_and_yarn/axios-1.0.0",
+              }),
+            ],
+            workflowRuns: [],
+            errors: [],
+          });
+        }
+      );
+
+      When("the user opens the Dependencies tab", async () => {
+        renderDashboard();
+        await waitFor(() => screen.getByRole("tab", { name: /Dependencies/ }));
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("tab", { name: /Dependencies/ }));
+      });
+
+      Then("only the non-excluded repo's dependency-bot PR is shown in the list", async () => {
+        await waitFor(() => {
+          expect(screen.getByText("axios: 0.27 → 1.0")).toBeDefined();
+          expect(screen.queryByText("lodash: 4.1 → 4.2")).toBeNull();
+        });
+      });
+
+      And('the Dependencies tab badge count reads "1"', () => {
+        const depsTab = screen.getByRole("tab", { name: /Dependencies/ });
+        expect(depsTab.textContent?.replace(/\D+/g, "")).toBe("1");
+      });
+    }
+  );
+
+  // ── S2: Excluding a repo leaves Issues/PRs/Actions untouched for that repo ──
+  Scenario(
+    "S2 - Excluding a repo leaves Issues/Pull Requests/Actions untouched for that repo",
+    ({ Given, When, Then }) => {
+      const ISSUE_TITLE = "Fix login redirect bug";
+      const PR_TITLE = "Add dark mode support";
+
+      Given(
+        "a repo is excluded from the Dependencies tab and has one open non-bot issue, one open non-bot pull request, and one workflow run, all visible before the exclusion was set",
+        () => {
+          configStore.updateConfig({
+            dependencies: {
+              ...configStore.config.dependencies,
+              excludedRepos: [{ owner: "owner", name: "repo", fullName: "owner/repo" }],
+            },
+          });
+          vi.mocked(pollService.fetchAllData).mockResolvedValue({
+            issues: [makeIssue({ title: ISSUE_TITLE, userLogin: "developer", state: "OPEN" })],
+            pullRequests: [makePullRequest({ title: PR_TITLE, userLogin: "developer" })],
+            workflowRuns: [makeWorkflowRun({ isPrRun: false })],
+            errors: [],
+          });
+        }
+      );
+
+      When(
+        "the user views the Issues, Pull Requests, and Actions tabs after excluding the repo",
+        async () => {
+          renderDashboard();
+          const user = userEvent.setup();
+          await waitFor(() => screen.getByLabelText("Expand all repos"));
+          await user.click(screen.getByLabelText("Expand all repos"));
+          await waitFor(() => screen.getByText(ISSUE_TITLE));
+          await user.click(screen.getByRole("tab", { name: /Pull Requests/ }));
+          await user.click(screen.getByLabelText("Expand all repos"));
+          await waitFor(() => screen.getByText(PR_TITLE));
+          await user.click(screen.getByRole("tab", { name: /Actions/ }));
+          await waitFor(() => screen.getByText("Show PR runs"));
+        }
+      );
+
+      Then(
+        "the same issue, pull request, and workflow run are still listed exactly as before exclusion, with the same titles, same tab, and same counts",
+        () => {
+          expect(screen.getByRole("tab", { name: /Issues/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+          expect(screen.getByRole("tab", { name: /Pull Requests/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+          expect(screen.getByRole("tab", { name: /Actions/ }).textContent?.replace(/\D+/g, "")).toBe("1");
+        }
+      );
+    }
+  );
+
+  // ── S3: Excluded repo's bot PR does not leak into the Pull Requests tab ─────
+  Scenario(
+    "S3 - Excluded repo's bot PR does not leak into the Pull Requests tab",
+    ({ Given, When, Then, And }) => {
+      const S3_REPO = { owner: "owner", name: "leaky-repo", fullName: "owner/leaky-repo" };
+
+      Given(
+        "a repo has an open dependency-bot PR, and that PR does not currently appear on the standard Pull Requests tab",
+        async () => {
+          vi.mocked(pollService.fetchAllData).mockResolvedValue({
+            issues: [],
+            pullRequests: [
+              depBotPR({
+                repoFullName: S3_REPO.fullName,
+                title: "Bump lodash from 4.1 to 4.2",
+                headRef: "dependabot/npm_and_yarn/lodash-4.2",
+              }),
+            ],
+            workflowRuns: [],
+            errors: [],
+          });
+          renderDashboard();
+          await waitFor(() => {
+            const prTab = screen.getByRole("tab", { name: /Pull Requests/ });
+            expect(prTab.textContent?.replace(/\D+/g, "")).toBe("0");
+          });
+        }
+      );
+
+      When("the user excludes that repo from Dependencies in Settings", () => {
+        configStore.updateConfig({
+          dependencies: { ...configStore.config.dependencies, excludedRepos: [S3_REPO] },
+        });
+      });
+
+      Then("the bot PR disappears from the Dependencies tab", async () => {
+        await waitFor(() => {
+          expect(screen.queryByRole("tab", { name: /Dependencies/ })).toBeNull();
+        });
+      });
+
+      And("the bot PR still does not appear on the standard Pull Requests tab", () => {
+        const prTab = screen.getByRole("tab", { name: /Pull Requests/ });
+        expect(prTab.textContent?.replace(/\D+/g, "")).toBe("0");
+      });
+    }
+  );
+
+  // ── S4: Excluding a repo also hides its Renovate abandoned-package badges ──
+  Scenario(
+    "S4 - Excluding a repo also hides its Renovate abandoned-package badges",
+    ({ Given, When, Then }) => {
+      const S4_REPO = { owner: "owner", name: "abandon-repo", fullName: "owner/abandon-repo" };
+
+      Given(
+        'a repo has an open "Dependency Dashboard" issue whose body lists one package under "Ignored or Blocked", rendered as an "Abandoned" badge on that repo\'s entry in the Dependencies tab',
+        async () => {
+          vi.mocked(pollService.fetchAllData).mockResolvedValue({
+            issues: [
+              makeIssue({
+                title: "Dependency Dashboard",
+                userLogin: "renovate[bot]",
+                nodeId: "DASH_S4",
+                repoFullName: S4_REPO.fullName,
+                state: "OPEN",
+              }),
+            ],
+            pullRequests: [
+              depBotPR({
+                repoFullName: S4_REPO.fullName,
+                title: "Bump lodash from 4.1 to 4.2",
+                headRef: "dependabot/npm_and_yarn/lodash-4.2",
+              }),
+            ],
+            workflowRuns: [],
+            errors: [],
+          });
+
+          const graphqlSpy = vi.fn().mockResolvedValue({
+            nodes: [
+              {
+                id: "DASH_S4",
+                body: "## Abandoned\n| Datasource | Package | Last Updated |\n|---|---|---|\n| npm | lodash | 2023-01-15 |\n",
+              },
+            ],
+            rateLimit: null,
+          });
+          vi.mocked(githubService.getClient).mockReturnValue(
+            { graphql: graphqlSpy } as unknown as ReturnType<typeof githubService.getClient>
+          );
+          vi.mocked(pollService.createPollCoordinator).mockImplementation(
+            (_getInterval: unknown, fetchAll: () => Promise<unknown>) => {
+              const [lastRefreshAt, setLastRefreshAt] = createSignal<Date | null>(null);
+              void fetchAll().then(() => setLastRefreshAt(new Date())).catch(() => {});
+              return { isRefreshing: () => false, lastRefreshAt, manualRefresh: vi.fn(), destroy: vi.fn() };
+            }
+          );
+
+          renderDashboard();
+          await waitFor(() => expect(graphqlSpy).toHaveBeenCalled());
+
+          const user = userEvent.setup();
+          await waitFor(() => screen.getByRole("tab", { name: /Dependencies/ }));
+          await user.click(screen.getByRole("tab", { name: /Dependencies/ }));
+          await waitFor(() => screen.getByText("Abandoned"));
+        }
+      );
+
+      When(
+        "the user excludes that repo from Dependencies in Settings and returns to the Dependencies tab",
+        () => {
+          configStore.updateConfig({
+            dependencies: { ...configStore.config.dependencies, excludedRepos: [S4_REPO] },
+          });
+        }
+      );
+
+      Then('the "Abandoned" badge for that repo is no longer shown anywhere on the tab', async () => {
+        await waitFor(() => {
+          expect(screen.queryByText("Abandoned")).toBeNull();
+        });
+      });
+    }
+  );
+
+  // ── S5: Excluding an org via the checkbox tree hides all its repos' PRs ─────
+  Scenario(
+    "S5 - Excluding an org via the checkbox tree hides all its repos' dependency PRs",
+    ({ Given, When, Then }) => {
+      const ORG = "big-org";
+      const REPOS = [
+        { owner: ORG, name: "repo1", fullName: `${ORG}/repo1` },
+        { owner: ORG, name: "repo2", fullName: `${ORG}/repo2` },
+        { owner: ORG, name: "repo3", fullName: `${ORG}/repo3` },
+      ];
+
+      Given("the user tracks 3 repos under one org, 2 of which have an open dependency-bot PR", () => {
+        configStore.updateConfig({ selectedRepos: REPOS });
+        vi.mocked(pollService.fetchAllData).mockResolvedValue({
+          issues: [],
+          pullRequests: [
+            depBotPR({
+              repoFullName: REPOS[0]!.fullName,
+              title: "Bump lodash from 4.1 to 4.2",
+              headRef: "dependabot/npm_and_yarn/lodash-4.2",
+            }),
+            depBotPR({
+              repoFullName: REPOS[1]!.fullName,
+              title: "Bump axios from 0.27 to 1.0",
+              headRef: "dependabot/npm_and_yarn/axios-1.0.0",
+            }),
+          ],
+          workflowRuns: [],
+          errors: [],
+        });
+      });
+
+      When("the user opens the Manage Dependencies-Exclusions modal and checks that org's checkbox", () => {
+        renderSettings();
+        openManageModal();
+        fireEvent.click(findCheckboxByLabelText(ORG));
+      });
+
+      Then("all 3 of that org's nested repo checkboxes immediately show as checked and disabled", () => {
+        for (const repo of REPOS) {
+          const cb = findCheckboxByLabelText(repo.name);
+          expect(cb.checked).toBe(true);
+          expect(cb.disabled).toBe(true);
+        }
+      });
+
+      When("the user then clicks Save", () => {
+        fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      });
+
+      Then("neither of the org's dependency-bot PRs appears in the Dependencies tab", async () => {
+        cleanup();
+        renderDashboard();
+        await waitFor(() => {
+          expect(screen.queryByRole("tab", { name: /Dependencies/ })).toBeNull();
+        });
+      });
+    }
+  );
+
+  // ── S6: Org-level exclusion automatically covers a repo added later ────────
+  Scenario(
+    "S6 - Org-level exclusion automatically covers a repo added to that org later",
+    ({ Given, When, Then, And }) => {
+      const ORG = "late-org";
+      const REPO = { owner: ORG, name: "late-repo", fullName: `${ORG}/late-repo` };
+
+      Given(
+        "the user has excluded an entire org from Dependencies, with no further changes made to the exclusion settings afterward",
+        () => {
+          configStore.updateConfig({
+            dependencies: { ...configStore.config.dependencies, excludedOrgs: [ORG] },
+          });
+        }
+      );
+
+      When(
+        "a repo under that same org is subsequently added to the user's tracked repos and that repo has an open dependency-bot PR",
+        async () => {
+          configStore.updateConfig({ selectedRepos: [...configStore.config.selectedRepos, REPO] });
+          vi.mocked(pollService.fetchAllData).mockResolvedValue({
+            issues: [],
+            pullRequests: [
+              depBotPR({
+                repoFullName: REPO.fullName,
+                title: "Bump lodash from 4.1 to 4.2",
+                headRef: "dependabot/npm_and_yarn/lodash-4.2",
+              }),
+            ],
+            workflowRuns: [],
+            errors: [],
+          });
+          renderDashboard();
+          await waitFor(() => screen.getByRole("tab", { name: /Issues/ }));
+        }
+      );
+
+      Then("that repo's dependency-bot PR does not appear in the Dependencies tab", async () => {
+        await waitFor(() => {
+          expect(screen.queryByRole("tab", { name: /Dependencies/ })).toBeNull();
+        });
+      });
+
+      And(
+        "the Manage modal, if reopened, shows that repo's checkbox as checked and disabled without the user having touched it directly",
+        () => {
+          cleanup();
+          renderSettings();
+          openManageModal();
+          const cb = findCheckboxByLabelText(REPO.name);
+          expect(cb.checked).toBe(true);
+          expect(cb.disabled).toBe(true);
+        }
+      );
+    }
+  );
+
+  // ── S7: Un-excluding a repo restores its PRs and abandoned-package badges ──
+  Scenario(
+    "S7 - Un-excluding a repo restores its dependency PRs and abandoned-package badges",
+    ({ Given, When, Then, And }) => {
+      const REPO = { owner: "owner", name: "restore-repo", fullName: "owner/restore-repo" };
+
+      Given(
+        'a repo was excluded at the repo level, not inherited from an org exclusion, and it has an open dependency-bot PR and an "Abandoned" badge',
+        () => {
+          configStore.updateConfig({
+            selectedRepos: [REPO],
+            dependencies: { ...configStore.config.dependencies, excludedRepos: [REPO] },
+          });
+          vi.mocked(pollService.fetchAllData).mockResolvedValue({
+            issues: [
+              makeIssue({
+                title: "Dependency Dashboard",
+                userLogin: "renovate[bot]",
+                nodeId: "DASH_S7",
+                repoFullName: REPO.fullName,
+                state: "OPEN",
+              }),
+            ],
+            pullRequests: [
+              depBotPR({
+                repoFullName: REPO.fullName,
+                title: "Bump lodash from 4.1 to 4.2",
+                headRef: "dependabot/npm_and_yarn/lodash-4.2",
+              }),
+            ],
+            workflowRuns: [],
+            errors: [],
+          });
+          const graphqlSpy = vi.fn().mockResolvedValue({
+            nodes: [
+              {
+                id: "DASH_S7",
+                body: "## Abandoned\n| Datasource | Package | Last Updated |\n|---|---|---|\n| npm | lodash | 2023-01-15 |\n",
+              },
+            ],
+            rateLimit: null,
+          });
+          vi.mocked(githubService.getClient).mockReturnValue(
+            { graphql: graphqlSpy } as unknown as ReturnType<typeof githubService.getClient>
+          );
+          vi.mocked(pollService.createPollCoordinator).mockImplementation(
+            (_getInterval: unknown, fetchAll: () => Promise<unknown>) => {
+              const [lastRefreshAt, setLastRefreshAt] = createSignal<Date | null>(null);
+              void fetchAll().then(() => setLastRefreshAt(new Date())).catch(() => {});
+              return { isRefreshing: () => false, lastRefreshAt, manualRefresh: vi.fn(), destroy: vi.fn() };
+            }
+          );
+        }
+      );
+
+      When("the user opens the Manage modal, unchecks that repo's checkbox, and clicks Save", () => {
+        renderSettings();
+        openManageModal();
+        const cb = findCheckboxByLabelText(REPO.name);
+        expect(cb.checked).toBe(true);
+        fireEvent.click(cb);
+        fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      });
+
+      Then("the repo's dependency-bot PR reappears in the Dependencies tab", async () => {
+        cleanup();
+        renderDashboard();
+        const user = userEvent.setup();
+        await waitFor(() => screen.getByRole("tab", { name: /Dependencies/ }));
+        await user.click(screen.getByRole("tab", { name: /Dependencies/ }));
+        await waitFor(() => screen.getByText("lodash: 4.1 → 4.2"));
+      });
+
+      And('its "Abandoned" badge is shown again', async () => {
+        await waitFor(() => screen.getByText("Abandoned"));
+      });
+    }
+  );
+
+  // ── S8: Exclusion pool spans selected, upstream, and monitored repos ───────
+  Scenario(
+    "S8 - Exclusion picker's available pool spans selected, upstream, and monitored repos",
+    ({ Given, When, Then }) => {
+      const SELECTED = { owner: "org-a", name: "repo-a", fullName: "org-a/repo-a" };
+      const UPSTREAM = { owner: "org-b", name: "repo-b", fullName: "org-b/repo-b" };
+      const MONITORED = { owner: "org-c", name: "repo-c", fullName: "org-c/repo-c" };
+
+      Given(
+        "the user has one repo added directly in Repository Selection, one repo reachable only via an upstream fork relationship, and one repo added via Monitor-All, each under a different org",
+        () => {
+          // selectedRepos must be set in its own call: updateConfig prunes
+          // monitoredRepos to intersect with selectedRepos whenever the
+          // "selectedRepos" key is present in the same partial update.
+          configStore.updateConfig({ selectedRepos: [SELECTED] });
+          configStore.updateConfig({ upstreamRepos: [UPSTREAM], monitoredRepos: [MONITORED] });
+        }
+      );
+
+      When("the user opens Settings -> Dependencies -> Manage", () => {
+        renderSettings();
+        openManageModal();
+      });
+
+      Then("all three repos and their three orgs appear as unchecked, checkable options in the tree", () => {
+        for (const repo of [SELECTED, UPSTREAM, MONITORED]) {
+          const orgCb = findCheckboxByLabelText(repo.owner);
+          expect(orgCb.checked).toBe(false);
+          expect(orgCb.disabled).toBe(false);
+          const repoCb = findCheckboxByLabelText(repo.name);
+          expect(repoCb.checked).toBe(false);
+          expect(repoCb.disabled).toBe(false);
+        }
+      });
+    }
+  );
+
+  // ── S9: Settings summary shows "None excluded" ──────────────────────────────
+  Scenario(
+    'S9 - Settings summary text shows "None excluded" with no exclusions configured',
+    ({ Given, When, Then }) => {
+      Given("the user has no dependency exclusions configured", () => {
+        configStore.updateConfig({
+          dependencies: { ...configStore.config.dependencies, excludedOrgs: [], excludedRepos: [] },
+        });
+      });
+
+      When("the user views Settings -> Dependencies", () => {
+        renderSettings();
+      });
+
+      Then('the "Excluded repos/orgs" row reads "None excluded"', () => {
+        screen.getByText("None excluded");
+      });
+    }
+  );
+
+  // ── S10: Settings summary updates to reflect saved exclusion count ─────────
+  Scenario(
+    "S10 - Settings summary text updates to reflect a saved exclusion count",
+    ({ Given, When, Then }) => {
+      const REPOS = [
+        { owner: "org-x", name: "repo-x1", fullName: "org-x/repo-x1" },
+        { owner: "org-y", name: "repo-y1", fullName: "org-y/repo-y1" },
+        { owner: "org-z", name: "repo-z1", fullName: "org-z/repo-z1" },
+      ];
+
+      Given("the user has no dependency exclusions configured", () => {
+        configStore.updateConfig({
+          selectedRepos: REPOS,
+          dependencies: { ...configStore.config.dependencies, excludedOrgs: [], excludedRepos: [] },
+        });
+      });
+
+      When(
+        "the user opens the Manage modal, checks 1 org's checkbox and 2 individual repo checkboxes under different orgs, and clicks Save",
+        () => {
+          renderSettings();
+          openManageModal();
+          fireEvent.click(findCheckboxByLabelText("org-x"));
+          fireEvent.click(findCheckboxByLabelText("repo-y1"));
+          fireEvent.click(findCheckboxByLabelText("repo-z1"));
+          fireEvent.click(screen.getByRole("button", { name: /save/i }));
+        }
+      );
+
+      Then('the "Excluded repos/orgs" row on the Settings page reads "1 org, 2 repos"', () => {
+        screen.getByText("1 org, 2 repos");
+      });
+    }
+  );
+
+  // ── S11: Canceling the exclusion modal discards unsaved changes ────────────
+  Scenario(
+    "S11 - Canceling the exclusion modal discards unsaved changes",
+    ({ Given, When, Then, And }) => {
+      const REPO = { owner: "owner", name: "cancel-repo", fullName: "owner/cancel-repo" };
+
+      Given(
+        "a repo is not excluded and has an open dependency-bot PR visible on the Dependencies tab",
+        async () => {
+          configStore.updateConfig({ selectedRepos: [REPO] });
+          vi.mocked(pollService.fetchAllData).mockResolvedValue({
+            issues: [],
+            pullRequests: [
+              depBotPR({
+                repoFullName: REPO.fullName,
+                title: "Bump lodash from 4.1 to 4.2",
+                headRef: "dependabot/npm_and_yarn/lodash-4.2",
+              }),
+            ],
+            workflowRuns: [],
+            errors: [],
+          });
+          renderDashboard();
+          const user = userEvent.setup();
+          await waitFor(() => screen.getByRole("tab", { name: /Dependencies/ }));
+          await user.click(screen.getByRole("tab", { name: /Dependencies/ }));
+          await waitFor(() => screen.getByText("lodash: 4.1 → 4.2"));
+        }
+      );
+
+      When(
+        "the user opens the Manage modal, checks that repo's checkbox, and clicks Cancel instead of Save",
+        () => {
+          cleanup();
+          renderSettings();
+          openManageModal();
+          fireEvent.click(findCheckboxByLabelText(REPO.name));
+          fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+        }
+      );
+
+      Then("the repo's dependency-bot PR still appears on the Dependencies tab", async () => {
+        cleanup();
+        renderDashboard();
+        const user = userEvent.setup();
+        await waitFor(() => screen.getByRole("tab", { name: /Dependencies/ }));
+        await user.click(screen.getByRole("tab", { name: /Dependencies/ }));
+        await waitFor(() => screen.getByText("lodash: 4.1 → 4.2"));
+      });
+
+      And("reopening the Manage modal shows that repo's checkbox unchecked again", () => {
+        cleanup();
+        renderSettings();
+        openManageModal();
+        const cb = findCheckboxByLabelText(REPO.name);
+        expect(cb.checked).toBe(false);
+      });
+    }
+  );
+});

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -2043,7 +2043,7 @@ describe("DashboardPage — dependency pre-exclusivity", () => {
       errors: [],
     });
 
-    configStore.updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase" } });
+    configStore.updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
 
     render(() => <DashboardPage />);
     await waitFor(() => {
@@ -2068,7 +2068,7 @@ describe("DashboardPage — dependency pre-exclusivity", () => {
   });
 
   it("dep PRs appear on Pull Requests tab when dependencies feature is disabled", async () => {
-    configStore.updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase" } });
+    configStore.updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     vi.mocked(pollService.fetchAllData).mockResolvedValue({
       issues: [],
       pullRequests: [

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSignal } from "solid-js";
 import { render, screen, waitFor, fireEvent } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { makeIssue, makePullRequest, makeWorkflowRun } from "../helpers/index";
@@ -53,7 +54,7 @@ vi.mock("../../src/app/services/jira-keys", () => ({
 vi.mock("../../src/app/services/github", () => ({
   getCoreRateLimit: () => null,
   getGraphqlRateLimit: () => null,
-  getClient: () => null,
+  getClient: vi.fn(() => null),
 }));
 
 // Mock notifications lib
@@ -2189,6 +2190,192 @@ describe("DashboardPage — dependency pre-exclusivity", () => {
       const readyToMerge = screen.getByText(/ready to merge/);
       expect(readyToMerge.textContent).toMatch(/^1\s/);
     });
+  });
+});
+
+// ── Dependencies tab — repo/org exclusion filtering ──────────────────────────
+
+describe("DashboardPage — dependency exclusions", () => {
+  it("Test A: excludedRepos hides that repo's dependency PR from the Dependencies tab", async () => {
+    configStore.updateConfig({
+      dependencies: {
+        ...configStore.config.dependencies,
+        excludedRepos: [{ owner: "owner", name: "excluded-repo", fullName: "owner/excluded-repo" }],
+      },
+    });
+
+    const user = userEvent.setup();
+
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [
+        makePullRequest({
+          repoFullName: "owner/excluded-repo",
+          title: "Bump lodash from 4.1 to 4.2",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/lodash-4.2",
+        }),
+        makePullRequest({
+          repoFullName: "owner/other-repo",
+          title: "Bump axios from 0.27 to 1.0",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/axios-1.0.0",
+        }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      const depsTab = screen.getByRole("tab", { name: /Dependencies/ });
+      expect(depsTab.textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+
+    await user.click(screen.getByRole("tab", { name: /Dependencies/ }));
+    await waitFor(() => {
+      expect(screen.getByText("axios: 0.27 → 1.0")).toBeDefined();
+      expect(screen.queryByText("lodash: 4.1 → 4.2")).toBeNull();
+    });
+  });
+
+  it("Test B: excluded repo's dependency PR does not leak into the Pull Requests tab (exclusivity preserved)", async () => {
+    configStore.updateConfig({
+      dependencies: {
+        ...configStore.config.dependencies,
+        excludedRepos: [{ owner: "owner", name: "excluded-repo", fullName: "owner/excluded-repo" }],
+      },
+    });
+
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [
+        makePullRequest({
+          repoFullName: "owner/excluded-repo",
+          title: "Bump lodash from 4.1 to 4.2",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/lodash-4.2",
+        }),
+        makePullRequest({
+          repoFullName: "owner/other-repo",
+          title: "Bump axios from 0.27 to 1.0",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/axios-1.0.0",
+        }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      const prTab = screen.getByRole("tab", { name: /^Pull Requests/ });
+      expect(prTab.textContent?.replace(/\D+/g, "")).toBe("0");
+    });
+  });
+
+  it("Test C: excludedOrgs hides that org's repo's dependency PR from the Dependencies tab", async () => {
+    configStore.updateConfig({
+      dependencies: {
+        ...configStore.config.dependencies,
+        excludedOrgs: ["excluded-org"],
+      },
+    });
+
+    const user = userEvent.setup();
+
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [
+        makePullRequest({
+          repoFullName: "excluded-org/repo-a",
+          title: "Bump lodash from 4.1 to 4.2",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/lodash-4.2",
+        }),
+        makePullRequest({
+          repoFullName: "other-org/repo-b",
+          title: "Bump axios from 0.27 to 1.0",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/axios-1.0.0",
+        }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      const depsTab = screen.getByRole("tab", { name: /Dependencies/ });
+      expect(depsTab.textContent?.replace(/\D+/g, "")).toBe("1");
+    });
+
+    await user.click(screen.getByRole("tab", { name: /Dependencies/ }));
+    await waitFor(() => {
+      expect(screen.getByText("axios: 0.27 → 1.0")).toBeDefined();
+      expect(screen.queryByText("lodash: 4.1 → 4.2")).toBeNull();
+    });
+  });
+
+  it("Test D: excluded repo's Dependency Dashboard issue is skipped for abandoned-package detection", async () => {
+    configStore.updateConfig({
+      dependencies: {
+        ...configStore.config.dependencies,
+        excludedRepos: [{ owner: "owner", name: "excluded-repo", fullName: "owner/excluded-repo" }],
+      },
+    });
+
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [
+        makeIssue({
+          title: "Dependency Dashboard",
+          userLogin: "renovate[bot]",
+          nodeId: "DASH_excluded",
+          repoFullName: "owner/excluded-repo",
+          state: "OPEN",
+        }),
+        makeIssue({
+          title: "Dependency Dashboard",
+          userLogin: "renovate[bot]",
+          nodeId: "DASH_other",
+          repoFullName: "owner/other-repo",
+          state: "OPEN",
+        }),
+      ],
+      pullRequests: [
+        makePullRequest({
+          repoFullName: "owner/excluded-repo",
+          title: "Bump lodash from 4.1 to 4.2",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/lodash-4.2",
+        }),
+        makePullRequest({
+          repoFullName: "owner/other-repo",
+          title: "Bump axios from 0.27 to 1.0",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/axios-1.0.0",
+        }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    const githubService = await import("../../src/app/services/github");
+    const graphqlSpy = vi.fn().mockResolvedValue({ nodes: [], rateLimit: null });
+    vi.mocked(githubService.getClient).mockReturnValue({ graphql: graphqlSpy } as unknown as ReturnType<typeof githubService.getClient>);
+
+    vi.mocked(pollService.createPollCoordinator).mockImplementation((_getInterval, fetchAll) => {
+      const [lastRefreshAt, setLastRefreshAt] = createSignal<Date | null>(null);
+      void fetchAll().then(() => setLastRefreshAt(new Date())).catch(() => {});
+      return { isRefreshing: () => false, lastRefreshAt, manualRefresh: vi.fn(), destroy: vi.fn() };
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => expect(graphqlSpy).toHaveBeenCalled());
+
+    const [, variables] = graphqlSpy.mock.calls[0] as [string, { ids: string[] }];
+    expect(variables.ids).toContain("DASH_other");
+    expect(variables.ids).not.toContain("DASH_excluded");
   });
 });
 

--- a/tests/components/DashboardPage.test.tsx
+++ b/tests/components/DashboardPage.test.tsx
@@ -2196,7 +2196,7 @@ describe("DashboardPage — dependency pre-exclusivity", () => {
 // ── Dependencies tab — repo/org exclusion filtering ──────────────────────────
 
 describe("DashboardPage — dependency exclusions", () => {
-  it("Test A: excludedRepos hides that repo's dependency PR from the Dependencies tab", async () => {
+  it("excludedRepos hides that repo's dependency PR from the Dependencies tab", async () => {
     configStore.updateConfig({
       dependencies: {
         ...configStore.config.dependencies,
@@ -2239,7 +2239,7 @@ describe("DashboardPage — dependency exclusions", () => {
     });
   });
 
-  it("Test B: excluded repo's dependency PR does not leak into the Pull Requests tab (exclusivity preserved)", async () => {
+  it("excluded repo's dependency PR does not leak into the Pull Requests tab (exclusivity preserved)", async () => {
     configStore.updateConfig({
       dependencies: {
         ...configStore.config.dependencies,
@@ -2274,7 +2274,7 @@ describe("DashboardPage — dependency exclusions", () => {
     });
   });
 
-  it("Test C: excludedOrgs hides that org's repo's dependency PR from the Dependencies tab", async () => {
+  it("excludedOrgs hides that org's repo's dependency PR from the Dependencies tab", async () => {
     configStore.updateConfig({
       dependencies: {
         ...configStore.config.dependencies,
@@ -2317,7 +2317,42 @@ describe("DashboardPage — dependency exclusions", () => {
     });
   });
 
-  it("Test D: excluded repo's Dependency Dashboard issue is skipped for abandoned-package detection", async () => {
+  it("excludedOrgs repo's dependency PR does not leak into the Pull Requests tab (exclusivity preserved)", async () => {
+    configStore.updateConfig({
+      dependencies: {
+        ...configStore.config.dependencies,
+        excludedOrgs: ["excluded-org"],
+      },
+    });
+
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [
+        makePullRequest({
+          repoFullName: "excluded-org/repo-a",
+          title: "Bump lodash from 4.1 to 4.2",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/lodash-4.2",
+        }),
+        makePullRequest({
+          repoFullName: "other-org/repo-b",
+          title: "Bump axios from 0.27 to 1.0",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/axios-1.0.0",
+        }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    render(() => <DashboardPage />);
+    await waitFor(() => {
+      const prTab = screen.getByRole("tab", { name: /^Pull Requests/ });
+      expect(prTab.textContent?.replace(/\D+/g, "")).toBe("0");
+    });
+  });
+
+  it("excluded repo's Dependency Dashboard issue is skipped for abandoned-package detection", async () => {
     configStore.updateConfig({
       dependencies: {
         ...configStore.config.dependencies,
@@ -2376,6 +2411,90 @@ describe("DashboardPage — dependency exclusions", () => {
     const [, variables] = graphqlSpy.mock.calls[0] as [string, { ids: string[] }];
     expect(variables.ids).toContain("DASH_other");
     expect(variables.ids).not.toContain("DASH_excluded");
+  });
+
+  it("depMeta cache entry for an excluded-but-still-tracked PR survives pruning", async () => {
+    const EXCLUDED_REPO = { owner: "owner", name: "excluded-repo", fullName: "owner/excluded-repo" };
+    const RENOVATE_BODY = [
+      "| Package | Update | Change |",
+      "|---|---|---|",
+      "| some-pkg | minor | `1.0.0` → `1.1.0` |",
+    ].join("\n");
+
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [
+        makePullRequest({
+          id: 100,
+          nodeId: "PR_A",
+          repoFullName: EXCLUDED_REPO.fullName,
+          title: "Update dependency some-pkg",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/some-pkg",
+        }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+
+    const githubService = await import("../../src/app/services/github");
+    const graphqlSpy = vi.fn().mockResolvedValue({
+      nodes: [{ databaseId: 100, body: RENOVATE_BODY }],
+      rateLimit: null,
+    });
+    vi.mocked(githubService.getClient).mockReturnValue({ graphql: graphqlSpy } as unknown as ReturnType<typeof githubService.getClient>);
+
+    render(() => <DashboardPage />);
+    await waitFor(() => expect(graphqlSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const raw = localStorage.getItem("github-tracker:dep-meta");
+      expect(raw && JSON.parse(raw)).toHaveProperty("100");
+    });
+
+    // Exclude the repo, then poll again with a second PR needing its own body
+    // fetch — this re-runs the effect (and its prune step) without which the
+    // prune logic never executes again.
+    configStore.updateConfig({
+      dependencies: { ...configStore.config.dependencies, excludedRepos: [EXCLUDED_REPO] },
+    });
+    graphqlSpy.mockResolvedValue({
+      nodes: [{ databaseId: 200, body: RENOVATE_BODY }],
+      rateLimit: null,
+    });
+    vi.mocked(pollService.fetchAllData).mockResolvedValue({
+      issues: [],
+      pullRequests: [
+        makePullRequest({
+          id: 100,
+          nodeId: "PR_A",
+          repoFullName: EXCLUDED_REPO.fullName,
+          title: "Update dependency some-pkg",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/some-pkg",
+        }),
+        makePullRequest({
+          id: 200,
+          nodeId: "PR_B",
+          repoFullName: "owner/other-repo",
+          title: "Update dependency other-pkg",
+          userLogin: "dependabot[bot]",
+          headRef: "dependabot/npm_and_yarn/other-pkg",
+        }),
+      ],
+      workflowRuns: [],
+      errors: [],
+    });
+    if (capturedFetchAll) await capturedFetchAll();
+
+    await waitFor(() => expect(graphqlSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      const raw = localStorage.getItem("github-tracker:dep-meta");
+      const parsed = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+      // PR-A (id 100) is excluded from the visible set but must survive
+      // pruning — the prune step keys off the unfiltered dependency set.
+      expect(parsed).toHaveProperty("100");
+      expect(parsed).toHaveProperty("200");
+    });
   });
 });
 

--- a/tests/components/IssuesTab.test.tsx
+++ b/tests/components/IssuesTab.test.tsx
@@ -577,7 +577,7 @@ describe("IssuesTab", () => {
 describe("IssuesTab — hideDepDashboard + dependencies.enabled interaction", () => {
   it("shows Dependency Dashboard in custom tab even when hideDepDashboard=true and deps disabled", () => {
     viewStore.updateViewState({ hideDepDashboard: true });
-    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     const issues = [
       makeIssue({ id: 1, title: "Dependency Dashboard", repoFullName: "org/repo", userLogin: "me" }),
     ];
@@ -590,7 +590,7 @@ describe("IssuesTab — hideDepDashboard + dependencies.enabled interaction", ()
 describe("IssuesTab — hideDepDashboard + dependencies.enabled", () => {
   it("hides Dependency Dashboard issue when hideDepDashboard=true and dependencies.enabled=false", () => {
     viewStore.updateViewState({ hideDepDashboard: true });
-    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     const issues = [
       makeIssue({ id: 1, title: "Dependency Dashboard", repoFullName: "org/repo" }),
       makeIssue({ id: 2, title: "Regular issue", repoFullName: "org/repo" }),
@@ -603,7 +603,7 @@ describe("IssuesTab — hideDepDashboard + dependencies.enabled", () => {
 
   it("shows Dependency Dashboard issue when hideDepDashboard=true but dependencies.enabled=true", () => {
     viewStore.updateViewState({ hideDepDashboard: true });
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     const issues = [
       makeIssue({ id: 1, title: "Dependency Dashboard", repoFullName: "org/repo" }),
       makeIssue({ id: 2, title: "Regular issue", repoFullName: "org/repo" }),
@@ -616,7 +616,7 @@ describe("IssuesTab — hideDepDashboard + dependencies.enabled", () => {
 
   it("shows Dependency Dashboard issue when hideDepDashboard=false regardless of dependencies.enabled", () => {
     viewStore.updateViewState({ hideDepDashboard: false });
-    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     const issues = [
       makeIssue({ id: 1, title: "Dependency Dashboard", repoFullName: "org/repo" }),
     ];

--- a/tests/components/settings/DependencyExclusionModal.test.tsx
+++ b/tests/components/settings/DependencyExclusionModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import DependencyExclusionModal from "../../../src/app/components/settings/DependencyExclusionModal";
 import type { RepoRef } from "../../../src/app/services/api";
+import { findCheckboxByLabelText } from "../../helpers/index";
 
 const availableOrgs = ["orgA", "orgB"];
 const availableRepos: RepoRef[] = [
@@ -10,14 +11,6 @@ const availableRepos: RepoRef[] = [
   { owner: "orgA", name: "repoA2", fullName: "orgA/repoA2" },
   { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
 ];
-
-function findCheckboxByLabelText(text: string): HTMLInputElement {
-  const checkbox = screen
-    .getAllByRole("checkbox")
-    .find((cb) => cb.closest("label")?.textContent?.includes(text));
-  if (!checkbox) throw new Error(`No checkbox found for label text "${text}"`);
-  return checkbox as HTMLInputElement;
-}
 
 function renderModal(overrides: Partial<Parameters<typeof DependencyExclusionModal>[0]> = {}) {
   const onClose = vi.fn();
@@ -141,6 +134,17 @@ describe("DependencyExclusionModal — save", () => {
       { owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" },
       { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
     ]);
+  });
+
+  it("silently drops a stale excludedRepos entry not present in availableRepos on save, even when untouched", () => {
+    // Accepted tradeoff — see tests/stores/config.test.ts structural-invariant block.
+    const STALE_REPO: RepoRef = { owner: "stale", name: "repo", fullName: "stale/repo" };
+    const { onSave } = renderModal({ excludedRepos: [STALE_REPO] });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    const [, repos] = onSave.mock.calls[0] as [string[], RepoRef[]];
+    expect(repos).toEqual([]);
   });
 });
 

--- a/tests/components/settings/DependencyExclusionModal.test.tsx
+++ b/tests/components/settings/DependencyExclusionModal.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import DependencyExclusionModal from "../../../src/app/components/settings/DependencyExclusionModal";
+import type { RepoRef } from "../../../src/app/services/api";
+
+const availableOrgs = ["orgA", "orgB"];
+const availableRepos: RepoRef[] = [
+  { owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" },
+  { owner: "orgA", name: "repoA2", fullName: "orgA/repoA2" },
+  { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
+];
+
+function findCheckboxByLabelText(text: string): HTMLInputElement {
+  const checkbox = screen
+    .getAllByRole("checkbox")
+    .find((cb) => cb.closest("label")?.textContent?.includes(text));
+  if (!checkbox) throw new Error(`No checkbox found for label text "${text}"`);
+  return checkbox as HTMLInputElement;
+}
+
+function renderModal(overrides: Partial<Parameters<typeof DependencyExclusionModal>[0]> = {}) {
+  const onClose = vi.fn();
+  const onSave = vi.fn();
+  render(() => (
+    <DependencyExclusionModal
+      open={true}
+      onClose={onClose}
+      availableOrgs={availableOrgs}
+      availableRepos={availableRepos}
+      excludedOrgs={[]}
+      excludedRepos={[]}
+      onSave={onSave}
+      {...overrides}
+    />
+  ));
+  return { onClose, onSave };
+}
+
+describe("DependencyExclusionModal — open/close", () => {
+  it("renders dialog when open is true", () => {
+    renderModal();
+    expect(screen.getByRole("dialog")).toBeDefined();
+  });
+
+  it("does not render dialog content when open is false", () => {
+    renderModal({ open: false });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("calls onClose when Cancel button is clicked, without calling onSave", () => {
+    const { onClose, onSave } = renderModal();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when the X button is clicked", () => {
+    const { onClose } = renderModal();
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DependencyExclusionModal — pre-checked state", () => {
+  it("pre-checks org/repo checkboxes matching the excludedOrgs/excludedRepos props", () => {
+    renderModal({
+      excludedOrgs: ["orgB"],
+      excludedRepos: [{ owner: "orgA", name: "repoA2", fullName: "orgA/repoA2" }],
+    });
+
+    expect(findCheckboxByLabelText("orgA").checked).toBe(false);
+    expect(findCheckboxByLabelText("orgB").checked).toBe(true);
+    expect(findCheckboxByLabelText("repoA1").checked).toBe(false);
+    expect(findCheckboxByLabelText("repoA2").checked).toBe(true);
+    // repoB1 is covered by the orgB exclusion (checked+disabled via the OR-logic)
+    expect(findCheckboxByLabelText("repoB1").checked).toBe(true);
+    expect(findCheckboxByLabelText("repoB1").disabled).toBe(true);
+  });
+});
+
+describe("DependencyExclusionModal — toggling", () => {
+  it("checking an org excludes all of that org's nested repos", () => {
+    renderModal();
+    fireEvent.click(findCheckboxByLabelText("orgA"));
+
+    expect(findCheckboxByLabelText("repoA1").checked).toBe(true);
+    expect(findCheckboxByLabelText("repoA1").disabled).toBe(true);
+    expect(findCheckboxByLabelText("repoA2").checked).toBe(true);
+    expect(findCheckboxByLabelText("repoA2").disabled).toBe(true);
+    expect(findCheckboxByLabelText("repoB1").checked).toBe(false);
+  });
+
+  it("deselecting an org un-checks and re-enables all of that org's nested repos", () => {
+    renderModal();
+    const orgA = findCheckboxByLabelText("orgA");
+    fireEvent.click(orgA); // select
+    fireEvent.click(orgA); // deselect
+
+    expect(findCheckboxByLabelText("repoA1").checked).toBe(false);
+    expect(findCheckboxByLabelText("repoA1").disabled).toBe(false);
+    expect(findCheckboxByLabelText("repoA2").checked).toBe(false);
+    expect(findCheckboxByLabelText("repoA2").disabled).toBe(false);
+  });
+
+  it("clicking a repo checkbox directly (org not excluded) toggles only that repo", () => {
+    renderModal();
+    fireEvent.click(findCheckboxByLabelText("repoA1"));
+
+    expect(findCheckboxByLabelText("repoA1").checked).toBe(true);
+    expect(findCheckboxByLabelText("repoA2").checked).toBe(false);
+    expect(findCheckboxByLabelText("orgA").checked).toBe(false);
+  });
+});
+
+describe("DependencyExclusionModal — save", () => {
+  it("calls onSave with the current excluded orgs and repos, then calls onClose", () => {
+    const { onClose, onSave } = renderModal();
+
+    fireEvent.click(findCheckboxByLabelText("orgB"));
+    fireEvent.click(findCheckboxByLabelText("repoA1"));
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const [orgs, repos] = onSave.mock.calls[0] as [string[], RepoRef[]];
+    expect(orgs).toEqual(["orgB"]);
+    expect(repos).toEqual([{ owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" }]);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters excluded repos against availableRepos on save (unfiltered orgs)", () => {
+    const { onSave } = renderModal();
+
+    fireEvent.click(findCheckboxByLabelText("repoA1"));
+    fireEvent.click(findCheckboxByLabelText("repoB1"));
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    const [, repos] = onSave.mock.calls[0] as [string[], RepoRef[]];
+    expect(repos).toEqual([
+      { owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" },
+      { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
+    ]);
+  });
+});
+
+describe("DependencyExclusionModal — reopening with different props", () => {
+  it("resets local checkbox state to match new props when reopened", () => {
+    type Props = Parameters<typeof DependencyExclusionModal>[0];
+    const [modalProps, setModalProps] = createSignal<Props>({
+      open: true,
+      onClose: vi.fn(),
+      availableOrgs,
+      availableRepos,
+      excludedOrgs: ["orgA"],
+      excludedRepos: [],
+      onSave: vi.fn(),
+    });
+
+    render(() => <DependencyExclusionModal {...modalProps()} />);
+
+    expect(findCheckboxByLabelText("orgA").checked).toBe(true);
+    expect(findCheckboxByLabelText("orgB").checked).toBe(false);
+
+    // Close, then reopen with different exclusions
+    setModalProps((prev) => ({ ...prev, open: false }));
+    setModalProps((prev) => ({
+      ...prev,
+      open: true,
+      excludedOrgs: ["orgB"],
+      excludedRepos: [{ owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" }],
+    }));
+
+    expect(findCheckboxByLabelText("orgA").checked).toBe(false);
+    expect(findCheckboxByLabelText("orgB").checked).toBe(true);
+    expect(findCheckboxByLabelText("repoA1").checked).toBe(true);
+  });
+});

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1238,4 +1238,74 @@ describe("Dependencies settings section", () => {
     fireEvent.input(input, { target: { value: "" } });
     expect(config.dependencies.rebaseLabel).toBe("rebase");
   });
+
+  it("renders 'None excluded' when excludedOrgs/excludedRepos are both empty", () => {
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
+    renderSettings();
+    screen.getByText("None excluded");
+  });
+
+  it("renders the count summary when both excluded lists are non-empty", () => {
+    updateConfig({
+      dependencies: {
+        enabled: true,
+        rebaseLabel: "rebase",
+        excludedOrgs: ["excluded-org"],
+        excludedRepos: [
+          { owner: "org1", name: "repo1", fullName: "org1/repo1" },
+          { owner: "org1", name: "repo2", fullName: "org1/repo2" },
+        ],
+      },
+    });
+    renderSettings();
+    screen.getByText("1 org, 2 repos");
+  });
+
+  it("renders '2 repos' (elideZero) when only excludedRepos is non-empty", () => {
+    updateConfig({
+      dependencies: {
+        enabled: true,
+        rebaseLabel: "rebase",
+        excludedOrgs: [],
+        excludedRepos: [
+          { owner: "org1", name: "repo1", fullName: "org1/repo1" },
+          { owner: "org1", name: "repo2", fullName: "org1/repo2" },
+        ],
+      },
+    });
+    renderSettings();
+    screen.getByText("2 repos");
+    expect(screen.queryByText("0 orgs, 2 repos")).toBeNull();
+  });
+
+  it("clicking Manage opens the exclusion modal", () => {
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
+    renderSettings();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+    screen.getByText("Exclude from Dependencies");
+  });
+
+  it("saving an exclusion updates config and the Section 12 summary re-renders", () => {
+    updateConfig({
+      selectedRepos: [{ owner: "org1", name: "repo1", fullName: "org1/repo1" }],
+      dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] },
+    });
+    renderSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+
+    const repoCheckbox = screen
+      .getAllByRole("checkbox")
+      .find((cb) => cb.closest("label")?.textContent?.includes("repo1")) as HTMLInputElement;
+    fireEvent.click(repoCheckbox);
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(config.dependencies.excludedRepos).toEqual([
+      { owner: "org1", name: "repo1", fullName: "org1/repo1" },
+    ]);
+    expect(config.dependencies.excludedOrgs).toEqual([]);
+    screen.getByText("1 repo");
+  });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1167,21 +1167,21 @@ describe("Dependencies settings section", () => {
   });
 
   it("renders Dependencies tab toggle checked when enabled", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     renderSettings();
     const toggle = screen.getByRole<HTMLInputElement>("checkbox", { name: /Enable dependencies tab/i });
     expect(toggle.checked).toBe(true);
   });
 
   it("renders Dependencies tab toggle unchecked when disabled", () => {
-    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: false, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     renderSettings();
     const toggle = screen.getByRole<HTMLInputElement>("checkbox", { name: /Enable dependencies tab/i });
     expect(toggle.checked).toBe(false);
   });
 
   it("toggles dependencies.enabled when checkbox is clicked", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     renderSettings();
     const toggle = screen.getByRole("checkbox", { name: /Enable dependencies tab/i });
     fireEvent.click(toggle);
@@ -1189,7 +1189,7 @@ describe("Dependencies settings section", () => {
   });
 
   it("disabling dependencies resets defaultTab to 'issues' when it was 'dependencies'", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" }, defaultTab: "dependencies" });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] }, defaultTab: "dependencies" });
     renderSettings();
     const toggle = screen.getByRole("checkbox", { name: /Enable dependencies tab/i });
     fireEvent.click(toggle);
@@ -1198,7 +1198,7 @@ describe("Dependencies settings section", () => {
   });
 
   it("disabling dependencies preserves defaultTab when it was not 'dependencies'", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" }, defaultTab: "pullRequests" });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] }, defaultTab: "pullRequests" });
     renderSettings();
     const toggle = screen.getByRole("checkbox", { name: /Enable dependencies tab/i });
     fireEvent.click(toggle);
@@ -1207,7 +1207,7 @@ describe("Dependencies settings section", () => {
   });
 
   it("disabling dependencies resets lastActiveTab to 'issues' when it was 'dependencies'", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     updateViewState({ lastActiveTab: "dependencies" });
     renderSettings();
     const toggle = screen.getByRole("checkbox", { name: /Enable dependencies tab/i });
@@ -1217,14 +1217,14 @@ describe("Dependencies settings section", () => {
   });
 
   it("renders rebase label input with current value", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase-please" } });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase-please", excludedOrgs: [], excludedRepos: [] } });
     renderSettings();
     const input = screen.getByRole<HTMLInputElement>("textbox", { name: /Rebase label/i });
     expect(input.value).toBe("rebase-please");
   });
 
   it("updates dependencies.rebaseLabel on input change", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     renderSettings();
     const input = screen.getByRole("textbox", { name: /Rebase label/i });
     fireEvent.input(input, { target: { value: "rebase-please" } });
@@ -1232,7 +1232,7 @@ describe("Dependencies settings section", () => {
   });
 
   it("rebase label input falls back to 'rebase' when cleared", () => {
-    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase" } });
+    updateConfig({ dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] } });
     renderSettings();
     const input = screen.getByRole("textbox", { name: /Rebase label/i });
     fireEvent.input(input, { target: { value: "" } });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1308,4 +1308,27 @@ describe("Dependencies settings section", () => {
     expect(config.dependencies.excludedOrgs).toEqual([]);
     screen.getByText("1 repo");
   });
+
+  it("de-dupes a repo present in both selectedRepos and monitoredRepos to a single checkbox and exclusion entry", () => {
+    updateConfig({
+      selectedRepos: [{ owner: "org1", name: "repo1", fullName: "org1/repo1" }],
+      monitoredRepos: [{ owner: "org1", name: "repo1", fullName: "org1/repo1" }],
+      dependencies: { enabled: true, rebaseLabel: "rebase", excludedOrgs: [], excludedRepos: [] },
+    });
+    renderSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+
+    const repoCheckboxes = screen
+      .getAllByRole("checkbox")
+      .filter((cb) => cb.closest("label")?.textContent?.includes("repo1"));
+    expect(repoCheckboxes).toHaveLength(1);
+
+    fireEvent.click(repoCheckboxes[0]);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(config.dependencies.excludedRepos).toEqual([
+      { owner: "org1", name: "repo1", fullName: "org1/repo1" },
+    ]);
+  });
 });

--- a/tests/components/shared/CustomTabModal.test.tsx
+++ b/tests/components/shared/CustomTabModal.test.tsx
@@ -45,6 +45,7 @@ vi.mock("../../../src/app/stores/view", () => ({
 import CustomTabModal from "../../../src/app/components/shared/CustomTabModal";
 import { config } from "../../../src/app/stores/config";
 import type { CustomTab } from "../../../src/app/stores/config";
+import { findCheckboxByLabelText } from "../../helpers/index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -62,7 +63,10 @@ function makeTab(overrides: Partial<CustomTab> = {}): CustomTab {
 }
 
 /**
- * Renders the modal wrapped in a signal so open/editingTab can be changed reactively.
+ * Renders the modal with `open` wrapped in a signal so it can be toggled reactively.
+ * `editingTab` is captured at render time — it is not reactive. For a test that needs
+ * editingTab to change after the initial render, build the props signal directly (see
+ * "CustomTabModal — reopening with a different editingTab" below).
  */
 function renderModal(
   initialOpen = true,
@@ -466,6 +470,41 @@ describe("CustomTabModal — scope accordion", () => {
     const arg = mockAddCustomTab.mock.calls[0][0] as CustomTab;
     expect(arg.orgScope).toEqual([]);
     expect(arg.repoScope).toEqual([{ owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" }]);
+  });
+});
+
+// ── Reopening with a different editingTab ────────────────────────────────────
+
+describe("CustomTabModal — reopening with a different editingTab", () => {
+  it("resets org/repo scope to match the new editingTab, not stale state from the previous one", () => {
+    type Props = Parameters<typeof CustomTabModal>[0];
+    const tabA = makeTab({ id: "tabA", name: "Tab A", orgScope: ["orgA"] });
+    const tabB = makeTab({ id: "tabB", name: "Tab B", orgScope: ["orgB"] });
+    const [modalProps, setModalProps] = createSignal<Props>({
+      open: true,
+      onClose: vi.fn(),
+      editingTab: tabA,
+      availableOrgs: ["orgA", "orgB"],
+      availableRepos: [
+        { owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" },
+        { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
+      ],
+    });
+
+    render(() => <CustomTabModal {...modalProps()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /scope/i }));
+    expect(findCheckboxByLabelText("orgA").checked).toBe(true);
+    expect(findCheckboxByLabelText("orgB").checked).toBe(false);
+
+    // Close, then reopen with a different editingTab
+    setModalProps((prev) => ({ ...prev, open: false }));
+    setModalProps((prev) => ({ ...prev, open: true, editingTab: tabB }));
+
+    // Reinitializing collapses the scope accordion — reopen it
+    fireEvent.click(screen.getByRole("button", { name: /scope/i }));
+    expect(findCheckboxByLabelText("orgA").checked).toBe(false);
+    expect(findCheckboxByLabelText("orgB").checked).toBe(true);
   });
 });
 

--- a/tests/components/shared/OrgRepoCheckboxTree.test.tsx
+++ b/tests/components/shared/OrgRepoCheckboxTree.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+import OrgRepoCheckboxTree from "../../../src/app/components/shared/OrgRepoCheckboxTree";
+
+const availableOrgs = ["orgA", "orgB"];
+const availableRepos = [
+  { owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" },
+  { owner: "orgA", name: "repoA2", fullName: "orgA/repoA2" },
+  { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
+];
+
+function findCheckboxByLabelText(text: string): HTMLInputElement {
+  const checkbox = screen
+    .getAllByRole("checkbox")
+    .find((cb) => cb.closest("label")?.textContent?.includes(text));
+  if (!checkbox) throw new Error(`No checkbox found for label text "${text}"`);
+  return checkbox as HTMLInputElement;
+}
+
+describe("OrgRepoCheckboxTree — rendering", () => {
+  it("renders one checkbox per org and one nested checkbox per repo", () => {
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={availableOrgs}
+        availableRepos={availableRepos}
+        checkedOrgs={new Set()}
+        checkedRepos={new Set()}
+        onToggleOrg={vi.fn()}
+        onToggleRepo={vi.fn()}
+      />
+    ));
+
+    expect(screen.getAllByRole("checkbox")).toHaveLength(5); // 2 orgs + 3 repos
+    expect(screen.getByText("orgA")).toBeDefined();
+    expect(screen.getByText("orgB")).toBeDefined();
+    expect(screen.getByText("repoA1")).toBeDefined();
+    expect(screen.getByText("repoA2")).toBeDefined();
+    expect(screen.getByText("repoB1")).toBeDefined();
+  });
+
+  it("pre-checks org checkboxes matching checkedOrgs prop", () => {
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={availableOrgs}
+        availableRepos={availableRepos}
+        checkedOrgs={new Set(["orgB"])}
+        checkedRepos={new Set()}
+        onToggleOrg={vi.fn()}
+        onToggleRepo={vi.fn()}
+      />
+    ));
+
+    expect(findCheckboxByLabelText("orgA").checked).toBe(false);
+    expect(findCheckboxByLabelText("orgB").checked).toBe(true);
+  });
+
+  it("pre-checks repo checkboxes matching checkedRepos prop", () => {
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={availableOrgs}
+        availableRepos={availableRepos}
+        checkedOrgs={new Set()}
+        checkedRepos={new Set(["orgA/repoA2"])}
+        onToggleOrg={vi.fn()}
+        onToggleRepo={vi.fn()}
+      />
+    ));
+
+    expect(findCheckboxByLabelText("repoA1").checked).toBe(false);
+    expect(findCheckboxByLabelText("repoA2").checked).toBe(true);
+    expect(findCheckboxByLabelText("repoB1").checked).toBe(false);
+  });
+
+  it("checking an org checks and disables all of that org's nested repo checkboxes", () => {
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={availableOrgs}
+        availableRepos={availableRepos}
+        checkedOrgs={new Set(["orgA"])}
+        checkedRepos={new Set()}
+        onToggleOrg={vi.fn()}
+        onToggleRepo={vi.fn()}
+      />
+    ));
+
+    const repoA1 = findCheckboxByLabelText("repoA1");
+    const repoA2 = findCheckboxByLabelText("repoA2");
+    const repoB1 = findCheckboxByLabelText("repoB1");
+
+    expect(repoA1.checked).toBe(true);
+    expect(repoA1.disabled).toBe(true);
+    expect(repoA2.checked).toBe(true);
+    expect(repoA2.disabled).toBe(true);
+    expect(repoB1.checked).toBe(false);
+    expect(repoB1.disabled).toBe(false);
+  });
+
+  it("renders emptyMessage when availableOrgs is empty", () => {
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={[]}
+        availableRepos={[]}
+        checkedOrgs={new Set()}
+        checkedRepos={new Set()}
+        onToggleOrg={vi.fn()}
+        onToggleRepo={vi.fn()}
+        emptyMessage="No repos tracked yet."
+      />
+    ));
+
+    expect(screen.getByText("No repos tracked yet.")).toBeDefined();
+  });
+
+  it("renders default 'No orgs available.' message when emptyMessage is omitted", () => {
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={[]}
+        availableRepos={[]}
+        checkedOrgs={new Set()}
+        checkedRepos={new Set()}
+        onToggleOrg={vi.fn()}
+        onToggleRepo={vi.fn()}
+      />
+    ));
+
+    expect(screen.getByText("No orgs available.")).toBeDefined();
+  });
+});
+
+describe("OrgRepoCheckboxTree — callbacks (pure function of props)", () => {
+  it("calls onToggleOrg with the org's name when its checkbox is clicked", () => {
+    const onToggleOrg = vi.fn();
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={availableOrgs}
+        availableRepos={availableRepos}
+        checkedOrgs={new Set()}
+        checkedRepos={new Set()}
+        onToggleOrg={onToggleOrg}
+        onToggleRepo={vi.fn()}
+      />
+    ));
+
+    fireEvent.click(findCheckboxByLabelText("orgA"));
+    expect(onToggleOrg).toHaveBeenCalledTimes(1);
+    expect(onToggleOrg).toHaveBeenCalledWith("orgA");
+  });
+
+  it("calls onToggleRepo with the repo's fullName when its checkbox is clicked", () => {
+    const onToggleRepo = vi.fn();
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={availableOrgs}
+        availableRepos={availableRepos}
+        checkedOrgs={new Set()}
+        checkedRepos={new Set()}
+        onToggleOrg={vi.fn()}
+        onToggleRepo={onToggleRepo}
+      />
+    ));
+
+    fireEvent.click(findCheckboxByLabelText("repoB1"));
+    expect(onToggleRepo).toHaveBeenCalledTimes(1);
+    expect(onToggleRepo).toHaveBeenCalledWith("orgB/repoB1");
+  });
+
+  it("reports every click identically regardless of click history — the component owns no toggle state", () => {
+    // If the component tracked its own checked/toggle state internally, repeated
+    // clicks might mutate that state and change what gets reported. Since it's a
+    // pure function of props + callbacks, every click on the same org must invoke
+    // onToggleOrg identically.
+    const onToggleOrg = vi.fn();
+    render(() => (
+      <OrgRepoCheckboxTree
+        availableOrgs={availableOrgs}
+        availableRepos={availableRepos}
+        checkedOrgs={new Set()}
+        checkedRepos={new Set()}
+        onToggleOrg={onToggleOrg}
+        onToggleRepo={vi.fn()}
+      />
+    ));
+
+    const orgA = findCheckboxByLabelText("orgA");
+    fireEvent.click(orgA);
+    fireEvent.click(orgA);
+    expect(onToggleOrg).toHaveBeenCalledTimes(2);
+    expect(onToggleOrg).toHaveBeenNthCalledWith(1, "orgA");
+    expect(onToggleOrg).toHaveBeenNthCalledWith(2, "orgA");
+  });
+});

--- a/tests/components/shared/OrgRepoCheckboxTree.test.tsx
+++ b/tests/components/shared/OrgRepoCheckboxTree.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
 import OrgRepoCheckboxTree from "../../../src/app/components/shared/OrgRepoCheckboxTree";
+import { findCheckboxByLabelText } from "../../helpers/index";
 
 const availableOrgs = ["orgA", "orgB"];
 const availableRepos = [
@@ -8,14 +9,6 @@ const availableRepos = [
   { owner: "orgA", name: "repoA2", fullName: "orgA/repoA2" },
   { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
 ];
-
-function findCheckboxByLabelText(text: string): HTMLInputElement {
-  const checkbox = screen
-    .getAllByRole("checkbox")
-    .find((cb) => cb.closest("label")?.textContent?.includes(text));
-  if (!checkbox) throw new Error(`No checkbox found for label text "${text}"`);
-  return checkbox as HTMLInputElement;
-}
 
 describe("OrgRepoCheckboxTree — rendering", () => {
   it("renders one checkbox per org and one nested checkbox per repo", () => {

--- a/tests/helpers/index.tsx
+++ b/tests/helpers/index.tsx
@@ -1,4 +1,4 @@
-import { render } from "@solidjs/testing-library";
+import { render, screen } from "@solidjs/testing-library";
 import { MemoryRouter, createMemoryHistory } from "@solidjs/router";
 import { resetViewState } from "../../src/app/stores/view";
 import type { JSX } from "solid-js";
@@ -18,4 +18,12 @@ export function renderWithRouter(
 
 export function resetViewStore(): void {
   resetViewState();
+}
+
+export function findCheckboxByLabelText(text: string): HTMLInputElement {
+  const checkbox = screen
+    .getAllByRole("checkbox")
+    .find((cb) => cb.closest("label")?.textContent?.includes(text));
+  if (!checkbox) throw new Error(`No checkbox found for label text "${text}"`);
+  return checkbox as HTMLInputElement;
 }

--- a/tests/lib/dependency-exclusion.test.ts
+++ b/tests/lib/dependency-exclusion.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { isRepoExcludedFromDependencies } from "../../src/app/lib/dependency-exclusion.js";
+
+describe("isRepoExcludedFromDependencies", () => {
+  it("returns true when the repo is in excludedRepos (exact fullName match)", () => {
+    const excludedRepos = [{ fullName: "owner/repo" }];
+    expect(isRepoExcludedFromDependencies("owner/repo", [], excludedRepos)).toBe(true);
+  });
+
+  it("returns true when the repo's owner is in excludedOrgs", () => {
+    expect(isRepoExcludedFromDependencies("owner/repo", ["owner"], [])).toBe(true);
+  });
+
+  it("returns false when neither list contains the repo", () => {
+    const excludedRepos = [{ fullName: "other-owner/other-repo" }];
+    expect(isRepoExcludedFromDependencies("owner/repo", ["other-org"], excludedRepos)).toBe(false);
+  });
+
+  it("matches org exclusion case-insensitively", () => {
+    expect(isRepoExcludedFromDependencies("some-org/repo", ["Some-Org"], [])).toBe(true);
+  });
+
+  it("matches repo exclusion case-insensitively", () => {
+    const excludedRepos = [{ fullName: "Some-Org/Repo" }];
+    expect(isRepoExcludedFromDependencies("some-org/repo", [], excludedRepos)).toBe(true);
+  });
+
+  it("returns false when excludedOrgs and excludedRepos are both empty", () => {
+    expect(isRepoExcludedFromDependencies("owner/repo", [], [])).toBe(false);
+  });
+});

--- a/tests/lib/orgRepoSelection.test.ts
+++ b/tests/lib/orgRepoSelection.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { createOrgRepoSelection } from "../../src/app/lib/orgRepoSelection";
+import type { RepoRef } from "../../src/app/services/api";
+
+const availableRepos: RepoRef[] = [
+  { owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" },
+  { owner: "orgA", name: "repoA2", fullName: "orgA/repoA2" },
+  { owner: "orgB", name: "repoB1", fullName: "orgB/repoB1" },
+];
+
+describe("createOrgRepoSelection", () => {
+  it("initializes selectedOrgs/selectedRepos from the initial accessors", () => {
+    createRoot((dispose) => {
+      const sel = createOrgRepoSelection({
+        getOpen: () => true,
+        getAvailableRepos: () => availableRepos,
+        getInitialOrgs: () => ["orgA"],
+        getInitialRepos: () => ["orgB/repoB1"],
+      });
+      expect(sel.selectedOrgs()).toEqual(new Set(["orgA"]));
+      expect(sel.selectedRepos()).toEqual(new Set(["orgB/repoB1"]));
+      dispose();
+    });
+  });
+
+  it("toggleOrg selects an org without touching the repo set", () => {
+    createRoot((dispose) => {
+      const sel = createOrgRepoSelection({
+        getOpen: () => true,
+        getAvailableRepos: () => availableRepos,
+        getInitialOrgs: () => [],
+        getInitialRepos: () => [],
+      });
+      sel.toggleOrg("orgA");
+      expect(sel.selectedOrgs()).toEqual(new Set(["orgA"]));
+      expect(sel.selectedRepos()).toEqual(new Set());
+      dispose();
+    });
+  });
+
+  it("deselecting an org clears that org's member repos from the repo set", () => {
+    createRoot((dispose) => {
+      const sel = createOrgRepoSelection({
+        getOpen: () => true,
+        getAvailableRepos: () => availableRepos,
+        getInitialOrgs: () => [],
+        getInitialRepos: () => ["orgB/repoB1"],
+      });
+      sel.toggleOrg("orgA"); // select
+      sel.toggleRepo("orgA/repoA1"); // individually select a member repo
+      sel.toggleOrg("orgA"); // deselect — should clear orgA's repos only
+      expect(sel.selectedOrgs()).toEqual(new Set());
+      expect(sel.selectedRepos()).toEqual(new Set(["orgB/repoB1"]));
+      dispose();
+    });
+  });
+
+  it("toggleRepo toggles an individual repo without affecting the org set", () => {
+    createRoot((dispose) => {
+      const sel = createOrgRepoSelection({
+        getOpen: () => true,
+        getAvailableRepos: () => availableRepos,
+        getInitialOrgs: () => [],
+        getInitialRepos: () => [],
+      });
+      sel.toggleRepo("orgA/repoA1");
+      expect(sel.selectedRepos()).toEqual(new Set(["orgA/repoA1"]));
+      expect(sel.selectedOrgs()).toEqual(new Set());
+      sel.toggleRepo("orgA/repoA1");
+      expect(sel.selectedRepos()).toEqual(new Set());
+      dispose();
+    });
+  });
+
+  it("buildRepoList filters availableRepos by selectedRepos membership, dropping stale entries", () => {
+    createRoot((dispose) => {
+      const sel = createOrgRepoSelection({
+        getOpen: () => true,
+        getAvailableRepos: () => availableRepos,
+        getInitialOrgs: () => [],
+        getInitialRepos: () => ["orgA/repoA1", "stale/repo"],
+      });
+      expect(sel.buildRepoList()).toEqual([{ owner: "orgA", name: "repoA1", fullName: "orgA/repoA1" }]);
+      dispose();
+    });
+  });
+
+  it("resets selection from initial accessors when getOpen flips false→true", () => {
+    let sel!: ReturnType<typeof createOrgRepoSelection>;
+    let dispose!: () => void;
+    let setOpen!: (v: boolean) => void;
+    let setInitialOrgs!: (v: string[]) => void;
+
+    createRoot((d) => {
+      dispose = d;
+      const [open, setOpenSignal] = createSignal(true);
+      const [initialOrgs, setInitialOrgsSignal] = createSignal<string[]>(["orgA"]);
+      setOpen = setOpenSignal;
+      setInitialOrgs = setInitialOrgsSignal;
+      sel = createOrgRepoSelection({
+        getOpen: open,
+        getAvailableRepos: () => availableRepos,
+        getInitialOrgs: initialOrgs,
+        getInitialRepos: () => [],
+      });
+    });
+
+    sel.toggleOrg("orgB"); // in-progress edit
+    expect(sel.selectedOrgs()).toEqual(new Set(["orgA", "orgB"]));
+
+    setOpen(false);
+    setInitialOrgs(["orgB"]);
+    setOpen(true);
+
+    expect(sel.selectedOrgs()).toEqual(new Set(["orgB"]));
+    dispose();
+  });
+});

--- a/tests/stores/config.test.ts
+++ b/tests/stores/config.test.ts
@@ -55,6 +55,21 @@ describe("ConfigSchema", () => {
     expect(result.onboardingComplete).toBe(false);
     expect(result.authMethod).toBe("oauth");
     expect(result.enableActions).toBe(true);
+    expect(result.dependencies.excludedOrgs).toEqual([]);
+    expect(result.dependencies.excludedRepos).toEqual([]);
+  });
+
+  it("round-trips excludedOrgs/excludedRepos when provided", () => {
+    const result = ConfigSchema.parse({
+      dependencies: {
+        enabled: true,
+        rebaseLabel: "rebase",
+        excludedOrgs: ["some-org"],
+        excludedRepos: [{ owner: "some-org", name: "repo", fullName: "some-org/repo" }],
+      },
+    });
+    expect(result.dependencies.excludedOrgs).toEqual(["some-org"]);
+    expect(result.dependencies.excludedRepos).toEqual([{ owner: "some-org", name: "repo", fullName: "some-org/repo" }]);
   });
 
   it("enableActions defaults to true (Actions tab enabled by default)", () => {
@@ -660,6 +675,39 @@ describe("updateConfig — customTabs scope pruning on selectedRepos change", ()
 //     curated via explicit add/remove UI, never auto-merged from a live fetch.
 //   - selectedOrgs: reconciled against a live fetchOrgs() result rather than
 //     a sibling config field — covered separately in OrgSelector.test.tsx.
+//   - dependencies.excludedOrgs / dependencies.excludedRepos: their available
+//     pool is the union of selectedRepos + upstreamRepos + monitoredRepos, not
+//     selectedRepos alone, so pruning against selectedRepos shrinkage alone
+//     would incorrectly drop valid exclusions for a repo still present via
+//     upstreamRepos or monitoredRepos.
+//
+//     Contrast with customTabs.orgScope/repoScope above, which IS pruned
+//     under this same `if ("selectedRepos" in partial)` guard — structurally
+//     it looks identical (an org-string array plus a repo-array, both living
+//     in a settings scope picker), which could tempt a future implementer or
+//     reviewer into "fixing" the asymmetry by copying that pruning onto
+//     excludedOrgs/excludedRepos. Don't: customTabs is safely prunable
+//     against selectedRepos alone specifically because its own
+//     available-options pool (availableOrgs/availableRepos, passed into
+//     CustomTabModal from config.selectedRepos only) IS selectedRepos alone,
+//     with no upstreamRepos/monitoredRepos contribution. excludedOrgs/
+//     excludedRepos have no such narrow pool; applying customTabs' pruning
+//     technique to them would silently drop valid exclusions for repos
+//     tracked only via upstreamRepos or monitoredRepos.
+//
+//     The two exclusion fields are NOT equally inert when stale. A stale
+//     excludedRepos entry (referencing a repo no longer in any of the three
+//     pools) has no effect unless that exact repo is re-added later, and is
+//     incidentally pruned the next time the exclusion modal is saved
+//     (buildExcludedRepos filters against availableRepos at save time — the
+//     same asymmetry CustomTabModal already has between its own repoScope,
+//     filtered via buildRepoScope() on save, and orgScope, saved verbatim).
+//     A stale excludedOrgs entry is more persistent: because org-level
+//     matching is intentionally dynamic and re-evaluated against
+//     pr.repoFullName on every render, a leftover org name silently
+//     re-excludes any repo added under that org later — including repos
+//     unrelated to the original exclusion — and, like CustomTabModal's
+//     orgScope, is never filtered against availableOrgs on save either.
 describe("updateConfig — structural invariant: repo-referencing fields reconcile with selectedRepos", () => {
   beforeEach(() => {
     resetConfig();

--- a/tests/stores/config.test.ts
+++ b/tests/stores/config.test.ts
@@ -72,6 +72,17 @@ describe("ConfigSchema", () => {
     expect(result.dependencies.excludedRepos).toEqual([{ owner: "some-org", name: "repo", fullName: "some-org/repo" }]);
   });
 
+  it("defaults excludedOrgs/excludedRepos to [] for a pre-migration persisted config missing the new fields", () => {
+    const result = ConfigSchema.parse({
+      dependencies: {
+        enabled: true,
+        rebaseLabel: "rebase",
+      },
+    });
+    expect(result.dependencies.excludedOrgs).toEqual([]);
+    expect(result.dependencies.excludedRepos).toEqual([]);
+  });
+
   it("enableActions defaults to true (Actions tab enabled by default)", () => {
     expect(ConfigSchema.parse({}).enableActions).toBe(true);
     expect(ConfigSchema.parse({ enableActions: false }).enableActions).toBe(false);
@@ -675,39 +686,12 @@ describe("updateConfig — customTabs scope pruning on selectedRepos change", ()
 //     curated via explicit add/remove UI, never auto-merged from a live fetch.
 //   - selectedOrgs: reconciled against a live fetchOrgs() result rather than
 //     a sibling config field — covered separately in OrgSelector.test.tsx.
-//   - dependencies.excludedOrgs / dependencies.excludedRepos: their available
-//     pool is the union of selectedRepos + upstreamRepos + monitoredRepos, not
-//     selectedRepos alone, so pruning against selectedRepos shrinkage alone
-//     would incorrectly drop valid exclusions for a repo still present via
-//     upstreamRepos or monitoredRepos.
-//
-//     Contrast with customTabs.orgScope/repoScope above, which IS pruned
-//     under this same `if ("selectedRepos" in partial)` guard — structurally
-//     it looks identical (an org-string array plus a repo-array, both living
-//     in a settings scope picker), which could tempt a future implementer or
-//     reviewer into "fixing" the asymmetry by copying that pruning onto
-//     excludedOrgs/excludedRepos. Don't: customTabs is safely prunable
-//     against selectedRepos alone specifically because its own
-//     available-options pool (availableOrgs/availableRepos, passed into
-//     CustomTabModal from config.selectedRepos only) IS selectedRepos alone,
-//     with no upstreamRepos/monitoredRepos contribution. excludedOrgs/
-//     excludedRepos have no such narrow pool; applying customTabs' pruning
-//     technique to them would silently drop valid exclusions for repos
-//     tracked only via upstreamRepos or monitoredRepos.
-//
-//     The two exclusion fields are NOT equally inert when stale. A stale
-//     excludedRepos entry (referencing a repo no longer in any of the three
-//     pools) has no effect unless that exact repo is re-added later, and is
-//     incidentally pruned the next time the exclusion modal is saved
-//     (buildExcludedRepos filters against availableRepos at save time — the
-//     same asymmetry CustomTabModal already has between its own repoScope,
-//     filtered via buildRepoScope() on save, and orgScope, saved verbatim).
-//     A stale excludedOrgs entry is more persistent: because org-level
-//     matching is intentionally dynamic and re-evaluated against
-//     pr.repoFullName on every render, a leftover org name silently
-//     re-excludes any repo added under that org later — including repos
-//     unrelated to the original exclusion — and, like CustomTabModal's
-//     orgScope, is never filtered against availableOrgs on save either.
+//   - dependencies.excludedOrgs / dependencies.excludedRepos: available pool
+//     is the union of selectedRepos + upstreamRepos + monitoredRepos, not
+//     selectedRepos alone — pruning against selectedRepos shrinkage alone
+//     would incorrectly drop valid exclusions for a repo still reachable via
+//     the other two. Unlike customTabs.orgScope/repoScope above, this pair is
+//     not pruned under the `if ("selectedRepos" in partial)` guard.
 describe("updateConfig — structural invariant: repo-referencing fields reconcile with selectedRepos", () => {
   beforeEach(() => {
     resetConfig();

--- a/tests/stores/config.test.ts
+++ b/tests/stores/config.test.ts
@@ -767,6 +767,30 @@ describe("updateConfig — structural invariant: repo-referencing fields reconci
       });
     }
   );
+
+  it("dependencies.excludedOrgs/excludedRepos survive a selectedRepos update that drops a repo still present via upstreamRepos", () => {
+    createRoot((dispose) => {
+      updateConfig({
+        selectedRepos: [STALE_REPO, SURVIVING_REPO],
+        upstreamRepos: [STALE_REPO],
+        dependencies: {
+          ...config.dependencies,
+          excludedOrgs: ["unrelated-org"],
+          excludedRepos: [STALE_REPO],
+        },
+      });
+
+      // STALE_REPO drops out of selectedRepos but remains available via
+      // upstreamRepos — its exclusion entries must NOT be pruned, unlike
+      // monitoredRepos/customTabs above (see the block comment before this
+      // describe for why excludedOrgs/excludedRepos are intentionally exempt).
+      updateConfig({ selectedRepos: [SURVIVING_REPO] });
+
+      expect(config.dependencies.excludedRepos).toEqual([STALE_REPO]);
+      expect(config.dependencies.excludedOrgs).toEqual(["unrelated-org"]);
+      dispose();
+    });
+  });
 });
 
 describe("setMonitoredRepo (C3)", () => {


### PR DESCRIPTION
## Summary
- Adds `excludedOrgs`/`excludedRepos` to the Dependency config schema and a new Settings → Dependencies checkbox-tree modal, letting users hide specific repos or entire orgs from the Dependencies tab (bot PRs and Renovate Dashboard abandoned-package badges) without affecting Issues, Pull Requests, or Actions
- Preserves existing cross-tab exclusivity by filtering a new `visibleDependencyPullRequests` memo on top of the unfiltered classification, so excluded repos' bot PRs vanish entirely instead of reappearing in Pull Requests
- Extracts a shared `OrgRepoCheckboxTree` component from `CustomTabModal`'s inline checkbox-tree JSX, reused by both the existing custom-tab scope picker and the new exclusion modal

Closes #126