### PR TITLE
feat: add settings import with encrypted credential migration

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -26,6 +26,7 @@ routing.
 - Multi-user tracking, upstream repo discovery, monitor-all mode
 - Repo pinning/reordering, themes, ignore system
 - IndexedDB caching + ETag optimization
+- Plaintext settings export and import (client-side only)
 - MCP server (separate Node.js process, independent of Worker)
 
 **What does NOT work without a backend:**
@@ -41,6 +42,10 @@ routing.
   404 console errors on static hosts. Optionally remove the `report-uri` and
   `report-to` directives if the noise is unwanted.
 - **Jira token sealing** (planned) — requires server-side encryption
+- **Encrypted-credentials export/import** — the credential seal/unseal endpoints
+  (`/api/proxy/seal`, `/api/proxy/unseal`) run only on the Worker. Plaintext settings
+  export and import still work on static-only deploys; only the optional
+  encrypted-credentials bundle needs the backend.
 
 **Security note:** The `public/_headers` file sets Content-Security-Policy and other
 security headers. Ensure your static host serves these headers — Cloudflare Pages,
@@ -64,6 +69,7 @@ PAT instead), and Turnstile is only used by the planned Jira integration.
 2. **Update `wrangler.toml`** — Change `pattern = "gh.gordoncode.dev"` to your domain
 3. **Set GitHub Actions secrets and variables** — See sections below
 4. **Set Cloudflare Worker secrets** — See "Cloudflare Worker Secrets" section below. **Critical:** `ALLOWED_ORIGIN` must exactly match your deployment URL (e.g., `https://your-domain.example.com`). An incorrect value causes all API requests to fail with CORS errors.
+5. **Provision the credential-nonce KV namespace** — See "Cloudflare KV Namespaces" section below. Required for the encrypted-credential import feature; skipping it makes every encrypted-credential import fail with a 503 (plaintext-config import still works).
 
 **Verify configuration:** Run `pnpm validate:deploy` locally to check that all required
 Cloudflare Worker secrets are set. In CI, the deploy workflow runs
@@ -150,13 +156,44 @@ wrangler secret put ALLOWED_ORIGIN
 - `GITHUB_CLIENT_SECRET`: the Client Secret from your GitHub OAuth App
 - `ALLOWED_ORIGIN`: `https://YOUR-DOMAIN` (e.g. `https://gh.gordoncode.dev`)
 
+## Cloudflare KV Namespaces
+
+The encrypted-credential import feature (`/api/proxy/unseal`) requires a KV namespace
+bound as `CREDENTIAL_NONCE_KV`. It backs single-use consumption of credential-bundle
+nonces, blocking an unseal-then-reseal renewal of a bundle's 30-day expiry. It holds only
+opaque nonce values (never plaintext, ciphertext, or tokens), with a TTL bounded by each
+bundle's own expiry window.
+
+Create the production and preview namespaces:
+
+```sh
+wrangler kv namespace create CREDENTIAL_NONCE_KV
+wrangler kv namespace create CREDENTIAL_NONCE_KV --preview
+```
+
+Each command prints an ID. Add the returned `id` and `preview_id` to the
+`[[kv_namespaces]]` block in `wrangler.toml`, replacing the upstream placeholder values:
+
+```toml
+[[kv_namespaces]]
+binding = "CREDENTIAL_NONCE_KV"
+id = "<your-production-id>"
+preview_id = "<your-preview-id>"
+```
+
+`pnpm validate:deploy` does **not** check KV bindings — it validates Worker secrets and
+build-time env vars only — so provision this manually. If the binding is missing or
+misconfigured, every encrypted-credential import fails closed with a **503**; the
+plaintext-configuration import path is unaffected and still works.
+
 ## Worker API Endpoints
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
 | `/api/oauth/token` | POST | Exchange OAuth authorization code for permanent access token. |
 | `/api/health` | GET | Health check. Returns `OK`. |
-| `/api/proxy/seal` | POST | Encrypt an API token for client-side storage. Requires Turnstile + session. |
+| `/api/proxy/seal` | POST | Encrypt (seal) an API token or credential-export bundle for client-side storage. Requires Turnstile + session. |
+| `/api/proxy/unseal` | POST | Decrypt (unseal) an encrypted credential-export bundle during import. Reachable pre-authentication (Login-page import). Requires Turnstile + the `CREDENTIAL_NONCE_KV` binding (single-use nonce enforcement). |
 
 ### Token Storage Security
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -775,6 +775,8 @@ Before signing in, click **Import from backup** on the Login page and choose an 
 - A file **without** encrypted credentials cannot sign you in. You are told to sign in normally first, then use Import on the Settings page to restore your configuration.
 - A file **with** encrypted credentials prompts for the one-time code and then signs you in automatically. If this browser already has settings from prior use (you have completed onboarding or selected any repos/orgs), an identity confirmation is shown first. A genuinely fresh browser or incognito window skips the confirmation and goes straight to the dashboard.
 
+If you have this app open in other browser tabs, importing credentials for a different GitHub identity reloads those tabs automatically so they reflect the new identity — any unsaved in-tab state there (such as a partially typed filter) is lost.
+
 ### The One-Time Code Is Single-Use
 
 The encrypted-credentials portion of an export can be **decrypted only once — the moment you first submit the one-time code**, not once per successful import. That first submission is irreversible for that file. This means any of the following, *after* the first code submission, permanently consumes the credentials portion:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -757,12 +757,13 @@ Before signing in, click **Import from backup** on the Login page and choose an 
 
 The encrypted-credentials portion of an export can be **decrypted only once — the moment you first submit the one-time code**, not once per successful import. That first submission is irreversible for that file. This means any of the following, *after* the first code submission, permanently consumes the credentials portion:
 
-- entering a wrong code,
 - declining the identity confirmation,
 - the GitHub token turning out to be revoked or expired,
 - reloading the page or closing the tab.
 
 If any of these happen, the plaintext configuration still imports fine, but the credentials can no longer be restored from that file — **re-export to get a fresh, single-use file** for another migration, test session, or retry.
+
+Entering a wrong code is **not** one of these. Your one-time code is never sent to the server — it's checked locally against the result of that first submission — so a typo is safely retryable in the same session: just retype it and submit again, as long as you have not already declined the confirmation, reloaded the page, or closed the tab.
 
 ### Keep the Export File Safe
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -54,6 +54,7 @@ GitHub Tracker is a dashboard that aggregates open issues, pull requests, and Gi
 - [Settings Reference](#settings-reference)
 - [Exporting and Importing Settings](#exporting-and-importing-settings)
   - [Exporting](#exporting)
+  - [View Preferences Are Included Too](#view-preferences-are-included-too)
   - [Including Encrypted Credentials](#including-encrypted-credentials)
   - [Importing on the Settings Page](#importing-on-the-settings-page)
   - [Importing on the Login Page](#importing-on-the-login-page)
@@ -702,7 +703,7 @@ Settings are saved automatically to `localStorage` and persist across sessions. 
 
 ### View State Settings
 
-These are UI preferences that persist across sessions but are not included in the exported config file.
+These are UI preferences that persist across sessions in your browser. Most of them also travel with an exported settings file — see [View Preferences Are Included Too](#view-preferences-are-included-too) for exactly what's included and what isn't.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -722,17 +723,38 @@ You can export your configuration to a JSON file and import it back later — on
 
 ### Exporting
 
-Go to **Settings > Data > Export** and click **Export**. This downloads `github-tracker-settings.json` containing your full configuration — repositories, organizations, tracked users, tabs, refresh interval, notification preferences, Jira display settings, and everything else on the Settings page.
+Go to **Settings > Data > Export** and click **Export**. A dialog opens with two choices:
 
-A plaintext export contains **no credentials**. Your Atlassian email is also omitted (it is personally identifiable and not needed to restore the configuration). Importing a plaintext export restores your settings but does not sign you in — you still authenticate normally.
+- **Export config only** — downloads `github-tracker-settings.json` immediately: your full configuration (repositories, organizations, tracked users, tabs, refresh interval, notification preferences, Jira display settings, and everything else on the Settings page) plus your view preferences (below), with no credentials.
+- **Export with encrypted credentials** — see [Including Encrypted Credentials](#including-encrypted-credentials).
+
+A plaintext export (config only) contains **no credentials**. Your Atlassian email is also omitted (it is personally identifiable and not needed to restore the configuration). Importing a plaintext export restores your settings but does not sign you in — you still authenticate normally.
+
+### View Preferences Are Included Too
+
+Every export — plaintext or with credentials — also carries a curated set of view preferences. On import, these are restored automatically alongside your configuration, for whichever GitHub identity that import establishes:
+
+- Jira custom sort order
+- Expand/collapse state and pinned/locked repos, per tab
+- Tab filters (including per-tab username filters) and custom tab filter values
+- Dependency-group expansion state
+- The Show PR Runs and Hide Dependency Dashboard toggles
+- Your Ignored Items and Tracked Items lists
+
+A few things are deliberately left out:
+
+- Issue/PR **titles and URLs**, and a tracked Jira issue's **status** (e.g. "In Progress"), are never included. On the target machine, tracked GitHub issues/PRs pick up their real title again automatically once the app has fetched their repo's data; tracked Jira issues show a blank title and status, and Ignored items show a blank title, until you interact with them again (re-track or re-ignore) — tracking and ignoring still work either way, since both are keyed by a stable identifier (item ID or Jira key), not the title.
+- What DOES travel for those lists — repo names, issue/PR numbers, Jira keys — is plaintext in the export file, the same as the rest of your configuration. So are your saved filter values (per-tab username filters, custom tab filter text).
+- The **org/repo filter** at the top of the dashboard is not included — it's transient and resets on a new browser or session anyway.
+- View preferences travel in the **plaintext** part of the export, never inside the encrypted credentials section — there's nothing secret in them.
 
 ### Including Encrypted Credentials
 
-To migrate a full session (or set up an incognito test session) without re-authenticating, check **Include encrypted credentials for migration** before clicking **Export**. The export then also bundles your GitHub token and — if connected — your Jira credentials, encrypted so they can travel in the file safely.
+To migrate a full session (or set up an incognito test session) without re-authenticating, choose **Export with encrypted credentials** in the export dialog. Right above that choice, the dialog shows a warning: *"This is a one-time transfer, not a durable backup — the encrypted credentials can be imported once and expire in 30 days."* The export then also bundles your GitHub token and — if connected — your Jira credentials, encrypted so they can travel in the file safely.
 
 When you export with credentials:
 
-1. A **one-time code** is generated and shown in a dialog. **This code is displayed only once.** Copy it and save it **separately from the export file** (for example, in a password manager) — you need *both* the file and the code to restore credentials.
+1. A **one-time code** is generated and shown in a dialog — 26 characters, shown in dashed groups for readability (`XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XX`). **This code is displayed only once.** Copy it and save it **separately from the export file** (for example, in a password manager) — you need *both* the file and the code to restore credentials, and it cannot be shown again or recovered later. When retyping it, case doesn't matter, and the letters I, L, and O are read as 1, 1, and 0 respectively, so a common misreading of the code still works.
 2. The file downloads only *after* you acknowledge the code dialog. If you dismiss the dialog without acknowledging, nothing is downloaded.
 
 The code never leaves your browser and is never written into the export file. The credentials inside the file are encrypted with it, so the file alone cannot reveal them.
@@ -761,7 +783,7 @@ The encrypted-credentials portion of an export can be **decrypted only once — 
 - the GitHub token turning out to be revoked or expired,
 - reloading the page or closing the tab.
 
-If any of these happen, the plaintext configuration still imports fine, but the credentials can no longer be restored from that file — **re-export to get a fresh, single-use file** for another migration, test session, or retry.
+If any of these happen, you'll see a message like *"Couldn't restore credentials — this file may already have been used (single-use), or the code/file don't match. Re-export to try again."* The plaintext configuration still imports fine, but the credentials can no longer be restored from that file — **re-export to get a fresh, single-use file** for another migration, test session, or retry.
 
 Entering a wrong code is **not** one of these. Your one-time code is never sent to the server — it's checked locally against the result of that first submission — so a typo is safely retryable in the same session: just retype it and submit again, as long as you have not already declined the confirmation, reloaded the page, or closed the tab.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -52,6 +52,15 @@ GitHub Tracker is a dashboard that aggregates open issues, pull requests, and Gi
   - [Bookmarking Jira Issues](#bookmarking-jira-issues)
   - [Disconnecting](#disconnecting-jira)
 - [Settings Reference](#settings-reference)
+- [Exporting and Importing Settings](#exporting-and-importing-settings)
+  - [Exporting](#exporting)
+  - [Including Encrypted Credentials](#including-encrypted-credentials)
+  - [Importing on the Settings Page](#importing-on-the-settings-page)
+  - [Importing on the Login Page](#importing-on-the-login-page)
+  - [The One-Time Code Is Single-Use](#the-one-time-code-is-single-use)
+  - [Keep the Export File Safe](#keep-the-export-file-safe)
+  - [Jira Credentials and Staleness](#jira-credentials-and-staleness)
+  - [Same-Deployment Only](#same-deployment-only)
 - [Troubleshooting](#troubleshooting)
 
 ---
@@ -704,6 +713,68 @@ These are UI preferences that persist across sessions but are not included in th
 | Sort preferences | Updated (desc) | Sort field and direction per tab, remembered across sessions. |
 | Pinned repos | (none) | Repos pinned to the top of the list, stored per tab independently. |
 | Tracked items | (none) | Issues and PRs pinned to the Tracked tab (max 200). |
+
+---
+
+## Exporting and Importing Settings
+
+You can export your configuration to a JSON file and import it back later — on the same machine, a new machine, or an incognito window for testing. Import is available both from the Settings page (when you are already signed in) and from the Login page (before you sign in, so a single file can restore your settings *and* sign you in).
+
+### Exporting
+
+Go to **Settings > Data > Export** and click **Export**. This downloads `github-tracker-settings.json` containing your full configuration — repositories, organizations, tracked users, tabs, refresh interval, notification preferences, Jira display settings, and everything else on the Settings page.
+
+A plaintext export contains **no credentials**. Your Atlassian email is also omitted (it is personally identifiable and not needed to restore the configuration). Importing a plaintext export restores your settings but does not sign you in — you still authenticate normally.
+
+### Including Encrypted Credentials
+
+To migrate a full session (or set up an incognito test session) without re-authenticating, check **Include encrypted credentials for migration** before clicking **Export**. The export then also bundles your GitHub token and — if connected — your Jira credentials, encrypted so they can travel in the file safely.
+
+When you export with credentials:
+
+1. A **one-time code** is generated and shown in a dialog. **This code is displayed only once.** Copy it and save it **separately from the export file** (for example, in a password manager) — you need *both* the file and the code to restore credentials.
+2. The file downloads only *after* you acknowledge the code dialog. If you dismiss the dialog without acknowledging, nothing is downloaded.
+
+The code never leaves your browser and is never written into the export file. The credentials inside the file are encrypted with it, so the file alone cannot reveal them.
+
+The encrypted-credentials portion of an export **expires 30 days after it is created**. After that, the credentials can no longer be imported and you must re-export. The plaintext configuration in the same file always imports regardless of age.
+
+### Importing on the Settings Page
+
+Go to **Settings > Data > Import** and choose an export file.
+
+- **Plaintext file (no credentials):** you are asked to confirm, then your current settings are replaced.
+- **File with encrypted credentials:** you are prompted for the one-time code. Enter it (use the show/hide toggle to check a manually typed code), then confirm. Because you are already signed in, the Settings page **always** shows an identity confirmation — "This will sign you in as @username and replace your current settings" — before finishing. You can also choose **Continue without credentials** to import just the plaintext configuration.
+
+### Importing on the Login Page
+
+Before signing in, click **Import from backup** on the Login page and choose an export file.
+
+- A file **without** encrypted credentials cannot sign you in. You are told to sign in normally first, then use Import on the Settings page to restore your configuration.
+- A file **with** encrypted credentials prompts for the one-time code and then signs you in automatically. If this browser already has settings from prior use (you have completed onboarding or selected any repos/orgs), an identity confirmation is shown first. A genuinely fresh browser or incognito window skips the confirmation and goes straight to the dashboard.
+
+### The One-Time Code Is Single-Use
+
+The encrypted-credentials portion of an export can be **decrypted only once — the moment you first submit the one-time code**, not once per successful import. That first submission is irreversible for that file. This means any of the following, *after* the first code submission, permanently consumes the credentials portion:
+
+- entering a wrong code,
+- declining the identity confirmation,
+- the GitHub token turning out to be revoked or expired,
+- reloading the page or closing the tab.
+
+If any of these happen, the plaintext configuration still imports fine, but the credentials can no longer be restored from that file — **re-export to get a fresh, single-use file** for another migration, test session, or retry.
+
+### Keep the Export File Safe
+
+Anyone who obtains the export file — **even without the one-time code** — can trigger that single, irreversible decryption step and thereby invalidate the file's credentials portion for the rest of its lifetime. This is an availability/griefing consideration, **not** a confidentiality break: the one-time code still protects the credentials' secrecy, and recovery is simply re-exporting. Treat the export file as sensitive, and re-export if you suspect it was exposed.
+
+### Jira Credentials and Staleness
+
+Jira **OAuth** credentials in an export often go stale quickly. Atlassian rotates refresh tokens on every refresh, and a signed-in machine refreshes roughly once an hour — so an exported Jira-OAuth credential is typically invalidated within about an hour of export. For a reliable Jira-OAuth migration, **re-export immediately before importing**, or simply **reconnect Jira on the target machine** after importing (the import degrades gracefully with a reconnect prompt rather than failing the whole import). Jira **API-token** mode and GitHub tokens do not rotate and are unaffected.
+
+### Same-Deployment Only
+
+Encrypted credentials are sealed by this deployment's server and can only be imported back into **the same deployment**. Credentials exported from `gh.gordoncode.dev` cannot be imported into a different deployment (a self-hosted fork or a different domain). Plaintext configuration is portable across deployments; credentials are not.
 
 ---
 

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -3,8 +3,9 @@ import { Select } from "@kobalte/core/select";
 import * as Sentry from "@sentry/solid";
 import { getRelayStatus } from "../../lib/mcp-relay";
 import { useNavigate } from "@solidjs/router";
-import { config, updateConfig, updateJiraConfig, updateJiraCustomFields, updateJiraCustomScopes, setMonitoredRepo, isActionsBasedTab } from "../../stores/config";
-import type { JiraCustomField } from "../../../shared/schemas";
+import { config, setConfig, updateConfig, updateJiraConfig, updateJiraCustomFields, updateJiraCustomScopes, setMonitoredRepo, isActionsBasedTab } from "../../stores/config";
+import type { Config, JiraCustomField } from "../../../shared/schemas";
+import { buildExportPayload, parseImportFile } from "../../lib/settings-transfer";
 import { viewState, updateViewState, setTabFilter } from "../../stores/view";
 import { clearAuth, jiraAuth, setJiraAuth, clearJiraConfigFull, isJiraAuthenticated, token, setAuthFromPat } from "../../stores/auth";
 import type { GitHubUser } from "../../stores/auth";
@@ -241,42 +242,9 @@ export default function SettingsPage() {
   }
 
   function handleExportSettings() {
-    const data = JSON.stringify(
-      {
-        selectedOrgs: config.selectedOrgs,
-        selectedRepos: config.selectedRepos,
-        upstreamRepos: config.upstreamRepos,
-        monitoredRepos: config.monitoredRepos,
-        trackedUsers: config.trackedUsers,
-        refreshInterval: config.refreshInterval,
-        hotPollInterval: config.hotPollInterval,
-        maxWorkflowsPerRepo: config.maxWorkflowsPerRepo,
-        maxRunsPerWorkflow: config.maxRunsPerWorkflow,
-        notifications: config.notifications,
-        theme: config.theme,
-        viewDensity: config.viewDensity,
-        itemsPerPage: config.itemsPerPage,
-        defaultTab: config.defaultTab,
-        rememberLastTab: config.rememberLastTab,
-        enableTracking: config.enableTracking,
-        enableActions: config.enableActions,
-        customTabs: config.customTabs,
-        // Non-secret jira config fields only — no tokens, sealed blobs, or email
-        jira: {
-          enabled: config.jira?.enabled ?? false,
-          authMethod: config.jira?.authMethod ?? "oauth",
-          issueKeyDetection: config.jira?.issueKeyDetection ?? true,
-          cloudId: config.jira?.cloudId,
-          siteName: config.jira?.siteName,
-          siteUrl: config.jira?.siteUrl,
-          customFields: config.jira?.customFields ?? [],
-          customScopes: config.jira?.customScopes ?? [],
-        },
-        dependencies: config.dependencies,
-      },
-      null,
-      2
-    );
+    // Schema-driven payload (spread of Config + denylist) — see
+    // src/app/lib/settings-transfer.ts. Blob/anchor-download mechanics unchanged.
+    const data = JSON.stringify(buildExportPayload(config), null, 2);
     const blob = new Blob([data], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -284,6 +252,49 @@ export default function SettingsPage() {
     a.download = "github-tracker-settings.json";
     a.click();
     URL.revokeObjectURL(url);
+  }
+
+  // ── Import settings (plaintext) ────────────────────────────────────────────
+  // pendingImport holds the parsed-and-validated Config awaiting confirmation;
+  // non-null doubles as the two-click confirm state (mirrors confirmReset).
+  const [pendingImport, setPendingImport] = createSignal<Config | null>(null);
+  let importInputRef: HTMLInputElement | undefined;
+
+  async function handleImportFileSelected(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    // Allow re-selecting the same file (change won't fire otherwise).
+    try { input.value = ""; } catch { /* ignore if unsupported */ }
+    if (!file) return;
+    let text: string;
+    try {
+      // A read rejection (unreadable/binary file) is treated identically to a
+      // parse failure below — same notification path, no confirmation shown.
+      text = await file.text();
+    } catch {
+      pushNotification("settings-import", "Could not read that file — choose a valid settings export.", "warning");
+      return;
+    }
+    const result = parseImportFile(text);
+    if (!result.ok) {
+      pushNotification("settings-import", `Import failed: ${result.errors[0] ?? "invalid settings file"}`, "warning");
+      return;
+    }
+    setPendingImport(result.config);
+  }
+
+  function handleConfirmImport() {
+    const imported = pendingImport();
+    if (!imported) return;
+    // Wholesale replace — parseImportFile returns a fully-parsed Config (every
+    // top-level key present), so setConfig is safe (NOT updateConfig's partial merge).
+    setConfig(imported);
+    setPendingImport(null);
+    pushNotification("settings-import", "Settings imported", "info");
+  }
+
+  function handleCancelImport() {
+    setPendingImport(null);
   }
 
   function handleResetAll() {
@@ -1519,6 +1530,51 @@ export default function SettingsPage() {
             >
               Export
             </button>
+          </SettingRow>
+
+          {/* Import settings */}
+          <SettingRow
+            label="Import settings"
+            description="Replace your configuration from a previously exported JSON file"
+          >
+            <Show
+              when={!pendingImport()}
+              fallback={
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-base-content/60">This will replace your current settings — continue?</span>
+                  <button
+                    type="button"
+                    onClick={handleConfirmImport}
+                    class="btn btn-warning btn-xs"
+                  >
+                    Yes, import
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCancelImport}
+                    class="btn btn-ghost btn-xs"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              }
+            >
+              <input
+                ref={importInputRef}
+                type="file"
+                accept="application/json,.json"
+                class="hidden"
+                aria-label="Import settings file"
+                onChange={(e) => void handleImportFileSelected(e)}
+              />
+              <button
+                type="button"
+                onClick={() => importInputRef?.click()}
+                class="btn btn-sm btn-outline"
+              >
+                Import
+              </button>
+            </Show>
           </SettingRow>
 
           {/* Reset all */}

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -8,13 +8,10 @@ import { config, setConfig, updateConfig, updateJiraConfig, updateJiraCustomFiel
 import type { Config, JiraCustomField } from "../../../shared/schemas";
 import {
   buildExportPayload,
-  parseImportFile,
   buildEncryptedCredentialsSection,
-  resolveImportedCredentials,
   commitImportedSettings,
-  CredentialsSectionSchema,
 } from "../../lib/settings-transfer";
-import type { CredentialBundle, CredentialsSection } from "../../lib/settings-transfer";
+import { createCredentialImport } from "../../lib/use-credential-import";
 import { viewState, updateViewState, setTabFilter } from "../../stores/view";
 import { clearAuth, jiraAuth, setJiraAuth, clearJiraConfigFull, isJiraAuthenticated, token, setAuthFromPat } from "../../stores/auth";
 import type { GitHubUser } from "../../stores/auth";
@@ -22,7 +19,7 @@ import { isValidPatFormat } from "../../lib/pat";
 import { clearCache } from "../../stores/cache";
 import { pushNotification } from "../../lib/errors";
 import { buildOrgAccessUrl, buildJiraAuthorizeUrl } from "../../lib/oauth";
-import { sealApiToken, unsealCredentialBundle } from "../../lib/proxy";
+import { sealApiToken } from "../../lib/proxy";
 import { isSafeGitHubUrl, openGitHubUrl } from "../../lib/url";
 import { relativeTime, formatScopeSummary } from "../../lib/format";
 import { fetchOrgs } from "../../services/api";
@@ -153,7 +150,7 @@ export default function SettingsPage() {
   // (handleConfirmImport / handleConfirmCredImport / handleContinueWithoutCredentials)
   // replaces config wholesale via setConfig without a reload, so they must be
   // resynced afterward — otherwise the next org/repo edit would save the stale,
-  // pre-import selection and silently discard the imported repos/orgs (CR-001).
+  // pre-import selection and silently discard the imported repos/orgs.
   // setConfig is synchronous, so config already reflects the import here.
   function resyncLocalEditors() {
     setLocalOrgs(config.selectedOrgs);
@@ -263,7 +260,7 @@ export default function SettingsPage() {
   }
 
   // ── Export settings ────────────────────────────────────────────────────────
-  // includeCredentials opts into an encrypted-credentials section (Task 5). On
+  // includeCredentials opts into an encrypted-credentials section. On
   // success the one-time code is shown in a modal and the file download is
   // DEFERRED until the user acknowledges — the code is shown only once.
   const [includeCredentials, setIncludeCredentials] = createSignal(false);
@@ -288,7 +285,7 @@ export default function SettingsPage() {
     // mint a NEW code + a new seal call while the old code is still displayed.
     // The Kobalte Dialog traps + restores focus (so the Export button can't be
     // re-fired behind the modal), and this guard closes the gap for any other
-    // trigger path (QA-001).
+    // trigger path.
     if (exportCode() !== null) return;
     const payload = buildExportPayload(config);
     if (!includeCredentials()) {
@@ -299,7 +296,7 @@ export default function SettingsPage() {
     try {
       // buildEncryptedCredentialsSection generates the code, encrypts the bundle
       // with it, THEN seals the ciphertext (encrypt-then-seal). No secret is
-      // logged here (SD-002).
+      // logged here.
       const { sealed, salt, oneTimeCode } = await buildEncryptedCredentialsSection();
       pendingExportJson = JSON.stringify({ ...payload, _credentials: { sealed, salt } }, null, 2);
       setCodeCopied(false);
@@ -351,37 +348,19 @@ export default function SettingsPage() {
   const [pendingImport, setPendingImport] = createSignal<Config | null>(null);
   let importInputRef: HTMLInputElement | undefined;
 
-  // ── Import settings (encrypted credentials, Task 6) ──────────────────────────
-  // credImport is set when the selected file has a valid _credentials section.
-  const [credImport, setCredImport] = createSignal<{ config: Config; credentials: CredentialsSection } | null>(null);
-  const [codeInput, setCodeInput] = createSignal("");
-  const [showCode, setShowCode] = createSignal(false);
-  const [unsealInFlight, setUnsealInFlight] = createSignal(false);
-  const [cachedCiphertext, setCachedCiphertext] = createSignal<string | null>(null);
-  const [credError, setCredError] = createSignal<string | null>(null);
-  const [credTerminalMsg, setCredTerminalMsg] = createSignal<string | null>(null);
-  const [resolvedCred, setResolvedCred] = createSignal<{ bundle: CredentialBundle; identity: GitHubUser } | null>(null);
+  // ── Import settings (encrypted credentials) ───────────────────────────────
+  // credentialImport.credImport() is set when the selected file has a valid
+  // _credentials section. On success it always shows the identity-confirm
+  // step below (unlike the Login page, which can skip it on a fresh session).
   const [committing, setCommitting] = createSignal(false);
-
-  // Generation counter tying an in-flight unseal/resolve to the file that started
-  // it (mirrors auth.ts's _crossTabFetchGen). Bumped on every reset and on every
-  // new file selection; the submit handler captures it before each await and
-  // bails if it changed, so a Cancel-then-reselect during the multi-second
-  // unseal/resolve window can't strand one file's ciphertext/credential into a
-  // different file's shared signals.
-  let unsealGen = 0;
-
-  function resetCredImport() {
-    unsealGen++;
-    setCredImport(null);
-    setCodeInput("");
-    setShowCode(false);
-    setUnsealInFlight(false);
-    setCachedCiphertext(null);
-    setCredError(null);
-    setCredTerminalMsg(null);
-    setResolvedCred(null);
-  }
+  const credentialImport = createCredentialImport({
+    expiredMessage:
+      "This export's credentials have expired — re-export from a machine where you're still signed in, or import the settings without credentials.",
+    onReadError: (message) => pushNotification("settings-import", message, "warning"),
+    onParseError: (message) => pushNotification("settings-import", message, "warning"),
+    onNoCredentials: (importedConfig) => setPendingImport(importedConfig),
+    onResolved: (bundle, identity) => credentialImport.setResolvedCred({ bundle, identity }),
+  });
 
   async function handleImportFileSelected(e: Event) {
     const input = e.currentTarget as HTMLInputElement;
@@ -389,35 +368,7 @@ export default function SettingsPage() {
     // Allow re-selecting the same file (change won't fire otherwise).
     try { input.value = ""; } catch { /* ignore if unsupported */ }
     if (!file) return;
-    let text: string;
-    try {
-      // A read rejection (unreadable/binary file) is treated identically to a
-      // parse failure below — same notification path, no confirmation shown.
-      text = await file.text();
-    } catch {
-      pushNotification("settings-import", "Could not read that file — choose a valid settings export.", "warning");
-      return;
-    }
-    const result = parseImportFile(text);
-    if (!result.ok) {
-      pushNotification("settings-import", `Import failed: ${result.errors[0] ?? "invalid settings file"}`, "warning");
-      return;
-    }
-    // Detect an encrypted-credentials section via schema validation (NOT a bare
-    // "in" check — a hand-crafted `_credentials: null` would pass that and then
-    // throw on dereference). A malformed/null/non-object one falls through to the
-    // plaintext-only path.
-    const rawCreds =
-      result.rawJson && typeof result.rawJson === "object"
-        ? (result.rawJson as Record<string, unknown>)._credentials
-        : undefined;
-    const credSection = CredentialsSectionSchema.safeParse(rawCreds);
-    if (credSection.success) {
-      resetCredImport();
-      setCredImport({ config: result.config, credentials: credSection.data });
-      return;
-    }
-    setPendingImport(result.config);
+    await credentialImport.handleFileSelected(file);
   }
 
   function handleConfirmImport() {
@@ -435,73 +386,16 @@ export default function SettingsPage() {
     setPendingImport(null);
   }
 
-  async function handleCredCodeSubmit() {
-    if (unsealInFlight()) return; // in-flight guard: exactly one network unseal
-    const ci = credImport();
-    if (!ci) return;
-    const code = codeInput();
-    setCredError(null);
-    const gen = unsealGen; // capture before the first await
-
-    let ciphertext = cachedCiphertext();
-    if (ciphertext === null) {
-      // FIRST submission — single-use network unseal (consumes the bundle nonce
-      // server-side). Never retried; wrong-code retries run against the cache.
-      setUnsealInFlight(true);
-      const res = await unsealCredentialBundle(ci.credentials.sealed).finally(() =>
-        setUnsealInFlight(false)
-      );
-      // A changed unsealGen means a Cancel-then-reselect started a different file
-      // while this await was pending; writing any signal now would strand this
-      // file's result into the newly-selected file's state, so stop here.
-      if (gen !== unsealGen) return;
-      if (!res.ok) {
-        if (res.reason === "turnstile" || res.reason === "network" || res.reason === "rate-limited") {
-          // Pre-nonce-consumption failure — the single-use nonce was NOT
-          // consumed, so this is retryable. Keep the code prompt available (do
-          // NOT fall through to the terminal "continue without credentials"
-          // screen); surface a retryable inline message.
-          setCredError(
-            res.reason === "rate-limited"
-              ? "Too many attempts — wait a moment and try again."
-              : res.reason === "network"
-                ? "Network problem — please try again."
-                : "Verification failed — please try again."
-          );
-          return;
-        }
-        setCredTerminalMsg(
-          res.reason === "expired"
-            ? "This export's credentials have expired — re-export from a machine where you're still signed in, or import the settings without credentials."
-            : "Couldn't decrypt credentials — check the code and file match."
-        );
-        return;
-      }
-      ciphertext = res.ciphertext;
-      setCachedCiphertext(ciphertext);
-    }
-
-    // Client-side, retryable against the cached ciphertext (no re-unseal).
-    const resolved = await resolveImportedCredentials(ciphertext, ci.credentials.salt, code);
-    // The resolve await is another window where a Cancel-then-reselect can change
-    // unsealGen (unsealInFlight is false here); discard the result if so.
-    if (gen !== unsealGen) return;
-    if (!resolved.ok) {
-      setCredError(resolved.error);
-      return;
-    }
-    setResolvedCred({ bundle: resolved.bundle, identity: resolved.identity });
-  }
-
   async function handleConfirmCredImport() {
-    const ci = credImport();
-    const rc = resolvedCred();
-    if (!ci || !rc) return;
+    if (committing()) return; // re-entry guard: exactly one commit
+    const cred = credentialImport.credImport();
+    const rc = credentialImport.resolvedCred();
+    if (!cred || !rc) return;
     setCommitting(true);
     try {
-      await commitImportedSettings(rc, ci.config);
+      await commitImportedSettings(rc, cred.config);
       resyncLocalEditors();
-      resetCredImport();
+      credentialImport.reset();
       pushNotification("settings-import", "Settings and credentials imported", "info");
     } catch {
       pushNotification("settings-import", "Something went wrong finishing the import — please try again.", "warning");
@@ -511,10 +405,10 @@ export default function SettingsPage() {
   }
 
   function handleContinueWithoutCredentials() {
-    const ci = credImport();
-    if (!ci) return;
-    const cfg = ci.config;
-    resetCredImport();
+    const cred = credentialImport.credImport();
+    if (!cred) return;
+    const cfg = cred.config;
+    credentialImport.reset();
     // Route the plaintext-only path through the SAME two-click confirm the
     // plaintext import uses (pendingImport), so both wholesale-replace paths
     // confirm consistently. handleConfirmImport applies it + resyncs the editors.
@@ -522,7 +416,7 @@ export default function SettingsPage() {
   }
 
   function handleCancelCredImport() {
-    resetCredImport();
+    credentialImport.reset();
   }
 
   function handleResetAll() {
@@ -1782,7 +1676,7 @@ export default function SettingsPage() {
             <Show
               when={pendingImport()}
               fallback={
-                <Show when={!credImport()}>
+                <Show when={!credentialImport.credImport()}>
                   <input
                     ref={importInputRef}
                     type="file"
@@ -1936,22 +1830,22 @@ export default function SettingsPage() {
             While a network unseal is in flight the close controls are disabled so
             the single-use nonce can't be abandoned mid-flight. */}
         <Dialog
-          open={credImport() !== null}
-          onOpenChange={(isOpen) => { if (!isOpen && !unsealInFlight()) handleCancelCredImport(); }}
+          open={credentialImport.credImport() !== null}
+          onOpenChange={(isOpen) => { if (!isOpen && !credentialImport.unsealInFlight() && !committing()) handleCancelCredImport(); }}
           modal
         >
           <Dialog.Portal>
             <Dialog.Overlay class="fixed inset-0 bg-black/50 z-50" />
             <Dialog.Content class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-base-100 rounded-xl shadow-xl z-[51] p-6 flex flex-col gap-4">
               <Show
-                when={resolvedCred()}
+                when={credentialImport.resolvedCred()}
                 fallback={
                   <Show
-                    when={!credTerminalMsg()}
+                    when={!credentialImport.terminalError()}
                     fallback={
                       <>
                         <Dialog.Title class="text-lg font-semibold">Credentials unavailable</Dialog.Title>
-                        <p role="alert" class="text-sm text-error">{credTerminalMsg()}</p>
+                        <p role="alert" class="text-sm text-error">{credentialImport.terminalError()}</p>
                         <div class="flex justify-end gap-2">
                           <button type="button" onClick={handleCancelCredImport} class="btn btn-sm btn-ghost">
                             Cancel
@@ -1967,43 +1861,43 @@ export default function SettingsPage() {
                     <p class="text-sm text-base-content/70">
                       Enter the one-time code shown when this file was exported.
                     </p>
-                    <form onSubmit={(e) => { e.preventDefault(); void handleCredCodeSubmit(); }}>
+                    <form onSubmit={(e) => { e.preventDefault(); void credentialImport.handleCodeSubmit(); }}>
                       <div class="flex items-center gap-2">
                         <input
-                          type={showCode() ? "text" : "password"}
+                          type={credentialImport.showCode() ? "text" : "password"}
                           class="input input-sm w-full font-mono"
                           aria-label="One-time code"
                           autocomplete="off"
                           placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
-                          value={codeInput()}
-                          onInput={(e) => setCodeInput(e.currentTarget.value)}
+                          value={credentialImport.codeInput()}
+                          onInput={(e) => credentialImport.setCodeInput(e.currentTarget.value)}
                         />
                         <button
                           type="button"
-                          onClick={() => setShowCode((v) => !v)}
+                          onClick={() => credentialImport.setShowCode((v) => !v)}
                           class="btn btn-sm btn-ghost"
-                          aria-pressed={showCode()}
+                          aria-pressed={credentialImport.showCode()}
                         >
-                          {showCode() ? "Hide" : "Show"}
+                          {credentialImport.showCode() ? "Hide" : "Show"}
                         </button>
                       </div>
-                      <Show when={credError()}>
-                        <p role="alert" class="text-error text-xs mt-2">{credError()}</p>
+                      <Show when={credentialImport.error()}>
+                        <p role="alert" class="text-error text-xs mt-2">{credentialImport.error()}</p>
                       </Show>
                       <div class="flex justify-end gap-2 mt-4">
-                        <button type="button" onClick={handleCancelCredImport} disabled={unsealInFlight()} class="btn btn-sm btn-ghost">
+                        <button type="button" onClick={handleCancelCredImport} disabled={credentialImport.unsealInFlight()} class="btn btn-sm btn-ghost">
                           Cancel
                         </button>
-                        <button type="button" onClick={handleContinueWithoutCredentials} disabled={unsealInFlight()} class="btn btn-sm btn-outline">
+                        <button type="button" onClick={handleContinueWithoutCredentials} disabled={credentialImport.unsealInFlight()} class="btn btn-sm btn-outline">
                           Continue without credentials
                         </button>
                         <button
                           type="submit"
-                          disabled={unsealInFlight()}
-                          aria-busy={unsealInFlight()}
+                          disabled={credentialImport.unsealInFlight()}
+                          aria-busy={credentialImport.unsealInFlight()}
                           class="btn btn-sm btn-primary"
                         >
-                          {unsealInFlight() ? "Checking..." : "Submit"}
+                          {credentialImport.unsealInFlight() ? "Checking..." : "Submit"}
                         </button>
                       </div>
                     </form>
@@ -2025,10 +1919,10 @@ export default function SettingsPage() {
                       </p>
                     </div>
                     <div class="flex justify-end gap-2">
-                      <button type="button" onClick={handleCancelCredImport} class="btn btn-sm btn-ghost">
+                      <button type="button" onClick={handleCancelCredImport} disabled={committing()} class="btn btn-sm btn-ghost">
                         Cancel
                       </button>
-                      <button type="button" onClick={handleContinueWithoutCredentials} class="btn btn-sm btn-outline">
+                      <button type="button" onClick={handleContinueWithoutCredentials} disabled={committing()} class="btn btn-sm btn-outline">
                         Continue without credentials
                       </button>
                       <button

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -260,10 +260,12 @@ export default function SettingsPage() {
   }
 
   // ── Export settings ────────────────────────────────────────────────────────
-  // includeCredentials opts into an encrypted-credentials section. On
-  // success the one-time code is shown in a modal and the file download is
-  // DEFERRED until the user acknowledges — the code is shown only once.
-  const [includeCredentials, setIncludeCredentials] = createSignal(false);
+  // The Export button opens a choice dialog (config only vs. with encrypted
+  // credentials). Choosing "with credentials" runs the seal flow and, on
+  // success, the one-time code is shown in a SEPARATE modal — the file
+  // download is DEFERRED until the user acknowledges that modal, since the
+  // code is shown only once.
+  const [showExportChoice, setShowExportChoice] = createSignal(false);
   const [exporting, setExporting] = createSignal(false);
   const [exportCode, setExportCode] = createSignal<string | null>(null);
   const [codeCopied, setCodeCopied] = createSignal(false);
@@ -279,31 +281,41 @@ export default function SettingsPage() {
     URL.revokeObjectURL(url);
   }
 
-  async function handleExportSettings() {
-    if (exporting()) return;
-    // Re-entry guard: while the one-time-code modal is open a fresh export would
-    // mint a NEW code + a new seal call while the old code is still displayed.
-    // The Kobalte Dialog traps + restores focus (so the Export button can't be
-    // re-fired behind the modal), and this guard closes the gap for any other
-    // trigger path.
+  function handleOpenExportChoice() {
+    // Re-entry guard: while the one-time-code modal is open, reopening the
+    // export-choice dialog would let a second export mint a NEW code while
+    // the old one is still displayed. The Kobalte Dialog traps + restores
+    // focus (so the Export button can't be re-fired behind the modal), and
+    // this guard closes the gap for any other trigger path.
     if (exportCode() !== null) return;
+    setShowExportChoice(true);
+  }
+
+  function handleExportConfigOnly() {
     const payload = buildExportPayload(config, viewState);
-    if (!includeCredentials()) {
-      triggerDownload(JSON.stringify(payload, null, 2));
-      return;
-    }
+    triggerDownload(JSON.stringify(payload, null, 2));
+    setShowExportChoice(false);
+  }
+
+  async function handleExportWithCredentials() {
+    if (exporting()) return; // re-entry guard: exactly one seal in flight
     setExporting(true);
     try {
+      const payload = buildExportPayload(config, viewState);
       // buildEncryptedCredentialsSection generates the code, encrypts the bundle
       // with it, THEN seals the ciphertext (encrypt-then-seal). No secret is
       // logged here.
       const { sealed, salt, oneTimeCode } = await buildEncryptedCredentialsSection();
       pendingExportJson = JSON.stringify({ ...payload, _credentials: { sealed, salt } }, null, 2);
       setCodeCopied(false);
+      // Close the choice dialog, then open the code modal — only one of the
+      // two export dialogs is ever visible at a time.
+      setShowExportChoice(false);
       setExportCode(oneTimeCode); // opens the modal; download deferred to ack
     } catch {
       // Turnstile rejection / SealError / oversized pre-check — leave the
-      // checkbox checked so the user can retry; do NOT download anything.
+      // export-choice dialog open so the user can retry; do NOT download
+      // anything.
       pushNotification(
         "settings-export",
         "Couldn't prepare encrypted credentials for export — please try again.",
@@ -1650,27 +1662,13 @@ export default function SettingsPage() {
             label="Export settings"
             description="Download your configuration as a JSON file"
           >
-            <div class="flex flex-col items-end gap-2">
-              <label class="flex items-center gap-2 text-xs text-base-content/70 cursor-pointer">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-xs"
-                  aria-label="Include encrypted credentials for migration"
-                  checked={includeCredentials()}
-                  onChange={(e) => setIncludeCredentials(e.currentTarget.checked)}
-                />
-                Include encrypted credentials for migration
-              </label>
-              <button
-                type="button"
-                onClick={() => void handleExportSettings()}
-                disabled={exporting()}
-                aria-busy={exporting()}
-                class="btn btn-sm btn-outline"
-              >
-                {exporting() ? "Preparing..." : "Export"}
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={handleOpenExportChoice}
+              class="btn btn-sm btn-outline"
+            >
+              Export
+            </button>
           </SettingRow>
 
           {/* Import settings */}
@@ -1785,6 +1783,56 @@ export default function SettingsPage() {
             saveWithFeedback({ dependencies: { ...config.dependencies, excludedOrgs: orgs, excludedRepos: repos } })
           }
         />
+
+        {/* Export-choice dialog: config only vs. with encrypted credentials.
+            On success the "with credentials" path closes this dialog and opens
+            the one-time-code modal below — only one of the two is ever open. */}
+        <Dialog
+          open={showExportChoice()}
+          onOpenChange={setShowExportChoice}
+          modal
+        >
+          <Dialog.Portal>
+            <Dialog.Overlay class="fixed inset-0 bg-black/50 z-50" />
+            <Dialog.Content class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-base-100 rounded-xl shadow-xl z-[51] p-6 flex flex-col gap-4">
+              <Dialog.Title class="text-lg font-semibold">Export settings</Dialog.Title>
+              <Dialog.Description class="text-sm text-base-content/70">
+                Choose what to include in the exported file.
+              </Dialog.Description>
+              <button
+                type="button"
+                onClick={handleExportConfigOnly}
+                class="btn btn-sm btn-outline w-full justify-start"
+              >
+                Export config only
+              </button>
+              <div class="flex flex-col gap-2">
+                <p class="text-xs text-warning">
+                  This is a one-time transfer, not a durable backup — the encrypted
+                  credentials can be imported once and expire in 30 days.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void handleExportWithCredentials()}
+                  disabled={exporting()}
+                  aria-busy={exporting()}
+                  class="btn btn-sm btn-primary w-full justify-start"
+                >
+                  {exporting() ? "Preparing..." : "Export with encrypted credentials"}
+                </button>
+              </div>
+              <div class="flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => setShowExportChoice(false)}
+                  class="btn btn-sm btn-ghost"
+                >
+                  Cancel
+                </button>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog>
 
         {/* One-time-code modal (encrypted export). Download is deferred until ack.
             Kobalte Dialog provides the focus trap + focus restoration that keeps

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -306,6 +306,12 @@ export default function SettingsPage() {
       // with it, THEN seals the ciphertext (encrypt-then-seal). No secret is
       // logged here.
       const { sealed, salt, oneTimeCode } = await buildEncryptedCredentialsSection();
+      // Defense-in-depth: the choice dialog's onOpenChange/buttons already block
+      // dismissal while exporting() is true, so this should be unreachable — but
+      // if the dialog was somehow closed out from under this await, discard the
+      // freshly-minted single-use code instead of popping it after the user
+      // backed out.
+      if (!showExportChoice()) return;
       pendingExportJson = JSON.stringify({ ...payload, _credentials: { sealed, salt } }, null, 2);
       setCodeCopied(false);
       // Close the choice dialog, then open the code modal — only one of the
@@ -1786,10 +1792,14 @@ export default function SettingsPage() {
 
         {/* Export-choice dialog: config only vs. with encrypted credentials.
             On success the "with credentials" path closes this dialog and opens
-            the one-time-code modal below — only one of the two is ever open. */}
+            the one-time-code modal below — only one of the two is ever open.
+            While a seal is in flight (exporting()), dismissal is blocked — both
+            via onOpenChange (Escape/overlay click) and by disabling the other
+            buttons — so a cancel-during-seal can't pop the one-time-code modal
+            after the user has already backed out. */}
         <Dialog
           open={showExportChoice()}
-          onOpenChange={setShowExportChoice}
+          onOpenChange={(isOpen) => { if (!isOpen && !exporting()) setShowExportChoice(false); }}
           modal
         >
           <Dialog.Portal>
@@ -1802,12 +1812,13 @@ export default function SettingsPage() {
               <button
                 type="button"
                 onClick={handleExportConfigOnly}
+                disabled={exporting()}
                 class="btn btn-sm btn-outline w-full justify-start"
               >
                 Export config only
               </button>
               <div class="flex flex-col gap-2">
-                <p class="text-xs text-warning">
+                <p id="export-credentials-warning" class="text-xs text-warning">
                   This is a one-time transfer, not a durable backup — the encrypted
                   credentials can be imported once and expire in 30 days.
                 </p>
@@ -1816,6 +1827,7 @@ export default function SettingsPage() {
                   onClick={() => void handleExportWithCredentials()}
                   disabled={exporting()}
                   aria-busy={exporting()}
+                  aria-describedby="export-credentials-warning"
                   class="btn btn-sm btn-primary w-full justify-start"
                 >
                   {exporting() ? "Preparing..." : "Export with encrypted credentials"}
@@ -1824,7 +1836,8 @@ export default function SettingsPage() {
               <div class="flex justify-end">
                 <button
                   type="button"
-                  onClick={() => setShowExportChoice(false)}
+                  onClick={() => { if (!exporting()) setShowExportChoice(false); }}
+                  disabled={exporting()}
                   class="btn btn-sm btn-ghost"
                 >
                   Cancel

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createMemo, Show, For, onCleanup, onMount } from "solid-js";
 import { Select } from "@kobalte/core/select";
+import { Dialog } from "@kobalte/core/dialog";
 import * as Sentry from "@sentry/solid";
 import { getRelayStatus } from "../../lib/mcp-relay";
 import { useNavigate } from "@solidjs/router";
@@ -148,6 +149,18 @@ export default function SettingsPage() {
   const [localRepos, setLocalRepos] = createSignal<RepoRef[]>(config.selectedRepos);
   const [localUpstream, setLocalUpstream] = createSignal<RepoRef[]>(config.upstreamRepos);
 
+  // These local editor copies are captured once at mount. An in-place import
+  // (handleConfirmImport / handleConfirmCredImport / handleContinueWithoutCredentials)
+  // replaces config wholesale via setConfig without a reload, so they must be
+  // resynced afterward — otherwise the next org/repo edit would save the stale,
+  // pre-import selection and silently discard the imported repos/orgs (CR-001).
+  // setConfig is synchronous, so config already reflects the import here.
+  function resyncLocalEditors() {
+    setLocalOrgs(config.selectedOrgs);
+    setLocalRepos(config.selectedRepos);
+    setLocalUpstream(config.upstreamRepos);
+  }
+
   const monitoredRepoNames = createMemo(() =>
     config.monitoredRepos.map(r => r.fullName).join(", ")
   );
@@ -271,6 +284,12 @@ export default function SettingsPage() {
 
   async function handleExportSettings() {
     if (exporting()) return;
+    // Re-entry guard: while the one-time-code modal is open a fresh export would
+    // mint a NEW code + a new seal call while the old code is still displayed.
+    // The Kobalte Dialog traps + restores focus (so the Export button can't be
+    // re-fired behind the modal), and this guard closes the gap for any other
+    // trigger path (QA-001).
+    if (exportCode() !== null) return;
     const payload = buildExportPayload(config);
     if (!includeCredentials()) {
       triggerDownload(JSON.stringify(payload, null, 2));
@@ -344,7 +363,16 @@ export default function SettingsPage() {
   const [resolvedCred, setResolvedCred] = createSignal<{ bundle: CredentialBundle; identity: GitHubUser } | null>(null);
   const [committing, setCommitting] = createSignal(false);
 
+  // Generation counter tying an in-flight unseal/resolve to the file that started
+  // it (mirrors auth.ts's _crossTabFetchGen). Bumped on every reset and on every
+  // new file selection; the submit handler captures it before each await and
+  // bails if it changed, so a Cancel-then-reselect during the multi-second
+  // unseal/resolve window can't strand one file's ciphertext/credential into a
+  // different file's shared signals.
+  let unsealGen = 0;
+
   function resetCredImport() {
+    unsealGen++;
     setCredImport(null);
     setCodeInput("");
     setShowCode(false);
@@ -398,6 +426,7 @@ export default function SettingsPage() {
     // Wholesale replace — parseImportFile returns a fully-parsed Config (every
     // top-level key present), so setConfig is safe (NOT updateConfig's partial merge).
     setConfig(imported);
+    resyncLocalEditors();
     setPendingImport(null);
     pushNotification("settings-import", "Settings imported", "info");
   }
@@ -412,6 +441,7 @@ export default function SettingsPage() {
     if (!ci) return;
     const code = codeInput();
     setCredError(null);
+    const gen = unsealGen; // capture before the first await
 
     let ciphertext = cachedCiphertext();
     if (ciphertext === null) {
@@ -421,13 +451,23 @@ export default function SettingsPage() {
       const res = await unsealCredentialBundle(ci.credentials.sealed).finally(() =>
         setUnsealInFlight(false)
       );
+      // A changed unsealGen means a Cancel-then-reselect started a different file
+      // while this await was pending; writing any signal now would strand this
+      // file's result into the newly-selected file's state, so stop here.
+      if (gen !== unsealGen) return;
       if (!res.ok) {
-        if (res.reason === "turnstile") {
-          // Client-side Turnstile hiccup BEFORE any request — the single-use
-          // nonce was NOT consumed, so this is retryable. Keep the code prompt
-          // available (do NOT fall through to the terminal "continue without
-          // credentials" screen); surface a retryable inline message (R-101).
-          setCredError("Verification failed — please try again.");
+        if (res.reason === "turnstile" || res.reason === "network" || res.reason === "rate-limited") {
+          // Pre-nonce-consumption failure — the single-use nonce was NOT
+          // consumed, so this is retryable. Keep the code prompt available (do
+          // NOT fall through to the terminal "continue without credentials"
+          // screen); surface a retryable inline message.
+          setCredError(
+            res.reason === "rate-limited"
+              ? "Too many attempts — wait a moment and try again."
+              : res.reason === "network"
+                ? "Network problem — please try again."
+                : "Verification failed — please try again."
+          );
           return;
         }
         setCredTerminalMsg(
@@ -443,6 +483,9 @@ export default function SettingsPage() {
 
     // Client-side, retryable against the cached ciphertext (no re-unseal).
     const resolved = await resolveImportedCredentials(ciphertext, ci.credentials.salt, code);
+    // The resolve await is another window where a Cancel-then-reselect can change
+    // unsealGen (unsealInFlight is false here); discard the result if so.
+    if (gen !== unsealGen) return;
     if (!resolved.ok) {
       setCredError(resolved.error);
       return;
@@ -457,6 +500,7 @@ export default function SettingsPage() {
     setCommitting(true);
     try {
       await commitImportedSettings(rc, ci.config);
+      resyncLocalEditors();
       resetCredImport();
       pushNotification("settings-import", "Settings and credentials imported", "info");
     } catch {
@@ -469,9 +513,12 @@ export default function SettingsPage() {
   function handleContinueWithoutCredentials() {
     const ci = credImport();
     if (!ci) return;
-    setConfig(ci.config);
+    const cfg = ci.config;
     resetCredImport();
-    pushNotification("settings-import", "Settings imported (credentials skipped)", "info");
+    // Route the plaintext-only path through the SAME two-click confirm the
+    // plaintext import uses (pendingImport), so both wholesale-replace paths
+    // confirm consistently. handleConfirmImport applies it + resyncs the editors.
+    setPendingImport(cfg);
   }
 
   function handleCancelCredImport() {
@@ -1840,55 +1887,62 @@ export default function SettingsPage() {
           }
         />
 
-        {/* One-time-code modal (encrypted export). Download is deferred until ack. */}
-        <Show when={exportCode()}>
-          {(code) => (
-            <div
-              class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-              role="dialog"
-              aria-modal="true"
-              aria-label="Save your one-time code"
-            >
-              <div class="card bg-base-100 shadow-xl max-w-md w-full p-6 flex flex-col gap-4">
-                <h3 class="text-lg font-semibold">Save your one-time code</h3>
-                <p class="text-sm text-base-content/70">
-                  Save this code separately from the export file — you'll need both to restore
-                  credentials, and it's shown only once.
-                </p>
-                <div class="flex items-center gap-2">
-                  <code class="flex-1 select-all rounded bg-base-200 px-3 py-2 font-mono text-sm break-all">
-                    {code()}
-                  </code>
-                  <button
-                    type="button"
-                    onClick={() => void handleCopyExportCode()}
-                    class="btn btn-sm btn-outline"
-                  >
-                    {codeCopied() ? "Copied" : "Copy"}
-                  </button>
-                </div>
-                <div class="flex justify-end gap-2">
-                  <button type="button" onClick={handleDismissExportCode} class="btn btn-sm btn-ghost">
-                    Cancel
-                  </button>
-                  <button type="button" onClick={handleAcknowledgeExportCode} class="btn btn-sm btn-primary">
-                    I've saved my code — download
-                  </button>
-                </div>
+        {/* One-time-code modal (encrypted export). Download is deferred until ack.
+            Kobalte Dialog provides the focus trap + focus restoration that keeps
+            the Export button from being re-fired behind the open modal. */}
+        <Dialog
+          open={exportCode() !== null}
+          onOpenChange={(isOpen) => { if (!isOpen) handleDismissExportCode(); }}
+          modal
+        >
+          <Dialog.Portal>
+            <Dialog.Overlay class="fixed inset-0 bg-black/50 z-50" />
+            <Dialog.Content class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-base-100 rounded-xl shadow-xl z-[51] p-6 flex flex-col gap-4">
+              <Dialog.Title class="text-lg font-semibold">Save your one-time code</Dialog.Title>
+              <Dialog.Description class="text-sm text-base-content/70">
+                Save this code separately from the export file — you'll need both to restore
+                credentials, and it's shown only once.
+              </Dialog.Description>
+              <Show when={exportCode()}>
+                {(code) => (
+                  <div class="flex items-center gap-2">
+                    <code class="flex-1 select-all rounded bg-base-200 px-3 py-2 font-mono text-sm break-all">
+                      {code()}
+                    </code>
+                    <button
+                      type="button"
+                      onClick={() => void handleCopyExportCode()}
+                      class="btn btn-sm btn-outline"
+                    >
+                      {codeCopied() ? "Copied" : "Copy"}
+                    </button>
+                  </div>
+                )}
+              </Show>
+              <div class="flex justify-end gap-2">
+                <button type="button" onClick={handleDismissExportCode} class="btn btn-sm btn-ghost">
+                  Cancel
+                </button>
+                <button type="button" onClick={handleAcknowledgeExportCode} class="btn btn-sm btn-primary">
+                  I've saved my code — download
+                </button>
               </div>
-            </div>
-          )}
-        </Show>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog>
 
-        {/* Encrypted-credentials import dialog: one-time-code entry → identity confirm. */}
-        <Show when={credImport()}>
-          <div
-            class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Import encrypted credentials"
-          >
-            <div class="card bg-base-100 shadow-xl max-w-md w-full p-6 flex flex-col gap-4">
+        {/* Encrypted-credentials import dialog: one-time-code entry → identity confirm.
+            Kobalte Dialog adds focus trap / Escape / scroll-lock / focus restore.
+            While a network unseal is in flight the close controls are disabled so
+            the single-use nonce can't be abandoned mid-flight. */}
+        <Dialog
+          open={credImport() !== null}
+          onOpenChange={(isOpen) => { if (!isOpen && !unsealInFlight()) handleCancelCredImport(); }}
+          modal
+        >
+          <Dialog.Portal>
+            <Dialog.Overlay class="fixed inset-0 bg-black/50 z-50" />
+            <Dialog.Content class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-base-100 rounded-xl shadow-xl z-[51] p-6 flex flex-col gap-4">
               <Show
                 when={resolvedCred()}
                 fallback={
@@ -1896,8 +1950,8 @@ export default function SettingsPage() {
                     when={!credTerminalMsg()}
                     fallback={
                       <>
-                        <h3 class="text-lg font-semibold">Credentials unavailable</h3>
-                        <p class="text-sm text-error">{credTerminalMsg()}</p>
+                        <Dialog.Title class="text-lg font-semibold">Credentials unavailable</Dialog.Title>
+                        <p role="alert" class="text-sm text-error">{credTerminalMsg()}</p>
                         <div class="flex justify-end gap-2">
                           <button type="button" onClick={handleCancelCredImport} class="btn btn-sm btn-ghost">
                             Cancel
@@ -1909,7 +1963,7 @@ export default function SettingsPage() {
                       </>
                     }
                   >
-                    <h3 class="text-lg font-semibold">Restore encrypted credentials</h3>
+                    <Dialog.Title class="text-lg font-semibold">Restore encrypted credentials</Dialog.Title>
                     <p class="text-sm text-base-content/70">
                       Enter the one-time code shown when this file was exported.
                     </p>
@@ -1937,10 +1991,10 @@ export default function SettingsPage() {
                         <p role="alert" class="text-error text-xs mt-2">{credError()}</p>
                       </Show>
                       <div class="flex justify-end gap-2 mt-4">
-                        <button type="button" onClick={handleCancelCredImport} class="btn btn-sm btn-ghost">
+                        <button type="button" onClick={handleCancelCredImport} disabled={unsealInFlight()} class="btn btn-sm btn-ghost">
                           Cancel
                         </button>
-                        <button type="button" onClick={handleContinueWithoutCredentials} class="btn btn-sm btn-outline">
+                        <button type="button" onClick={handleContinueWithoutCredentials} disabled={unsealInFlight()} class="btn btn-sm btn-outline">
                           Continue without credentials
                         </button>
                         <button
@@ -1958,7 +2012,7 @@ export default function SettingsPage() {
               >
                 {(rc) => (
                   <>
-                    <h3 class="text-lg font-semibold">Confirm identity</h3>
+                    <Dialog.Title class="text-lg font-semibold">Confirm identity</Dialog.Title>
                     <div class="flex items-center gap-3">
                       <img
                         src={rc().identity.avatar_url}
@@ -1990,9 +2044,9 @@ export default function SettingsPage() {
                   </>
                 )}
               </Show>
-            </div>
-          </div>
-        </Show>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog>
 
         <footer class="mt-8 border-t border-base-300 pt-4 pb-8 text-xs text-base-content/50 text-center">
           <div class="flex items-center justify-center gap-3">

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -12,7 +12,7 @@ import {
   commitImportedSettings,
 } from "../../lib/settings-transfer";
 import { createCredentialImport } from "../../lib/use-credential-import";
-import { viewState, updateViewState, setTabFilter } from "../../stores/view";
+import { viewState, updateViewState, setTabFilter, applyImportedViewState } from "../../stores/view";
 import { clearAuth, jiraAuth, setJiraAuth, clearJiraConfigFull, isJiraAuthenticated, token, setAuthFromPat } from "../../stores/auth";
 import type { GitHubUser } from "../../stores/auth";
 import { isValidPatFormat } from "../../lib/pat";
@@ -343,9 +343,10 @@ export default function SettingsPage() {
   }
 
   // ── Import settings (plaintext) ────────────────────────────────────────────
-  // pendingImport holds the parsed-and-validated Config awaiting confirmation;
+  // pendingImport holds the parsed-and-validated Config (+ the file's raw,
+  // as-yet-unvalidated _viewPreferences section, if any) awaiting confirmation;
   // non-null doubles as the two-click confirm state (mirrors confirmReset).
-  const [pendingImport, setPendingImport] = createSignal<Config | null>(null);
+  const [pendingImport, setPendingImport] = createSignal<{ config: Config; viewPreferences: unknown } | null>(null);
   let importInputRef: HTMLInputElement | undefined;
 
   // ── Import settings (encrypted credentials) ───────────────────────────────
@@ -358,7 +359,7 @@ export default function SettingsPage() {
       "This export's credentials have expired — re-export from a machine where you're still signed in, or import the settings without credentials.",
     onReadError: (message) => pushNotification("settings-import", message, "warning"),
     onParseError: (message) => pushNotification("settings-import", message, "warning"),
-    onNoCredentials: (importedConfig) => setPendingImport(importedConfig),
+    onNoCredentials: (importedConfig, viewPreferences) => setPendingImport({ config: importedConfig, viewPreferences }),
     onResolved: (bundle, identity) => credentialImport.setResolvedCred({ bundle, identity }),
   });
 
@@ -372,11 +373,15 @@ export default function SettingsPage() {
   }
 
   function handleConfirmImport() {
-    const imported = pendingImport();
-    if (!imported) return;
+    const pending = pendingImport();
+    if (!pending) return;
     // Wholesale replace — parseImportFile returns a fully-parsed Config (every
     // top-level key present), so setConfig is safe (NOT updateConfig's partial merge).
-    setConfig(imported);
+    setConfig(pending.config);
+    // Identity is already established on this page (Settings is post-auth) —
+    // applyImportedViewState is total/no-throw, so this is safe even when the
+    // file carries no _viewPreferences section at all.
+    applyImportedViewState(pending.viewPreferences);
     resyncLocalEditors();
     setPendingImport(null);
     pushNotification("settings-import", "Settings imported", "info");
@@ -393,7 +398,7 @@ export default function SettingsPage() {
     if (!cred || !rc) return;
     setCommitting(true);
     try {
-      await commitImportedSettings(rc, cred.config);
+      await commitImportedSettings(rc, cred.config, cred.viewPreferences);
       resyncLocalEditors();
       credentialImport.reset();
       pushNotification("settings-import", "Settings and credentials imported", "info");
@@ -407,12 +412,12 @@ export default function SettingsPage() {
   function handleContinueWithoutCredentials() {
     const cred = credentialImport.credImport();
     if (!cred) return;
-    const cfg = cred.config;
+    const { config: cfg, viewPreferences } = cred;
     credentialImport.reset();
     // Route the plaintext-only path through the SAME two-click confirm the
     // plaintext import uses (pendingImport), so both wholesale-replace paths
     // confirm consistently. handleConfirmImport applies it + resyncs the editors.
-    setPendingImport(cfg);
+    setPendingImport({ config: cfg, viewPreferences });
   }
 
   function handleCancelCredImport() {

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -5,7 +5,15 @@ import { getRelayStatus } from "../../lib/mcp-relay";
 import { useNavigate } from "@solidjs/router";
 import { config, setConfig, updateConfig, updateJiraConfig, updateJiraCustomFields, updateJiraCustomScopes, setMonitoredRepo, isActionsBasedTab } from "../../stores/config";
 import type { Config, JiraCustomField } from "../../../shared/schemas";
-import { buildExportPayload, parseImportFile } from "../../lib/settings-transfer";
+import {
+  buildExportPayload,
+  parseImportFile,
+  buildEncryptedCredentialsSection,
+  resolveImportedCredentials,
+  commitImportedSettings,
+  CredentialsSectionSchema,
+} from "../../lib/settings-transfer";
+import type { CredentialBundle, CredentialsSection } from "../../lib/settings-transfer";
 import { viewState, updateViewState, setTabFilter } from "../../stores/view";
 import { clearAuth, jiraAuth, setJiraAuth, clearJiraConfigFull, isJiraAuthenticated, token, setAuthFromPat } from "../../stores/auth";
 import type { GitHubUser } from "../../stores/auth";
@@ -13,7 +21,7 @@ import { isValidPatFormat } from "../../lib/pat";
 import { clearCache } from "../../stores/cache";
 import { pushNotification } from "../../lib/errors";
 import { buildOrgAccessUrl, buildJiraAuthorizeUrl } from "../../lib/oauth";
-import { sealApiToken } from "../../lib/proxy";
+import { sealApiToken, unsealCredentialBundle } from "../../lib/proxy";
 import { isSafeGitHubUrl, openGitHubUrl } from "../../lib/url";
 import { relativeTime, formatScopeSummary } from "../../lib/format";
 import { fetchOrgs } from "../../services/api";
@@ -241,11 +249,18 @@ export default function SettingsPage() {
     }
   }
 
-  function handleExportSettings() {
-    // Schema-driven payload (spread of Config + denylist) — see
-    // src/app/lib/settings-transfer.ts. Blob/anchor-download mechanics unchanged.
-    const data = JSON.stringify(buildExportPayload(config), null, 2);
-    const blob = new Blob([data], { type: "application/json" });
+  // ── Export settings ────────────────────────────────────────────────────────
+  // includeCredentials opts into an encrypted-credentials section (Task 5). On
+  // success the one-time code is shown in a modal and the file download is
+  // DEFERRED until the user acknowledges — the code is shown only once.
+  const [includeCredentials, setIncludeCredentials] = createSignal(false);
+  const [exporting, setExporting] = createSignal(false);
+  const [exportCode, setExportCode] = createSignal<string | null>(null);
+  const [codeCopied, setCodeCopied] = createSignal(false);
+  let pendingExportJson: string | null = null;
+
+  function triggerDownload(jsonText: string) {
+    const blob = new Blob([jsonText], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -254,11 +269,91 @@ export default function SettingsPage() {
     URL.revokeObjectURL(url);
   }
 
+  async function handleExportSettings() {
+    if (exporting()) return;
+    const payload = buildExportPayload(config);
+    if (!includeCredentials()) {
+      triggerDownload(JSON.stringify(payload, null, 2));
+      return;
+    }
+    setExporting(true);
+    try {
+      // buildEncryptedCredentialsSection generates the code, encrypts the bundle
+      // with it, THEN seals the ciphertext (encrypt-then-seal). No secret is
+      // logged here (SD-002).
+      const { sealed, salt, oneTimeCode } = await buildEncryptedCredentialsSection();
+      pendingExportJson = JSON.stringify({ ...payload, _credentials: { sealed, salt } }, null, 2);
+      setCodeCopied(false);
+      setExportCode(oneTimeCode); // opens the modal; download deferred to ack
+    } catch {
+      // Turnstile rejection / SealError / oversized pre-check — leave the
+      // checkbox checked so the user can retry; do NOT download anything.
+      pushNotification(
+        "settings-export",
+        "Couldn't prepare encrypted credentials for export — please try again.",
+        "warning"
+      );
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  async function handleCopyExportCode() {
+    const code = exportCode();
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCodeCopied(true);
+    } catch {
+      // clipboard unavailable — user can still select/copy the shown code
+    }
+  }
+
+  function handleAcknowledgeExportCode() {
+    if (pendingExportJson) {
+      triggerDownload(pendingExportJson);
+      pendingExportJson = null;
+    }
+    setExportCode(null);
+    setCodeCopied(false);
+  }
+
+  function handleDismissExportCode() {
+    // Dismiss without downloading. The sealed blob held in memory is inert
+    // ciphertext without the code; nothing needs cleanup.
+    pendingExportJson = null;
+    setExportCode(null);
+    setCodeCopied(false);
+  }
+
   // ── Import settings (plaintext) ────────────────────────────────────────────
   // pendingImport holds the parsed-and-validated Config awaiting confirmation;
   // non-null doubles as the two-click confirm state (mirrors confirmReset).
   const [pendingImport, setPendingImport] = createSignal<Config | null>(null);
   let importInputRef: HTMLInputElement | undefined;
+
+  // ── Import settings (encrypted credentials, Task 6) ──────────────────────────
+  // credImport is set when the selected file has a valid _credentials section.
+  const [credImport, setCredImport] = createSignal<{ config: Config; credentials: CredentialsSection } | null>(null);
+  const [codeInput, setCodeInput] = createSignal("");
+  const [showCode, setShowCode] = createSignal(false);
+  const [unsealInFlight, setUnsealInFlight] = createSignal(false);
+  const [cachedCiphertext, setCachedCiphertext] = createSignal<string | null>(null);
+  const [credError, setCredError] = createSignal<string | null>(null);
+  const [credTerminalMsg, setCredTerminalMsg] = createSignal<string | null>(null);
+  const [resolvedCred, setResolvedCred] = createSignal<{ bundle: CredentialBundle; identity: GitHubUser } | null>(null);
+  const [committing, setCommitting] = createSignal(false);
+
+  function resetCredImport() {
+    setCredImport(null);
+    setCodeInput("");
+    setShowCode(false);
+    setUnsealInFlight(false);
+    setCachedCiphertext(null);
+    setCredError(null);
+    setCredTerminalMsg(null);
+    setResolvedCred(null);
+  }
 
   async function handleImportFileSelected(e: Event) {
     const input = e.currentTarget as HTMLInputElement;
@@ -280,6 +375,20 @@ export default function SettingsPage() {
       pushNotification("settings-import", `Import failed: ${result.errors[0] ?? "invalid settings file"}`, "warning");
       return;
     }
+    // Detect an encrypted-credentials section via schema validation (NOT a bare
+    // "in" check — a hand-crafted `_credentials: null` would pass that and then
+    // throw on dereference). A malformed/null/non-object one falls through to the
+    // plaintext-only path.
+    const rawCreds =
+      result.rawJson && typeof result.rawJson === "object"
+        ? (result.rawJson as Record<string, unknown>)._credentials
+        : undefined;
+    const credSection = CredentialsSectionSchema.safeParse(rawCreds);
+    if (credSection.success) {
+      resetCredImport();
+      setCredImport({ config: result.config, credentials: credSection.data });
+      return;
+    }
     setPendingImport(result.config);
   }
 
@@ -295,6 +404,70 @@ export default function SettingsPage() {
 
   function handleCancelImport() {
     setPendingImport(null);
+  }
+
+  async function handleCredCodeSubmit() {
+    if (unsealInFlight()) return; // in-flight guard: exactly one network unseal
+    const ci = credImport();
+    if (!ci) return;
+    const code = codeInput();
+    setCredError(null);
+
+    let ciphertext = cachedCiphertext();
+    if (ciphertext === null) {
+      // FIRST submission — single-use network unseal (consumes the bundle nonce
+      // server-side). Never retried; wrong-code retries run against the cache.
+      setUnsealInFlight(true);
+      const res = await unsealCredentialBundle(ci.credentials.sealed).finally(() =>
+        setUnsealInFlight(false)
+      );
+      if (!res.ok) {
+        setCredTerminalMsg(
+          res.reason === "expired"
+            ? "This export's credentials have expired — re-export from a machine where you're still signed in, or import the settings without credentials."
+            : "Couldn't decrypt credentials — check the code and file match."
+        );
+        return;
+      }
+      ciphertext = res.ciphertext;
+      setCachedCiphertext(ciphertext);
+    }
+
+    // Client-side, retryable against the cached ciphertext (no re-unseal).
+    const resolved = await resolveImportedCredentials(ciphertext, ci.credentials.salt, code);
+    if (!resolved.ok) {
+      setCredError(resolved.error);
+      return;
+    }
+    setResolvedCred({ bundle: resolved.bundle, identity: resolved.identity });
+  }
+
+  async function handleConfirmCredImport() {
+    const ci = credImport();
+    const rc = resolvedCred();
+    if (!ci || !rc) return;
+    setCommitting(true);
+    try {
+      await commitImportedSettings(rc, ci.config);
+      resetCredImport();
+      pushNotification("settings-import", "Settings and credentials imported", "info");
+    } catch {
+      pushNotification("settings-import", "Something went wrong finishing the import — please try again.", "warning");
+    } finally {
+      setCommitting(false);
+    }
+  }
+
+  function handleContinueWithoutCredentials() {
+    const ci = credImport();
+    if (!ci) return;
+    setConfig(ci.config);
+    resetCredImport();
+    pushNotification("settings-import", "Settings imported (credentials skipped)", "info");
+  }
+
+  function handleCancelCredImport() {
+    resetCredImport();
   }
 
   function handleResetAll() {
@@ -1523,13 +1696,27 @@ export default function SettingsPage() {
             label="Export settings"
             description="Download your configuration as a JSON file"
           >
-            <button
-              type="button"
-              onClick={handleExportSettings}
-              class="btn btn-sm btn-outline"
-            >
-              Export
-            </button>
+            <div class="flex flex-col items-end gap-2">
+              <label class="flex items-center gap-2 text-xs text-base-content/70 cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-xs"
+                  aria-label="Include encrypted credentials for migration"
+                  checked={includeCredentials()}
+                  onChange={(e) => setIncludeCredentials(e.currentTarget.checked)}
+                />
+                Include encrypted credentials for migration
+              </label>
+              <button
+                type="button"
+                onClick={() => void handleExportSettings()}
+                disabled={exporting()}
+                aria-busy={exporting()}
+                class="btn btn-sm btn-outline"
+              >
+                {exporting() ? "Preparing..." : "Export"}
+              </button>
+            </div>
           </SettingRow>
 
           {/* Import settings */}
@@ -1538,42 +1725,44 @@ export default function SettingsPage() {
             description="Replace your configuration from a previously exported JSON file"
           >
             <Show
-              when={!pendingImport()}
+              when={pendingImport()}
               fallback={
-                <div class="flex items-center gap-2">
-                  <span class="text-xs text-base-content/60">This will replace your current settings — continue?</span>
+                <Show when={!credImport()}>
+                  <input
+                    ref={importInputRef}
+                    type="file"
+                    accept="application/json,.json"
+                    class="hidden"
+                    aria-label="Import settings file"
+                    onChange={(e) => void handleImportFileSelected(e)}
+                  />
                   <button
                     type="button"
-                    onClick={handleConfirmImport}
-                    class="btn btn-warning btn-xs"
+                    onClick={() => importInputRef?.click()}
+                    class="btn btn-sm btn-outline"
                   >
-                    Yes, import
+                    Import
                   </button>
-                  <button
-                    type="button"
-                    onClick={handleCancelImport}
-                    class="btn btn-ghost btn-xs"
-                  >
-                    Cancel
-                  </button>
-                </div>
+                </Show>
               }
             >
-              <input
-                ref={importInputRef}
-                type="file"
-                accept="application/json,.json"
-                class="hidden"
-                aria-label="Import settings file"
-                onChange={(e) => void handleImportFileSelected(e)}
-              />
-              <button
-                type="button"
-                onClick={() => importInputRef?.click()}
-                class="btn btn-sm btn-outline"
-              >
-                Import
-              </button>
+              <div class="flex items-center gap-2">
+                <span class="text-xs text-base-content/60">This will replace your current settings — continue?</span>
+                <button
+                  type="button"
+                  onClick={handleConfirmImport}
+                  class="btn btn-warning btn-xs"
+                >
+                  Yes, import
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancelImport}
+                  class="btn btn-ghost btn-xs"
+                >
+                  Cancel
+                </button>
+              </div>
             </Show>
           </SettingRow>
 
@@ -1642,6 +1831,160 @@ export default function SettingsPage() {
             saveWithFeedback({ dependencies: { ...config.dependencies, excludedOrgs: orgs, excludedRepos: repos } })
           }
         />
+
+        {/* One-time-code modal (encrypted export). Download is deferred until ack. */}
+        <Show when={exportCode()}>
+          {(code) => (
+            <div
+              class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Save your one-time code"
+            >
+              <div class="card bg-base-100 shadow-xl max-w-md w-full p-6 flex flex-col gap-4">
+                <h3 class="text-lg font-semibold">Save your one-time code</h3>
+                <p class="text-sm text-base-content/70">
+                  Save this code separately from the export file — you'll need both to restore
+                  credentials, and it's shown only once.
+                </p>
+                <div class="flex items-center gap-2">
+                  <code class="flex-1 select-all rounded bg-base-200 px-3 py-2 font-mono text-sm break-all">
+                    {code()}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() => void handleCopyExportCode()}
+                    class="btn btn-sm btn-outline"
+                  >
+                    {codeCopied() ? "Copied" : "Copy"}
+                  </button>
+                </div>
+                <div class="flex justify-end gap-2">
+                  <button type="button" onClick={handleDismissExportCode} class="btn btn-sm btn-ghost">
+                    Cancel
+                  </button>
+                  <button type="button" onClick={handleAcknowledgeExportCode} class="btn btn-sm btn-primary">
+                    I've saved my code — download
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </Show>
+
+        {/* Encrypted-credentials import dialog: one-time-code entry → identity confirm. */}
+        <Show when={credImport()}>
+          <div
+            class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Import encrypted credentials"
+          >
+            <div class="card bg-base-100 shadow-xl max-w-md w-full p-6 flex flex-col gap-4">
+              <Show
+                when={resolvedCred()}
+                fallback={
+                  <Show
+                    when={!credTerminalMsg()}
+                    fallback={
+                      <>
+                        <h3 class="text-lg font-semibold">Credentials unavailable</h3>
+                        <p class="text-sm text-error">{credTerminalMsg()}</p>
+                        <div class="flex justify-end gap-2">
+                          <button type="button" onClick={handleCancelCredImport} class="btn btn-sm btn-ghost">
+                            Cancel
+                          </button>
+                          <button type="button" onClick={handleContinueWithoutCredentials} class="btn btn-sm btn-primary">
+                            Continue without credentials
+                          </button>
+                        </div>
+                      </>
+                    }
+                  >
+                    <h3 class="text-lg font-semibold">Restore encrypted credentials</h3>
+                    <p class="text-sm text-base-content/70">
+                      Enter the one-time code shown when this file was exported.
+                    </p>
+                    <form onSubmit={(e) => { e.preventDefault(); void handleCredCodeSubmit(); }}>
+                      <div class="flex items-center gap-2">
+                        <input
+                          type={showCode() ? "text" : "password"}
+                          class="input input-sm w-full font-mono"
+                          aria-label="One-time code"
+                          autocomplete="off"
+                          placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                          value={codeInput()}
+                          onInput={(e) => setCodeInput(e.currentTarget.value)}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowCode((v) => !v)}
+                          class="btn btn-sm btn-ghost"
+                          aria-pressed={showCode()}
+                        >
+                          {showCode() ? "Hide" : "Show"}
+                        </button>
+                      </div>
+                      <Show when={credError()}>
+                        <p role="alert" class="text-error text-xs mt-2">{credError()}</p>
+                      </Show>
+                      <div class="flex justify-end gap-2 mt-4">
+                        <button type="button" onClick={handleCancelCredImport} class="btn btn-sm btn-ghost">
+                          Cancel
+                        </button>
+                        <button type="button" onClick={handleContinueWithoutCredentials} class="btn btn-sm btn-outline">
+                          Continue without credentials
+                        </button>
+                        <button
+                          type="submit"
+                          disabled={unsealInFlight()}
+                          aria-busy={unsealInFlight()}
+                          class="btn btn-sm btn-primary"
+                        >
+                          {unsealInFlight() ? "Checking..." : "Submit"}
+                        </button>
+                      </div>
+                    </form>
+                  </Show>
+                }
+              >
+                {(rc) => (
+                  <>
+                    <h3 class="text-lg font-semibold">Confirm identity</h3>
+                    <div class="flex items-center gap-3">
+                      <img
+                        src={rc().identity.avatar_url}
+                        alt=""
+                        class="h-10 w-10 rounded-full"
+                      />
+                      <p class="text-sm">
+                        This will sign you in as <strong>@{rc().identity.login}</strong> and replace
+                        your current settings — continue?
+                      </p>
+                    </div>
+                    <div class="flex justify-end gap-2">
+                      <button type="button" onClick={handleCancelCredImport} class="btn btn-sm btn-ghost">
+                        Cancel
+                      </button>
+                      <button type="button" onClick={handleContinueWithoutCredentials} class="btn btn-sm btn-outline">
+                        Continue without credentials
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleConfirmCredImport()}
+                        disabled={committing()}
+                        aria-busy={committing()}
+                        class="btn btn-sm btn-primary"
+                      >
+                        {committing() ? "Importing..." : "Continue"}
+                      </button>
+                    </div>
+                  </>
+                )}
+              </Show>
+            </div>
+          </div>
+        </Show>
 
         <footer class="mt-8 border-t border-base-300 pt-4 pb-8 text-xs text-base-content/50 text-center">
           <div class="flex items-center justify-center gap-3">

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -422,6 +422,14 @@ export default function SettingsPage() {
         setUnsealInFlight(false)
       );
       if (!res.ok) {
+        if (res.reason === "turnstile") {
+          // Client-side Turnstile hiccup BEFORE any request — the single-use
+          // nonce was NOT consumed, so this is retryable. Keep the code prompt
+          // available (do NOT fall through to the terminal "continue without
+          // credentials" screen); surface a retryable inline message (R-101).
+          setCredError("Verification failed — please try again.");
+          return;
+        }
         setCredTerminalMsg(
           res.reason === "expired"
             ? "This export's credentials have expired — re-export from a machine where you're still signed in, or import the settings without credentials."

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -287,7 +287,7 @@ export default function SettingsPage() {
     // re-fired behind the modal), and this guard closes the gap for any other
     // trigger path.
     if (exportCode() !== null) return;
-    const payload = buildExportPayload(config);
+    const payload = buildExportPayload(config, viewState);
     if (!includeCredentials()) {
       triggerDownload(JSON.stringify(payload, null, 2));
       return;

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1868,7 +1868,7 @@ export default function SettingsPage() {
                           class="input input-sm w-full font-mono"
                           aria-label="One-time code"
                           autocomplete="off"
-                          placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                          placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XX"
                           value={credentialImport.codeInput()}
                           onInput={(e) => credentialImport.setCodeInput(e.currentTarget.value)}
                         />

--- a/src/app/lib/proxy.ts
+++ b/src/app/lib/proxy.ts
@@ -220,17 +220,27 @@ export async function sealCredentialBundle(ciphertext: string): Promise<string> 
  *
  * MUST use `proxyFetch()` (sets `X-Requested-With`); a raw fetch would be
  * rejected with `403 missing_csrf_header`. Only `expired` is distinguished from
- * the uniform `invalid` failure (per the endpoint's contract).
+ * the uniform `invalid` failure among SERVER responses (per the endpoint's
+ * contract). A `turnstile` reason is distinct from both: it signals a CLIENT-side
+ * Turnstile-acquisition failure that happened BEFORE any request reached the
+ * server, so the bundle's single-use nonce was NOT consumed and the whole unseal
+ * is safely retryable (R-101) — callers must treat it as non-terminal.
  */
 export async function unsealCredentialBundle(
   sealed: string
-): Promise<{ ok: true; ciphertext: string } | { ok: false; reason: "expired" | "invalid" }> {
+): Promise<
+  | { ok: true; ciphertext: string }
+  | { ok: false; reason: "expired" | "invalid" | "turnstile" }
+> {
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
   let turnstileToken: string;
   try {
     turnstileToken = await acquireTurnstileToken(siteKey ?? "", "unseal");
   } catch {
-    return { ok: false, reason: "invalid" };
+    // Acquisition threw (widget hiccup/timeout/missing key) BEFORE any network
+    // request — the server nonce is untouched and the bundle is still valid.
+    // Return a DISTINCT retryable result, NOT the terminal `invalid` (R-101).
+    return { ok: false, reason: "turnstile" };
   }
 
   let res: Response;

--- a/src/app/lib/proxy.ts
+++ b/src/app/lib/proxy.ts
@@ -173,8 +173,9 @@ export const CREDENTIAL_BUNDLE_MAX_CIPHERTEXT = 4096;
 /**
  * Seals a client-side envelope ciphertext (already encrypted with the one-time
  * code — encrypt-THEN-seal) under the `credential-export-bundle` purpose.
- * Mirrors `sealApiToken()` but with a distinct purpose and a client-side size
- * pre-check. Uses `proxyFetch()` so the `X-Requested-With` CSRF header is set.
+ * Adds a client-side size pre-check, then delegates to `sealApiToken()` — same
+ * `/api/proxy/seal` endpoint, `seal` Turnstile action, `{ token, purpose }` body,
+ * `X-Requested-With` CSRF header (via `proxyFetch`), and `SealError` handling.
  */
 export async function sealCredentialBundle(ciphertext: string): Promise<string> {
   if (ciphertext.length > CREDENTIAL_BUNDLE_MAX_CIPHERTEXT) {
@@ -182,30 +183,7 @@ export async function sealCredentialBundle(ciphertext: string): Promise<string> 
       "Credentials are too large to export securely. Please report this — it should not happen for a normal account."
     );
   }
-  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
-  const turnstileToken = await acquireTurnstileToken(siteKey ?? "", "seal");
-
-  const res = await proxyFetch("/api/proxy/seal", {
-    method: "POST",
-    headers: {
-      "cf-turnstile-response": turnstileToken,
-    },
-    body: JSON.stringify({ token: ciphertext, purpose: "credential-export-bundle" }),
-  });
-
-  if (!res.ok) {
-    let code = "unknown_error";
-    try {
-      const body = (await res.json()) as { error?: string };
-      code = body.error ?? code;
-    } catch {
-      // ignore parse errors — keep default code
-    }
-    throw new SealError(res.status, code);
-  }
-
-  const data = (await res.json()) as { sealed: string };
-  return data.sealed;
+  return sealApiToken(ciphertext, "credential-export-bundle");
 }
 
 /**
@@ -220,17 +198,28 @@ export async function sealCredentialBundle(ciphertext: string): Promise<string> 
  *
  * MUST use `proxyFetch()` (sets `X-Requested-With`); a raw fetch would be
  * rejected with `403 missing_csrf_header`. Only `expired` is distinguished from
- * the uniform `invalid` failure among SERVER responses (per the endpoint's
- * contract). A `turnstile` reason is distinct from both: it signals a CLIENT-side
- * Turnstile-acquisition failure that happened BEFORE any request reached the
- * server, so the bundle's single-use nonce was NOT consumed and the whole unseal
- * is safely retryable (R-101) — callers must treat it as non-terminal.
+ * the uniform `invalid` failure among SERVER responses that reached the nonce
+ * step (per the endpoint's contract).
+ *
+ * RETRYABLE (non-consuming) reasons — these all happen BEFORE the server reaches
+ * the single-use nonce, so the bundle is STILL valid and callers MUST treat them
+ * as non-terminal (keep the code/unseal step available), NOT as a burned bundle:
+ *   - `turnstile`: a CLIENT-side Turnstile-acquisition failure BEFORE any request
+ *     reached the server (R-101).
+ *   - `network`: a thrown `proxyFetch` (no server response at all), or a server
+ *     403 (turnstile_failed) / 503 (internal_error / KV) — all pre-nonce
+ *     (SEC-001/API-001).
+ *   - `rate-limited`: a server 429 from the pre-gate rate limiter, which fires
+ *     before Turnstile and long before nonce access (API-001).
+ * Only `expired` and `invalid` are TERMINAL (the single-use bundle is spent /
+ * unusable): `invalid` covers a genuine bad blob, wrong key, or already-consumed
+ * nonce (401 with no `expired` marker).
  */
 export async function unsealCredentialBundle(
   sealed: string
 ): Promise<
   | { ok: true; ciphertext: string }
-  | { ok: false; reason: "expired" | "invalid" | "turnstile" }
+  | { ok: false; reason: "expired" | "invalid" | "turnstile" | "network" | "rate-limited" }
 > {
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
   let turnstileToken: string;
@@ -253,7 +242,10 @@ export async function unsealCredentialBundle(
       body: JSON.stringify({ sealed, purpose: "credential-export-bundle" }),
     });
   } catch {
-    return { ok: false, reason: "invalid" };
+    // A network throw means NO server response arrived — the single-use nonce was
+    // never reached, so the bundle is still valid. Retryable, NOT terminal
+    // `invalid` (SEC-001).
+    return { ok: false, reason: "network" };
   }
 
   if (res.ok) {
@@ -268,6 +260,15 @@ export async function unsealCredentialBundle(
     return { ok: false, reason: "invalid" };
   }
 
+  // Non-2xx. Statuses that fire BEFORE the server reaches nonce consumption leave
+  // the bundle valid → retryable, NOT the terminal `invalid` path
+  // (SEC-001/API-001): 429 rate_limited (pre-gate), 403 turnstile_failed, 503
+  // internal_error / KV outage.
+  if (res.status === 429) return { ok: false, reason: "rate-limited" };
+  if (res.status === 403 || res.status === 503) return { ok: false, reason: "network" };
+
+  // 401 (and anything else): distinguish the server's `expired` marker from the
+  // uniform terminal `invalid` (bad blob / wrong key / already-consumed nonce).
   try {
     const body = (await res.json()) as { error?: string };
     if (body.error === "expired") return { ok: false, reason: "expired" };

--- a/src/app/lib/proxy.ts
+++ b/src/app/lib/proxy.ts
@@ -24,7 +24,7 @@ function loadTurnstileScript(): Promise<void> {
   return turnstilePromise;
 }
 
-export async function acquireTurnstileToken(siteKey: string): Promise<string> {
+export async function acquireTurnstileToken(siteKey: string, action: string): Promise<string> {
   if (!siteKey) {
     throw new Error("VITE_TURNSTILE_SITE_KEY not configured");
   }
@@ -62,7 +62,7 @@ export async function acquireTurnstileToken(siteKey: string): Promise<string> {
     try {
       const widgetId = window.turnstile.render(container, {
         sitekey: siteKey,
-        action: "seal",
+        action,
         size: "compact",
         execution: "execute",
         retry: "never",
@@ -140,7 +140,7 @@ export class SealError extends Error {
 
 export async function sealApiToken(token: string, purpose: string): Promise<string> {
   const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
-  const turnstileToken = await acquireTurnstileToken(siteKey ?? "");
+  const turnstileToken = await acquireTurnstileToken(siteKey ?? "", "seal");
 
   const res = await proxyFetch("/api/proxy/seal", {
     method: "POST",
@@ -163,4 +163,106 @@ export async function sealApiToken(token: string, purpose: string): Promise<stri
 
   const data = (await res.json()) as { sealed: string };
   return data.sealed;
+}
+
+// The purpose-specific inner-ciphertext cap the Worker enforces for
+// "credential-export-bundle" seals (src/worker/index.ts). Checked client-side
+// so an oversized bundle fails fast with a clear error instead of a generic 400.
+export const CREDENTIAL_BUNDLE_MAX_CIPHERTEXT = 4096;
+
+/**
+ * Seals a client-side envelope ciphertext (already encrypted with the one-time
+ * code — encrypt-THEN-seal) under the `credential-export-bundle` purpose.
+ * Mirrors `sealApiToken()` but with a distinct purpose and a client-side size
+ * pre-check. Uses `proxyFetch()` so the `X-Requested-With` CSRF header is set.
+ */
+export async function sealCredentialBundle(ciphertext: string): Promise<string> {
+  if (ciphertext.length > CREDENTIAL_BUNDLE_MAX_CIPHERTEXT) {
+    throw new Error(
+      "Credentials are too large to export securely. Please report this — it should not happen for a normal account."
+    );
+  }
+  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
+  const turnstileToken = await acquireTurnstileToken(siteKey ?? "", "seal");
+
+  const res = await proxyFetch("/api/proxy/seal", {
+    method: "POST",
+    headers: {
+      "cf-turnstile-response": turnstileToken,
+    },
+    body: JSON.stringify({ token: ciphertext, purpose: "credential-export-bundle" }),
+  });
+
+  if (!res.ok) {
+    let code = "unknown_error";
+    try {
+      const body = (await res.json()) as { error?: string };
+      code = body.error ?? code;
+    } catch {
+      // ignore parse errors — keep default code
+    }
+    throw new SealError(res.status, code);
+  }
+
+  const data = (await res.json()) as { sealed: string };
+  return data.sealed;
+}
+
+/**
+ * Unseals a credential-export-bundle blob via the pre-auth-reachable
+ * `/api/proxy/unseal` endpoint. Returns the still-code-encrypted inner
+ * ciphertext (never plaintext credentials — encrypt-then-seal design).
+ *
+ * SINGLE-USE: the endpoint consumes the bundle's nonce server-side on the first
+ * successful unseal, so callers MUST call this exactly once per bundle, cache the
+ * returned `ciphertext`, and run any wrong-code retries against the cache via
+ * `resolveImportedCredentials()` — re-calling this on a retry burns the bundle.
+ *
+ * MUST use `proxyFetch()` (sets `X-Requested-With`); a raw fetch would be
+ * rejected with `403 missing_csrf_header`. Only `expired` is distinguished from
+ * the uniform `invalid` failure (per the endpoint's contract).
+ */
+export async function unsealCredentialBundle(
+  sealed: string
+): Promise<{ ok: true; ciphertext: string } | { ok: false; reason: "expired" | "invalid" }> {
+  const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
+  let turnstileToken: string;
+  try {
+    turnstileToken = await acquireTurnstileToken(siteKey ?? "", "unseal");
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+
+  let res: Response;
+  try {
+    res = await proxyFetch("/api/proxy/unseal", {
+      method: "POST",
+      headers: {
+        "cf-turnstile-response": turnstileToken,
+      },
+      body: JSON.stringify({ sealed, purpose: "credential-export-bundle" }),
+    });
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+
+  if (res.ok) {
+    try {
+      const data = (await res.json()) as { payload?: unknown };
+      if (typeof data.payload === "string") {
+        return { ok: true, ciphertext: data.payload };
+      }
+    } catch {
+      // fall through to invalid
+    }
+    return { ok: false, reason: "invalid" };
+  }
+
+  try {
+    const body = (await res.json()) as { error?: string };
+    if (body.error === "expired") return { ok: false, reason: "expired" };
+  } catch {
+    // fall through to invalid
+  }
+  return { ok: false, reason: "invalid" };
 }

--- a/src/app/lib/proxy.ts
+++ b/src/app/lib/proxy.ts
@@ -205,12 +205,11 @@ export async function sealCredentialBundle(ciphertext: string): Promise<string> 
  * the single-use nonce, so the bundle is STILL valid and callers MUST treat them
  * as non-terminal (keep the code/unseal step available), NOT as a burned bundle:
  *   - `turnstile`: a CLIENT-side Turnstile-acquisition failure BEFORE any request
- *     reached the server (R-101).
+ *     reached the server.
  *   - `network`: a thrown `proxyFetch` (no server response at all), or a server
- *     403 (turnstile_failed) / 503 (internal_error / KV) — all pre-nonce
- *     (SEC-001/API-001).
+ *     403 (turnstile_failed) / 503 (internal_error / KV) — all pre-nonce.
  *   - `rate-limited`: a server 429 from the pre-gate rate limiter, which fires
- *     before Turnstile and long before nonce access (API-001).
+ *     before Turnstile and long before nonce access.
  * Only `expired` and `invalid` are TERMINAL (the single-use bundle is spent /
  * unusable): `invalid` covers a genuine bad blob, wrong key, or already-consumed
  * nonce (401 with no `expired` marker).
@@ -228,7 +227,7 @@ export async function unsealCredentialBundle(
   } catch {
     // Acquisition threw (widget hiccup/timeout/missing key) BEFORE any network
     // request — the server nonce is untouched and the bundle is still valid.
-    // Return a DISTINCT retryable result, NOT the terminal `invalid` (R-101).
+    // Return a DISTINCT retryable result, NOT the terminal `invalid`.
     return { ok: false, reason: "turnstile" };
   }
 
@@ -244,7 +243,7 @@ export async function unsealCredentialBundle(
   } catch {
     // A network throw means NO server response arrived — the single-use nonce was
     // never reached, so the bundle is still valid. Retryable, NOT terminal
-    // `invalid` (SEC-001).
+    // `invalid`.
     return { ok: false, reason: "network" };
   }
 
@@ -262,7 +261,7 @@ export async function unsealCredentialBundle(
 
   // Non-2xx. Statuses that fire BEFORE the server reaches nonce consumption leave
   // the bundle valid → retryable, NOT the terminal `invalid` path
-  // (SEC-001/API-001): 429 rate_limited (pre-gate), 403 turnstile_failed, 503
+  // 429 rate_limited (pre-gate), 403 turnstile_failed, 503
   // internal_error / KV outage.
   if (res.status === 429) return { ok: false, reason: "rate-limited" };
   if (res.status === 403 || res.status === 503) return { ok: false, reason: "network" };

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -156,12 +156,13 @@ export type ParseImportResult =
 
 /**
  * Single entry point for importing a settings file, shared by SettingsPage and
- * (in a later task) LoginPage. Runs: byte-size guard → JSON parse → pre-parse
- * fixups → full `ConfigSchema.safeParse()` (NOT `.partial()`) → post-parse
- * fixups. Mirrors `loadConfig()`'s validation pattern.
+ * LoginPage. Runs: byte-size guard → JSON parse → pre-parse fixups → full
+ * `ConfigSchema.safeParse()` (NOT `.partial()`) → post-parse fixups. Mirrors
+ * `loadConfig()`'s validation pattern.
  *
- * `rawJson` is the parsed-but-unvalidated object, retained so a later task can
- * inspect it for a `_credentials` section without re-parsing the text.
+ * `rawJson` is the parsed-but-unvalidated object, retained so callers can
+ * inspect it for `_credentials`/`_viewPreferences` sections without re-parsing
+ * the text.
  */
 export function parseImportFile(rawText: string): ParseImportResult {
   // (a) Byte-size guard — measure UTF-8 bytes, NOT rawText.length (UTF-16 code
@@ -212,7 +213,7 @@ export function parseImportFile(rawText: string): ParseImportResult {
   // (e) post-parse migrations (stale-defaultTab cleanup)
   const config = postParseConfigFixups(result.data);
 
-  // (f) success — rawJson is the parsed original (for later _credentials inspection)
+  // (f) success — rawJson is the parsed original, retained for _credentials/_viewPreferences inspection
   return { ok: true, config, rawJson };
 }
 

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -103,6 +103,23 @@ export function parseImportFile(rawText: string): ParseImportResult {
     return { ok: false, errors: ["File is not valid JSON."] };
   }
 
+  // (b2) file-level version gate — reject a file stamped with a NEWER export
+  // version up front with a clear message, mirroring the envelope/seal
+  // version-byte fail-clean behavior (STRUCT-I-001). A missing/absent
+  // _exportVersion is treated as version 1 (back-compat with pre-version
+  // exports); ConfigSchema strips the key, so it must be read from rawJson here.
+  if (rawJson && typeof rawJson === "object") {
+    const rawVersion = (rawJson as Record<string, unknown>)._exportVersion;
+    if (typeof rawVersion === "number" && rawVersion > EXPORT_VERSION) {
+      return {
+        ok: false,
+        errors: [
+          `This settings file was made by a newer version of the app (export v${rawVersion}). Update the app, then try importing again.`,
+        ],
+      };
+    }
+  }
+
   // (c) pre-parse migrations (theme salvage, [bot]-suffix strip)
   const fixed = preParseConfigFixups(rawJson);
 
@@ -302,21 +319,26 @@ export const CredentialBundleSchema = z.object({
   }),
   jira: z.union([
     z.null(),
+    // Jira identity fields mirror JiraAuthStateSchema's constraints
+    // (cloudId/siteName .min(1), siteUrl .url()) so a malformed bundle fails
+    // clearly at import via resolveImportedCredentials' generic failure, instead
+    // of importing + working in-session then silently vanishing on the next
+    // reload when the stricter JiraAuthStateSchema rejects it (SEC-002).
     z.discriminatedUnion("authMethod", [
       z.object({
         authMethod: z.literal("oauth"),
         sealedRefreshToken: z.string(),
-        cloudId: z.string(),
-        siteUrl: z.string(),
-        siteName: z.string(),
+        cloudId: z.string().min(1),
+        siteUrl: z.string().url(),
+        siteName: z.string().min(1),
       }),
       z.object({
         authMethod: z.literal("token"),
         sealedApiToken: z.string(),
         email: z.string(),
-        cloudId: z.string(),
-        siteUrl: z.string(),
-        siteName: z.string(),
+        cloudId: z.string().min(1),
+        siteUrl: z.string().url(),
+        siteName: z.string().min(1),
       }),
     ]),
   ]),
@@ -411,6 +433,17 @@ const IMPORT_INSECURE_CONTEXT =
   "Encrypted credential import requires a secure context (HTTPS or localhost) — this page was loaded insecurely.";
 
 /**
+ * Standard GitHub REST headers for the identity check, mirroring auth.ts's
+ * VALIDATE_HEADERS (not exported there) used at every other GET /user site —
+ * pins the API version so a future default change can't shift this validation
+ * (QA-002).
+ */
+const GITHUB_API_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+} as const;
+
+/**
  * Resolves (validates — does NOT commit) imported credentials from an
  * already-unsealed inner ciphertext. NON-mutating and retryable against a cached
  * ciphertext: the single-use network unseal happens once in the caller (via
@@ -458,7 +491,7 @@ export async function resolveImportedCredentials(
   let resp: Response;
   try {
     resp = await fetch("https://api.github.com/user", {
-      headers: { Authorization: `Bearer ${bundle.github.token}` },
+      headers: { ...GITHUB_API_HEADERS, Authorization: `Bearer ${bundle.github.token}` },
     });
   } catch {
     return { ok: false, error: IMPORT_GITHUB_INVALID };
@@ -505,10 +538,19 @@ export async function commitImportedSettings(
   setAuthFromCredential(resolved.bundle.github.token, resolved.identity);
 
   // (b) apply the imported config wholesale AFTER identity is established.
+  // STRUCT-I-003: the sealed bundle's authMethod is the tamper-proof source of
+  // truth for the restored credential SHAPE (the plaintext config.jira.authMethod
+  // is user-editable via the export file). Align the config to the bundle so
+  // runtime createJiraClient/ensureJiraTokenValid take the branch matching the
+  // JiraAuthState we actually restore below — otherwise a hand-edited
+  // config.jira.authMethod could make Jira silently never work.
+  const jira = resolved.bundle.jira;
+  if (jira !== null && importedConfig.jira) {
+    importedConfig.jira = { ...importedConfig.jira, authMethod: jira.authMethod };
+  }
   setConfig(importedConfig);
 
   // (c) restore Jira.
-  const jira = resolved.bundle.jira;
   if (jira === null) {
     return { jiraRestored: true };
   }
@@ -561,10 +603,14 @@ export async function commitImportedSettings(
     sealed_refresh_token: string;
     expires_in: number;
   };
+  // STRUCT-I-002: clamp expires_in defensively, matching ensureJiraTokenValid's
+  // handling of the same endpoint's contract — a non-positive/absent value would
+  // otherwise yield a past/NaN expiresAt.
+  const ttl = typeof data.expires_in === "number" && data.expires_in > 0 ? data.expires_in : 3600;
   const state: JiraAuthState = {
     accessToken: data.access_token,
     sealedRefreshToken: data.sealed_refresh_token,
-    expiresAt: Date.now() + data.expires_in * 1000,
+    expiresAt: Date.now() + ttl * 1000,
     cloudId: jira.cloudId,
     siteUrl: jira.siteUrl,
     siteName: jira.siteName,

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { ConfigSchema } from "../../shared/schemas";
 import type { Config } from "../../shared/schemas";
 import { preParseConfigFixups, postParseConfigFixups, config, setConfig } from "../stores/config";
+import { EXPORTED_VIEW_PREF_KEYS, applyImportedViewState } from "../stores/view";
 import type { ViewState, TrackedItem, IgnoredItem } from "../stores/view";
 import {
   token,
@@ -47,33 +48,11 @@ export const EXPORT_DENYLIST: Record<string, readonly string[]> = {
 /** Version stamp on exported payloads (bump on an incompatible format change). */
 export const EXPORT_VERSION = 1;
 
-/**
- * Top-level ViewState keys included in an export's `_viewPreferences` section.
- * Deliberately a curated allowlist, NOT the full ViewState — three top-level
- * keys are excluded on purpose:
- *   - `lastActiveTab`, `globalSort`: transient session state, not a durable
- *     preference worth restoring on another device.
- *   - `globalFilter`: a free-typed org/repo search string. Even though it's
- *     not secret, it's arbitrary user-typed text with no bound on content, so
- *     it's excluded from the plaintext export on privacy-scrub grounds.
- * `satisfies readonly (keyof ViewState)[]` is a compile-time guard: if a key
- * here is ever renamed/removed from ViewStateSchema, this fails to typecheck.
- * The runtime schema-drift guard test in settings-transfer.test.ts is the
- * complementary check — it fails when ViewStateSchema gains or loses a
- * TOP-LEVEL key, forcing a conscious include/exclude decision here.
- */
-export const EXPORTED_VIEW_PREF_KEYS = [
-  "jiraCustomOrder",
-  "expandedRepos",
-  "lockedRepos",
-  "tabFilters",
-  "customTabFilters",
-  "dependencyExpandedGroups",
-  "showPrRuns",
-  "hideDepDashboard",
-  "ignoredItems",
-  "trackedItems",
-] as const satisfies readonly (keyof ViewState)[];
+// EXPORTED_VIEW_PREF_KEYS lives in stores/view.ts (not here) to avoid a
+// circular import — this module already transitively depends on that one via
+// stores/config.ts and stores/auth.ts. Re-exported so existing consumers of
+// this module (tests, EXPORT_DENYLIST-style callers) don't need to know that.
+export { EXPORTED_VIEW_PREF_KEYS };
 
 /**
  * `trackedItems` entry fields included in the export. An ALLOWLIST, not a
@@ -659,8 +638,8 @@ export async function resolveImportedCredentials(
 }
 
 /**
- * Commits resolved credentials + imported config in a strict order. Called ONLY
- * after user confirmation.
+ * Commits resolved credentials + imported config + imported view preferences
+ * in a strict order. Called ONLY after user confirmation.
  *
  *   (a0) pre-auth (user() === null, the Login-page path): `await
  *        clearIdentityData()` FIRST so a prior identity's IndexedDB cache + poll
@@ -672,7 +651,11 @@ export async function resolveImportedCredentials(
  *        when the login differs).
  *   (b)  `setConfig(importedConfig)` — full replacement, AFTER (a) so the reset
  *        cascade can't clobber the just-imported config (and this corrects the
- *        transient `authMethod: "pat"` the cascade sets).
+ *        transient `authMethod: "pat"` the cascade sets). Immediately followed
+ *        by `applyImportedViewState(viewPreferences)` — same identity-scoped
+ *        ordering rationale, and it's a total/no-throw no-op when
+ *        `viewPreferences` is absent or malformed, so callers with no
+ *        `_viewPreferences` section can pass `undefined` unconditionally.
  *   (c)  Jira restore — token-mode: build JiraAuthState locally (no network);
  *        oauth-mode: POST /api/oauth/jira/refresh to mint a fresh access token.
  *        Jira restore failure does NOT abort — GitHub identity/config are already
@@ -680,7 +663,8 @@ export async function resolveImportedCredentials(
  */
 export async function commitImportedSettings(
   resolved: { bundle: CredentialBundle; identity: GitHubUser },
-  importedConfig: Config
+  importedConfig: Config,
+  viewPreferences?: unknown
 ): Promise<{ jiraRestored: boolean }> {
   // (a0) pre-auth identity isolation — awaited, so the cache clear + reset
   // callbacks fully complete before the new identity/config are established.
@@ -703,6 +687,7 @@ export async function commitImportedSettings(
     importedConfig.jira = { ...importedConfig.jira, authMethod: jira.authMethod };
   }
   setConfig(importedConfig);
+  applyImportedViewState(viewPreferences);
 
   // (c) restore Jira.
   if (jira === null) {

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -30,7 +30,7 @@ import type { GitHubUser, JiraAuthState } from "../stores/auth";
 import { pushNotification } from "./errors";
 import { proxyFetch, sealCredentialBundle } from "./proxy";
 
-// ── Export (Task 1) ────────────────────────────────────────────────────────────
+// ── Export ────────────────────────────────────────────────────────────
 
 /**
  * Nested paths stripped from the exported config. Currently only `jira.email`
@@ -67,7 +67,7 @@ export function buildExportPayload(config: Config): Record<string, unknown> {
   return { ...snapshot, _exportVersion: EXPORT_VERSION };
 }
 
-// ── Import (Task 2) ──────────────────────────────────────────────────────────
+// ── Import ──────────────────────────────────────────────────────────
 
 /**
  * Max import file size, in BYTES. Legitimate exports are only a few KB; this
@@ -105,7 +105,7 @@ export function parseImportFile(rawText: string): ParseImportResult {
 
   // (b2) file-level version gate — reject a file stamped with a NEWER export
   // version up front with a clear message, mirroring the envelope/seal
-  // version-byte fail-clean behavior (STRUCT-I-001). A missing/absent
+  // version-byte fail-clean behavior. A missing/absent
   // _exportVersion is treated as version 1 (back-compat with pre-version
   // exports); ConfigSchema strips the key, so it must be read from rawJson here.
   if (rawJson && typeof rawJson === "object") {
@@ -141,7 +141,7 @@ export function parseImportFile(rawText: string): ParseImportResult {
   return { ok: true, config, rawJson };
 }
 
-// ── Client-side envelope encryption (Task 4) ─────────────────────────────────
+// ── Client-side envelope encryption ─────────────────────────────────
 //
 // A fully independent client-side AES-256-GCM implementation (NO shared code
 // with src/worker/crypto.ts). Wire format for the ciphertext genuinely mirrors
@@ -302,7 +302,7 @@ export async function decryptWithCode(
   }
 }
 
-// ── Encrypted credentials export (Task 5) ────────────────────────────────────
+// ── Encrypted credentials export ────────────────────────────────────
 
 /**
  * Schema for the decrypted credential bundle. The Jira sub-object is a
@@ -323,7 +323,7 @@ export const CredentialBundleSchema = z.object({
     // (cloudId/siteName .min(1), siteUrl .url()) so a malformed bundle fails
     // clearly at import via resolveImportedCredentials' generic failure, instead
     // of importing + working in-session then silently vanishing on the next
-    // reload when the stricter JiraAuthStateSchema rejects it (SEC-002).
+    // reload when the stricter JiraAuthStateSchema rejects it.
     z.discriminatedUnion("authMethod", [
       z.object({
         authMethod: z.literal("oauth"),
@@ -423,7 +423,7 @@ export async function buildEncryptedCredentialsSection(): Promise<{
   return { sealed, salt, oneTimeCode };
 }
 
-// ── Encrypted credentials import (Task 6) ────────────────────────────────────
+// ── Encrypted credentials import ────────────────────────────────────
 
 const IMPORT_DECRYPT_FAILED =
   "Couldn't decrypt credentials — check the code and file match.";
@@ -435,8 +435,7 @@ const IMPORT_INSECURE_CONTEXT =
 /**
  * Standard GitHub REST headers for the identity check, mirroring auth.ts's
  * VALIDATE_HEADERS (not exported there) used at every other GET /user site —
- * pins the API version so a future default change can't shift this validation
- * (QA-002).
+ * pins the API version so a future default change can't shift this validation.
  */
 const GITHUB_API_HEADERS = {
   Accept: "application/vnd.github+json",
@@ -455,7 +454,7 @@ const GITHUB_API_HEADERS = {
  * message (uniform-failure security decision); a revoked/expired GitHub token
  * (401 OR network failure) surfaces a distinct message; and the secure-context
  * precondition — an environment condition, not a secret — is surfaced distinctly
- * (R-001) up front so it isn't swallowed into a null that masquerades as a wrong
+ * up front so it isn't swallowed into a null that masquerades as a wrong
  * code.
  */
 export async function resolveImportedCredentials(
@@ -538,7 +537,7 @@ export async function commitImportedSettings(
   setAuthFromCredential(resolved.bundle.github.token, resolved.identity);
 
   // (b) apply the imported config wholesale AFTER identity is established.
-  // STRUCT-I-003: the sealed bundle's authMethod is the tamper-proof source of
+  // The sealed bundle's authMethod is the tamper-proof source of
   // truth for the restored credential SHAPE (the plaintext config.jira.authMethod
   // is user-editable via the export file). Align the config to the bundle so
   // runtime createJiraClient/ensureJiraTokenValid take the branch matching the
@@ -598,12 +597,25 @@ export async function commitImportedSettings(
     return { jiraRestored: false };
   }
 
-  const data = (await resp.json()) as {
-    access_token: string;
-    sealed_refresh_token: string;
-    expires_in: number;
-  };
-  // STRUCT-I-002: clamp expires_in defensively, matching ensureJiraTokenValid's
+  let data: { access_token: string; sealed_refresh_token: string; expires_in: number };
+  try {
+    data = (await resp.json()) as {
+      access_token: string;
+      sealed_refresh_token: string;
+      expires_in: number;
+    };
+  } catch {
+    // A malformed (but 200) refresh body degrades gracefully like the failures
+    // above — GitHub identity/config are already committed, so throwing here
+    // would abort a half-applied import instead of returning jiraRestored:false.
+    pushNotification(
+      "settings-import-jira",
+      "Your Jira connection couldn't be restored — please reconnect it in Settings.",
+      "warning"
+    );
+    return { jiraRestored: false };
+  }
+  // Clamp expires_in defensively, matching ensureJiraTokenValid's
   // handling of the same endpoint's contract — a non-positive/absent value would
   // otherwise yield a past/NaN expiresAt.
   const ttl = typeof data.expires_in === "number" && data.expires_in > 0 ? data.expires_in : 3600;
@@ -619,7 +631,7 @@ export async function commitImportedSettings(
   return { jiraRestored: true };
 }
 
-// ── Login-page import (Task 7) ────────────────────────────────────────────────
+// ── Login-page import ────────────────────────────────────────────────
 
 /**
  * True when the local config indicates prior onboarding or use — the signal the
@@ -628,7 +640,7 @@ export async function commitImportedSettings(
  * onboarding, no repo/org selections) returns `false` and imports straight
  * through to the dashboard without a confirmation prompt. On the Settings page
  * the user is always already authenticated, so that flow always confirms and
- * never consults this helper. (Plan Key Decisions + Task 7 Step 1.)
+ * never consults this helper.
  */
 export function hasExistingLocalConfig(config: Config): boolean {
   return (

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -572,3 +572,22 @@ export async function commitImportedSettings(
   setJiraAuth(state);
   return { jiraRestored: true };
 }
+
+// ── Login-page import (Task 7) ────────────────────────────────────────────────
+
+/**
+ * True when the local config indicates prior onboarding or use — the signal the
+ * pre-auth Login-page import uses to decide whether to show the identity-confirm
+ * dialog before finalizing. A genuinely fresh browser/incognito session (no
+ * onboarding, no repo/org selections) returns `false` and imports straight
+ * through to the dashboard without a confirmation prompt. On the Settings page
+ * the user is always already authenticated, so that flow always confirms and
+ * never consults this helper. (Plan Key Decisions + Task 7 Step 1.)
+ */
+export function hasExistingLocalConfig(config: Config): boolean {
+  return (
+    config.onboardingComplete === true ||
+    config.selectedRepos.length > 0 ||
+    config.selectedOrgs.length > 0
+  );
+}

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -159,8 +159,6 @@ export const ENVELOPE_VERSION = 0x01;
  */
 export const ENVELOPE_KEY_INFO = "envelope-key:credential-bundle-export";
 
-const ONE_TIME_CODE_HEX_RE = /^[0-9a-f]{32}$/;
-
 // ── base64url helpers (client-side, self-contained) ──────────────────────────
 
 function toBase64Url(bytes: Uint8Array): string {
@@ -182,33 +180,96 @@ function fromBase64Url(str: string): Uint8Array {
   return bytes;
 }
 
+// ── Crockford base32 helpers (client-side, self-contained) ───────────────────
+//
+// The one-time code is encoded as Crockford base32 rather than hex: it's what
+// a user hand-types back in on the Login page, and Crockford's alphabet omits
+// I, L, O, U specifically to avoid characters that are easily confused with
+// each other (or, for U, with profanity) when read aloud or copied by hand.
+//
+// 16 bytes is 128 bits, which doesn't divide evenly into 5-bit groups, so the
+// value is treated as a 128-bit big-endian integer, left-shifted 2 bits to 130
+// bits (26 * 5 divides evenly), then emitted as 26 base32 digits MSB-first.
+// Decoding reverses this: parse 26 digits back to the 130-bit integer, then
+// right-shift 2 bits and serialize 16 big-endian bytes. The 2 padding bits
+// introduced by the left-shift are always 0, so this round-trips exactly for
+// any 16-byte input.
+
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
 /**
- * Generates a one-time code: 16 CSPRNG bytes (128 bits) hex-encoded and
- * formatted for display/copy as 8 dash-separated groups of 4 hex chars
- * (`XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`).
+ * Crockford's documented human-entry leniency: I and L are easily misread as
+ * the digit 1, and O as the digit 0, so a hand-retyped code maps them back
+ * deterministically. U is deliberately NOT included here — it's simply not a
+ * valid alphabet character, so an input 'U' is rejected by the format check
+ * below rather than silently remapped (mapping it would make decoding
+ * ambiguous with whatever character it aliased to).
+ */
+const CROCKFORD_LENIENCY: Readonly<Record<string, string>> = { I: "1", L: "1", O: "0" };
+
+/** Exactly 26 Crockford base32 characters. Checked AFTER normalization (see `decodeOneTimeCode`), so this only ever sees uppercase, leniency-mapped input. */
+const ONE_TIME_CODE_FORMAT_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+function toCrockfordBase32(bytes: Uint8Array): string {
+  let value = 0n;
+  for (const b of bytes) {
+    value = (value << 8n) | BigInt(b);
+  }
+  value <<= 2n; // 128 -> 130 bits (26 * 5)
+  let out = "";
+  for (let i = 25; i >= 0; i--) {
+    out += CROCKFORD_ALPHABET[Number((value >> BigInt(i * 5)) & 0x1fn)];
+  }
+  return out;
+}
+
+/**
+ * Inverse of `toCrockfordBase32`. `chars` MUST already be normalized and
+ * format-validated (exactly 26 characters, all members of CROCKFORD_ALPHABET)
+ * — see `decodeOneTimeCode`, the only caller.
+ */
+function fromCrockfordBase32(chars: string): Uint8Array {
+  let value = 0n;
+  for (const ch of chars) {
+    value = (value << 5n) | BigInt(CROCKFORD_ALPHABET.indexOf(ch));
+  }
+  value >>= 2n; // 130 -> 128 bits
+  const bytes = new Uint8Array(16);
+  for (let i = 15; i >= 0; i--) {
+    bytes[i] = Number(value & 0xffn);
+    value >>= 8n;
+  }
+  return bytes;
+}
+
+/**
+ * Generates a one-time code: 16 CSPRNG bytes (128 bits) Crockford base32-
+ * encoded (26 chars) and formatted for display/copy as dash-separated groups
+ * of 4 (`XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XX`).
  */
 export function generateOneTimeCode(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(16));
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-  return hex.match(/.{4}/g)!.join("-");
+  const encoded = toCrockfordBase32(bytes);
+  return encoded.match(/.{1,4}/g)!.join("-");
 }
 
 /**
  * Decodes a one-time code (as displayed OR as manually retyped by a user) back
  * to its 16 raw bytes. Normalizes first — trims surrounding whitespace, strips
- * all internal dashes/whitespace, and lowercases — because on the pre-auth
- * Login page the code is retyped by hand and copy-paste may perturb it.
+ * all internal dashes/whitespace, uppercases, and applies Crockford's I/L->1,
+ * O->0 leniency — because on the pre-auth Login page the code is retyped by
+ * hand and copy-paste may perturb it.
  */
 export function decodeOneTimeCode(code: string): Uint8Array {
-  const normalized = code.trim().replace(/[\s-]/g, "").toLowerCase();
-  if (!ONE_TIME_CODE_HEX_RE.test(normalized)) {
+  const stripped = code.trim().replace(/[\s-]/g, "").toUpperCase();
+  let normalized = "";
+  for (const ch of stripped) {
+    normalized += CROCKFORD_LENIENCY[ch] ?? ch;
+  }
+  if (!ONE_TIME_CODE_FORMAT_RE.test(normalized)) {
     throw new Error("One-time code is not in the expected format.");
   }
-  const bytes = new Uint8Array(16);
-  for (let i = 0; i < 16; i++) {
-    bytes[i] = parseInt(normalized.slice(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
+  return fromCrockfordBase32(normalized);
 }
 
 /**

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -18,7 +18,7 @@ import { z } from "zod";
 import { ConfigSchema } from "../../shared/schemas";
 import type { Config } from "../../shared/schemas";
 import { preParseConfigFixups, postParseConfigFixups, config, setConfig } from "../stores/config";
-import { EXPORTED_VIEW_PREF_KEYS, applyImportedViewState } from "../stores/view";
+import { EXPORTED_VIEW_PREF_KEYS, applyImportedViewState, resetViewState } from "../stores/view";
 import type { ViewState, TrackedItem, IgnoredItem } from "../stores/view";
 import {
   token,
@@ -93,14 +93,16 @@ function pickAllowedFields<T extends object, K extends keyof T>(obj: T, keys: re
  * Builds the `_viewPreferences` export section from the live view-state store.
  * Deep-clones via a JSON round-trip (same reason as `buildExportPayload`'s
  * config handling — `viewState` is a SolidJS store proxy), keeps only
- * `EXPORTED_VIEW_PREF_KEYS`, then rebuilds every `ignoredItems`/`trackedItems`
- * entry from its allowlist so content/PII-adjacent fields never reach the
- * export regardless of what else is on the live entry.
+ * `EXPORTED_VIEW_PREF_KEYS` — `ignoredItems`/`trackedItems` are skipped in
+ * this generic copy and rebuilt below from their allowlists instead, so
+ * content/PII-adjacent fields never reach the export regardless of what else
+ * is on the live entry.
  */
 function buildViewPreferencesSection(viewState: ViewState): Record<string, unknown> {
   const snapshot = JSON.parse(JSON.stringify(viewState)) as ViewState;
   const section: Record<string, unknown> = {};
   for (const key of EXPORTED_VIEW_PREF_KEYS) {
+    if (key === "ignoredItems" || key === "trackedItems") continue;
     section[key] = snapshot[key];
   }
   section.ignoredItems = snapshot.ignoredItems.map((item) =>
@@ -643,9 +645,15 @@ export async function resolveImportedCredentials(
  *
  *   (a0) pre-auth (user() === null, the Login-page path): `await
  *        clearIdentityData()` FIRST so a prior identity's IndexedDB cache + poll
- *        state can't leak into the just-imported identity. On the Settings page
- *        user() is non-null, so this is skipped and setAuthFromCredential's own
- *        identity-switch reset handles isolation.
+ *        state can't leak into the just-imported identity, THEN `resetViewState()`
+ *        — setAuthFromCredential's identity-switch reset is INERT here (its
+ *        `previousLogin` check needs a non-null `user()`), and `setConfig`/
+ *        `applyImportedViewState` below only wholesale-replace config and overlay
+ *        the CURATED view-preference keys respectively, so without this a prior
+ *        expired-token session's transient view keys (globalFilter/lastActiveTab/
+ *        globalSort) would otherwise survive the import. On the Settings page
+ *        user() is non-null, so this whole branch is skipped and
+ *        setAuthFromCredential's own identity-switch reset handles isolation.
  *   (a)  `setAuthFromCredential(token, identity)` — establishes the GitHub
  *        session (auth-method-agnostic; runs the identity-switch reset cascade
  *        when the login differs).
@@ -670,6 +678,7 @@ export async function commitImportedSettings(
   // callbacks fully complete before the new identity/config are established.
   if (user() === null) {
     await clearIdentityData();
+    resetViewState();
   }
 
   // (a) establish the GitHub credential (used for BOTH pat and oauth methods).

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { ConfigSchema } from "../../shared/schemas";
 import type { Config } from "../../shared/schemas";
 import { preParseConfigFixups, postParseConfigFixups, config, setConfig } from "../stores/config";
+import type { ViewState, TrackedItem, IgnoredItem } from "../stores/view";
 import {
   token,
   jiraAuth,
@@ -47,14 +48,103 @@ export const EXPORT_DENYLIST: Record<string, readonly string[]> = {
 export const EXPORT_VERSION = 1;
 
 /**
- * Builds the plaintext export payload from the live config store.
- *
- * Deep-clones via a JSON round-trip — `config` is a SolidJS store proxy, so a
- * raw spread would leave nested objects proxied (matching the clone pattern in
- * `initConfigPersistence()`, src/app/stores/config.ts) — then deletes each
- * denylisted nested path and stamps `_exportVersion`.
+ * Top-level ViewState keys included in an export's `_viewPreferences` section.
+ * Deliberately a curated allowlist, NOT the full ViewState — three top-level
+ * keys are excluded on purpose:
+ *   - `lastActiveTab`, `globalSort`: transient session state, not a durable
+ *     preference worth restoring on another device.
+ *   - `globalFilter`: a free-typed org/repo search string. Even though it's
+ *     not secret, it's arbitrary user-typed text with no bound on content, so
+ *     it's excluded from the plaintext export on privacy-scrub grounds.
+ * `satisfies readonly (keyof ViewState)[]` is a compile-time guard: if a key
+ * here is ever renamed/removed from ViewStateSchema, this fails to typecheck.
+ * The runtime schema-drift guard test in settings-transfer.test.ts is the
+ * complementary check — it fails when ViewStateSchema gains or loses a
+ * TOP-LEVEL key, forcing a conscious include/exclude decision here.
  */
-export function buildExportPayload(config: Config): Record<string, unknown> {
+export const EXPORTED_VIEW_PREF_KEYS = [
+  "jiraCustomOrder",
+  "expandedRepos",
+  "lockedRepos",
+  "tabFilters",
+  "customTabFilters",
+  "dependencyExpandedGroups",
+  "showPrRuns",
+  "hideDepDashboard",
+  "ignoredItems",
+  "trackedItems",
+] as const satisfies readonly (keyof ViewState)[];
+
+/**
+ * `trackedItems` entry fields included in the export. An ALLOWLIST, not a
+ * denylist — `title`, `htmlUrl`, and `jiraStatus` are content/PII-adjacent
+ * fields that must never leave the browser in plaintext, and an allowlist
+ * excludes them (and any future field) by default until a conscious decision
+ * adds it here, whereas a denylist would leak every new field automatically.
+ */
+const TRACKED_ITEM_EXPORT_KEEP_LIST = [
+  "id",
+  "number",
+  "type",
+  "source",
+  "repoFullName",
+  "jiraKey",
+  "jiraProjectKey",
+  "addedAt",
+] as const satisfies readonly (keyof TrackedItem)[];
+
+/** Same allowlist rationale as TRACKED_ITEM_EXPORT_KEEP_LIST — `title` excluded. */
+const IGNORED_ITEM_EXPORT_KEEP_LIST = [
+  "id",
+  "type",
+  "repo",
+  "ignoredAt",
+] as const satisfies readonly (keyof IgnoredItem)[];
+
+/** Reconstructs `obj` from ONLY the given keys (allowlist), dropping everything else. */
+function pickAllowedFields<T extends object, K extends keyof T>(obj: T, keys: readonly K[]): Pick<T, K> {
+  const out = {} as Pick<T, K>;
+  for (const key of keys) {
+    if (key in obj) out[key] = obj[key];
+  }
+  return out;
+}
+
+/**
+ * Builds the `_viewPreferences` export section from the live view-state store.
+ * Deep-clones via a JSON round-trip (same reason as `buildExportPayload`'s
+ * config handling — `viewState` is a SolidJS store proxy), keeps only
+ * `EXPORTED_VIEW_PREF_KEYS`, then rebuilds every `ignoredItems`/`trackedItems`
+ * entry from its allowlist so content/PII-adjacent fields never reach the
+ * export regardless of what else is on the live entry.
+ */
+function buildViewPreferencesSection(viewState: ViewState): Record<string, unknown> {
+  const snapshot = JSON.parse(JSON.stringify(viewState)) as ViewState;
+  const section: Record<string, unknown> = {};
+  for (const key of EXPORTED_VIEW_PREF_KEYS) {
+    section[key] = snapshot[key];
+  }
+  section.ignoredItems = snapshot.ignoredItems.map((item) =>
+    pickAllowedFields(item, IGNORED_ITEM_EXPORT_KEEP_LIST)
+  );
+  section.trackedItems = snapshot.trackedItems.map((item) =>
+    pickAllowedFields(item, TRACKED_ITEM_EXPORT_KEEP_LIST)
+  );
+  return section;
+}
+
+/**
+ * Builds the plaintext export payload from the live config + view-state
+ * stores.
+ *
+ * Deep-clones `config` via a JSON round-trip — it's a SolidJS store proxy, so
+ * a raw spread would leave nested objects proxied (matching the clone pattern
+ * in `initConfigPersistence()`, src/app/stores/config.ts) — then deletes each
+ * denylisted nested path, attaches the curated `_viewPreferences` section
+ * (plaintext — it never carries secrets, so it does NOT go through the
+ * encrypted-credentials envelope), and stamps `_exportVersion`.
+ */
+export function buildExportPayload(config: Config, viewState: ViewState): Record<string, unknown> {
   const snapshot = JSON.parse(JSON.stringify(config)) as Record<string, unknown>;
   for (const [parentKey, childKeys] of Object.entries(EXPORT_DENYLIST)) {
     const parent = snapshot[parentKey];
@@ -64,7 +154,11 @@ export function buildExportPayload(config: Config): Record<string, unknown> {
       }
     }
   }
-  return { ...snapshot, _exportVersion: EXPORT_VERSION };
+  return {
+    ...snapshot,
+    _exportVersion: EXPORT_VERSION,
+    _viewPreferences: buildViewPreferencesSection(viewState),
+  };
 }
 
 // ── Import ──────────────────────────────────────────────────────────

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -1,0 +1,274 @@
+// ── Settings import / export utilities ────────────────────────────────────────
+//
+// Schema-drift guard workflow (enforced by tests/lib/settings-transfer.test.ts):
+//   1. Add or remove a field on ConfigSchema / JiraConfigSchema (src/shared/schemas.ts).
+//   2. Run `pnpm vitest run tests/lib/settings-transfer.test.ts`.
+//   3. The guard test FAILS, naming the added/removed key(s).
+//   4. Decide whether an ADDED field carries a secret or PII that must NOT leave
+//      the browser. buildExportPayload() spreads the ENTIRE Config, so every new
+//      field is exported by default — if the new field is sensitive, add it to
+//      EXPORT_DENYLIST below. This conscious review is the whole point of the guard.
+//   5. Only then update the snapshot arrays in the guard test to match the schema.
+//
+// SECURITY: nothing in this module may log the one-time code, decrypted bundle
+// contents, or raw GitHub/Jira tokens — no console.* and no Sentry capture here
+// (console output is production-visible and captured as Sentry breadcrumbs).
+
+import { ConfigSchema } from "../../shared/schemas";
+import type { Config } from "../../shared/schemas";
+import { preParseConfigFixups, postParseConfigFixups } from "../stores/config";
+
+// ── Export (Task 1) ────────────────────────────────────────────────────────────
+
+/**
+ * Nested paths stripped from the exported config. Currently only `jira.email`
+ * (PII). The export spreads the full Config (see `buildExportPayload`) so every
+ * current and future field is captured automatically; this denylist is the
+ * single place secrets/PII are removed, and the schema-drift guard test forces a
+ * review of it whenever the schema changes.
+ */
+export const EXPORT_DENYLIST: Record<string, readonly string[]> = {
+  jira: ["email"],
+};
+
+/** Version stamp on exported payloads (bump on an incompatible format change). */
+export const EXPORT_VERSION = 1;
+
+/**
+ * Builds the plaintext export payload from the live config store.
+ *
+ * Deep-clones via a JSON round-trip — `config` is a SolidJS store proxy, so a
+ * raw spread would leave nested objects proxied (matching the clone pattern in
+ * `initConfigPersistence()`, src/app/stores/config.ts) — then deletes each
+ * denylisted nested path and stamps `_exportVersion`.
+ */
+export function buildExportPayload(config: Config): Record<string, unknown> {
+  const snapshot = JSON.parse(JSON.stringify(config)) as Record<string, unknown>;
+  for (const [parentKey, childKeys] of Object.entries(EXPORT_DENYLIST)) {
+    const parent = snapshot[parentKey];
+    if (parent && typeof parent === "object") {
+      for (const childKey of childKeys) {
+        delete (parent as Record<string, unknown>)[childKey];
+      }
+    }
+  }
+  return { ...snapshot, _exportVersion: EXPORT_VERSION };
+}
+
+// ── Import (Task 2) ──────────────────────────────────────────────────────────
+
+/**
+ * Max import file size, in BYTES. Legitimate exports are only a few KB; this
+ * bounds hand-crafted/adversarial files before we attempt to parse them.
+ */
+export const MAX_IMPORT_BYTES = 256 * 1024;
+
+export type ParseImportResult =
+  | { ok: true; config: Config; rawJson: unknown }
+  | { ok: false; errors: string[] };
+
+/**
+ * Single entry point for importing a settings file, shared by SettingsPage and
+ * (in a later task) LoginPage. Runs: byte-size guard → JSON parse → pre-parse
+ * fixups → full `ConfigSchema.safeParse()` (NOT `.partial()`) → post-parse
+ * fixups. Mirrors `loadConfig()`'s validation pattern.
+ *
+ * `rawJson` is the parsed-but-unvalidated object, retained so a later task can
+ * inspect it for a `_credentials` section without re-parsing the text.
+ */
+export function parseImportFile(rawText: string): ParseImportResult {
+  // (a) Byte-size guard — measure UTF-8 bytes, NOT rawText.length (UTF-16 code
+  // units undercount multi-byte content by up to ~3x). Reject before parsing.
+  if (new TextEncoder().encode(rawText).length > MAX_IMPORT_BYTES) {
+    return { ok: false, errors: ["File is too large to import (max 256KB)."] };
+  }
+
+  // (b) JSON parse
+  let rawJson: unknown;
+  try {
+    rawJson = JSON.parse(rawText);
+  } catch {
+    return { ok: false, errors: ["File is not valid JSON."] };
+  }
+
+  // (c) pre-parse migrations (theme salvage, [bot]-suffix strip)
+  const fixed = preParseConfigFixups(rawJson);
+
+  // (d) full schema validation
+  const result = ConfigSchema.safeParse(fixed);
+  if (!result.success) {
+    return {
+      ok: false,
+      errors: result.error.issues.map(
+        (issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`
+      ),
+    };
+  }
+
+  // (e) post-parse migrations (stale-defaultTab cleanup)
+  const config = postParseConfigFixups(result.data);
+
+  // (f) success — rawJson is the parsed original (for later _credentials inspection)
+  return { ok: true, config, rawJson };
+}
+
+// ── Client-side envelope encryption (Task 4) ─────────────────────────────────
+//
+// A fully independent client-side AES-256-GCM implementation (NO shared code
+// with src/worker/crypto.ts). Wire format for the ciphertext genuinely mirrors
+// the Worker's sealToken layout: [ENVELOPE_VERSION:1][iv:12][ciphertext+tag:N],
+// base64url-encoded. The one-time code is CSPRNG output (full entropy), so the
+// key is HKDF-derived (not PBKDF2 — iteration cost buys nothing here).
+
+/** Envelope wire-format version byte (mirrors crypto.ts's SEAL_VERSION). */
+export const ENVELOPE_VERSION = 0x01;
+
+/**
+ * HKDF `info` string for the envelope key. Named for the FULL bundle's scope
+ * (GitHub AND Jira credentials), distinct from every Worker-side HKDF purpose
+ * string — this key is derived and used entirely client-side, never transmitted.
+ */
+export const ENVELOPE_KEY_INFO = "envelope-key:credential-bundle-export";
+
+const ONE_TIME_CODE_HEX_RE = /^[0-9a-f]{32}$/;
+
+// ── base64url helpers (client-side, self-contained) ──────────────────────────
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function fromBase64Url(str: string): Uint8Array {
+  const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (normalized.length % 4)) % 4;
+  const binary = atob(normalized + "=".repeat(padding));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Generates a one-time code: 16 CSPRNG bytes (128 bits) hex-encoded and
+ * formatted for display/copy as 8 dash-separated groups of 4 hex chars
+ * (`XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`).
+ */
+export function generateOneTimeCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return hex.match(/.{4}/g)!.join("-");
+}
+
+/**
+ * Decodes a one-time code (as displayed OR as manually retyped by a user) back
+ * to its 16 raw bytes. Normalizes first — trims surrounding whitespace, strips
+ * all internal dashes/whitespace, and lowercases — because on the pre-auth
+ * Login page the code is retyped by hand and copy-paste may perturb it.
+ */
+export function decodeOneTimeCode(code: string): Uint8Array {
+  const normalized = code.trim().replace(/[\s-]/g, "").toLowerCase();
+  if (!ONE_TIME_CODE_HEX_RE.test(normalized)) {
+    throw new Error("One-time code is not in the expected format.");
+  }
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    bytes[i] = parseInt(normalized.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Derives the AES-256-GCM envelope key from a one-time `code` and a `salt` (raw
+ * bytes). The single entry point both `encryptWithCode` and `decryptWithCode`
+ * call through, so the secure-context guard lives here and nowhere else.
+ */
+export async function deriveEnvelopeKey(code: string, salt: Uint8Array): Promise<CryptoKey> {
+  if (!crypto.subtle) {
+    throw new Error(
+      "Encrypted credential export/import requires a secure context (HTTPS, or localhost) — this page was loaded insecurely."
+    );
+  }
+  const ikm = decodeOneTimeCode(code);
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    ikm.buffer as ArrayBuffer,
+    { name: "HKDF" },
+    false,
+    ["deriveKey"]
+  );
+  return crypto.subtle.deriveKey(
+    // `salt as BufferSource`: the param is Uint8Array<ArrayBufferLike>, which the
+    // strict lib types don't accept for HkdfParams.salt (SharedArrayBuffer-vs-
+    // ArrayBuffer). Cast the view (preserves byteOffset/length, unlike .buffer).
+    { name: "HKDF", hash: "SHA-256", salt: salt as BufferSource, info: new TextEncoder().encode(ENVELOPE_KEY_INFO) },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+/**
+ * Encrypts `plaintext` with an already-derived `key`, producing a base64url
+ * `[ENVELOPE_VERSION:1][iv:12][ciphertext+tag]` blob with a FRESH random 12-byte
+ * IV per call. Exported so the IV-freshness test can hold the key fixed across
+ * two calls and assert the ciphertexts differ (the catastrophic AES-GCM
+ * IV-reuse regression guard).
+ */
+export async function encryptWithKey(plaintext: string, key: CryptoKey): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintextBytes = new TextEncoder().encode(plaintext);
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintextBytes);
+  const ciphertextBytes = new Uint8Array(ciphertext);
+  const result = new Uint8Array(1 + 12 + ciphertextBytes.length);
+  result[0] = ENVELOPE_VERSION;
+  result.set(iv, 1);
+  result.set(ciphertextBytes, 13);
+  return toBase64Url(result);
+}
+
+/**
+ * Encrypts `plaintext` under a key derived from `code`, generating a FRESH
+ * random 16-byte salt per call. Returns the base64url `ciphertext` and the
+ * base64url `salt` (the salt is not secret — it's stored in the export file so
+ * the same key can be re-derived on import).
+ */
+export async function encryptWithCode(
+  plaintext: string,
+  code: string
+): Promise<{ ciphertext: string; salt: string }> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const key = await deriveEnvelopeKey(code, salt);
+  const ciphertext = await encryptWithKey(plaintext, key);
+  return { ciphertext, salt: toBase64Url(salt) };
+}
+
+/**
+ * Inverse of `encryptWithCode`. Returns the plaintext on success, or `null` on
+ * ANY failure — wrong code, tampered ciphertext, malformed input, or an
+ * unrecognized version byte — matching the Worker-side `unsealToken` convention
+ * (no differentiated error detail).
+ */
+export async function decryptWithCode(
+  ciphertext: string,
+  salt: string,
+  code: string
+): Promise<string | null> {
+  try {
+    const key = await deriveEnvelopeKey(code, fromBase64Url(salt));
+    const bytes = fromBase64Url(ciphertext);
+    if (bytes.length < 1 + 12 + 16) return null; // too short to be valid
+    if (bytes[0] !== ENVELOPE_VERSION) return null;
+    const iv = bytes.slice(1, 13);
+    const payload = bytes.slice(13);
+    const plaintext = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, payload);
+    return new TextDecoder().decode(plaintext);
+  } catch {
+    return null;
+  }
+}

--- a/src/app/lib/settings-transfer.ts
+++ b/src/app/lib/settings-transfer.ts
@@ -14,9 +14,21 @@
 // contents, or raw GitHub/Jira tokens — no console.* and no Sentry capture here
 // (console output is production-visible and captured as Sentry breadcrumbs).
 
+import { z } from "zod";
 import { ConfigSchema } from "../../shared/schemas";
 import type { Config } from "../../shared/schemas";
-import { preParseConfigFixups, postParseConfigFixups } from "../stores/config";
+import { preParseConfigFixups, postParseConfigFixups, config, setConfig } from "../stores/config";
+import {
+  token,
+  jiraAuth,
+  user,
+  setJiraAuth,
+  setAuthFromCredential,
+  clearIdentityData,
+} from "../stores/auth";
+import type { GitHubUser, JiraAuthState } from "../stores/auth";
+import { pushNotification } from "./errors";
+import { proxyFetch, sealCredentialBundle } from "./proxy";
 
 // ── Export (Task 1) ────────────────────────────────────────────────────────────
 
@@ -271,4 +283,292 @@ export async function decryptWithCode(
   } catch {
     return null;
   }
+}
+
+// ── Encrypted credentials export (Task 5) ────────────────────────────────────
+
+/**
+ * Schema for the decrypted credential bundle. The Jira sub-object is a
+ * discriminated union on `authMethod` so TypeScript narrows
+ * `sealedRefreshToken`/`sealedApiToken` to defined after the check (avoids a cast
+ * in `commitImportedSettings`). Reused on import to validate the decrypted bundle
+ * before use, matching this codebase's Zod-validate-every-persisted-blob
+ * convention.
+ */
+export const CredentialBundleSchema = z.object({
+  github: z.object({
+    token: z.string(),
+    method: z.enum(["pat", "oauth"]),
+  }),
+  jira: z.union([
+    z.null(),
+    z.discriminatedUnion("authMethod", [
+      z.object({
+        authMethod: z.literal("oauth"),
+        sealedRefreshToken: z.string(),
+        cloudId: z.string(),
+        siteUrl: z.string(),
+        siteName: z.string(),
+      }),
+      z.object({
+        authMethod: z.literal("token"),
+        sealedApiToken: z.string(),
+        email: z.string(),
+        cloudId: z.string(),
+        siteUrl: z.string(),
+        siteName: z.string(),
+      }),
+    ]),
+  ]),
+});
+
+export type CredentialBundle = z.infer<typeof CredentialBundleSchema>;
+
+/**
+ * Schema for the export file's `_credentials` section (sealed blob + salt).
+ * Import uses `.safeParse()` on `rawJson._credentials` (NOT a bare `"in"` check —
+ * a hand-crafted `_credentials: null` would pass that and then throw on
+ * dereference) to decide whether a credentials section is present.
+ */
+export const CredentialsSectionSchema = z.object({
+  sealed: z.string(),
+  salt: z.string(),
+});
+
+export type CredentialsSection = z.infer<typeof CredentialsSectionSchema>;
+
+/**
+ * Assembles the credential bundle from the live auth + config stores.
+ * Non-nullable — the Settings page always has an authenticated GitHub session.
+ *
+ * Jira identity fields (cloudId/siteUrl/siteName) are read from `JiraAuthState`,
+ * the authoritative source restored on import — NOT `config.jira`'s independent
+ * copies. The Jira OAuth branch deliberately excludes the short-lived plaintext
+ * `accessToken` (re-minted on import via `/api/oauth/jira/refresh`); the
+ * token-mode branch carries the already-Worker-sealed API token + email.
+ */
+export function assembleCredentialBundle(): CredentialBundle {
+  const githubToken = token() ?? "";
+  const method = config.authMethod; // "oauth" | "pat"
+
+  const auth = jiraAuth();
+  let jira: CredentialBundle["jira"] = null;
+  if (config.jira?.enabled && auth) {
+    if (config.jira.authMethod === "oauth") {
+      jira = {
+        authMethod: "oauth",
+        sealedRefreshToken: auth.sealedRefreshToken,
+        cloudId: auth.cloudId,
+        siteUrl: auth.siteUrl,
+        siteName: auth.siteName,
+      };
+    } else {
+      jira = {
+        authMethod: "token",
+        sealedApiToken: auth.accessToken,
+        email: auth.email ?? config.jira.email ?? "",
+        cloudId: auth.cloudId,
+        siteUrl: auth.siteUrl,
+        siteName: auth.siteName,
+      };
+    }
+  }
+
+  return { github: { token: githubToken, method }, jira };
+}
+
+/**
+ * Orchestrates the encrypted-credentials export section:
+ *   1. generate a one-time code (client-side CSPRNG),
+ *   2. encrypt the JSON-stringified bundle WITH that code (client-side), THEN
+ *   3. seal ONLY that ciphertext server-side.
+ *
+ * ENCRYPT-THEN-SEAL ordering is load-bearing (see the plan's security review):
+ * `sealCredentialBundle` receives ONLY `encryptWithCode`'s ciphertext output,
+ * never the raw bundle. Returns the sealed blob + salt (both safe to store in the
+ * export file) and the one-time code (returned for one-time display, NEVER
+ * written into the export JSON).
+ */
+export async function buildEncryptedCredentialsSection(): Promise<{
+  sealed: string;
+  salt: string;
+  oneTimeCode: string;
+}> {
+  const bundle = assembleCredentialBundle();
+  const oneTimeCode = generateOneTimeCode();
+  const { ciphertext, salt } = await encryptWithCode(JSON.stringify(bundle), oneTimeCode);
+  const sealed = await sealCredentialBundle(ciphertext);
+  return { sealed, salt, oneTimeCode };
+}
+
+// ── Encrypted credentials import (Task 6) ────────────────────────────────────
+
+const IMPORT_DECRYPT_FAILED =
+  "Couldn't decrypt credentials — check the code and file match.";
+const IMPORT_GITHUB_INVALID =
+  "Imported GitHub credential is no longer valid — it may have been revoked, or the token/session has expired.";
+const IMPORT_INSECURE_CONTEXT =
+  "Encrypted credential import requires a secure context (HTTPS or localhost) — this page was loaded insecurely.";
+
+/**
+ * Resolves (validates — does NOT commit) imported credentials from an
+ * already-unsealed inner ciphertext. NON-mutating and retryable against a cached
+ * ciphertext: the single-use network unseal happens once in the caller (via
+ * `unsealCredentialBundle`); this only decrypts, schema-validates, and makes a
+ * read-only `GET /user` identity check, so wrong-code retries never re-hit the
+ * single-use endpoint.
+ *
+ * Failure messages: wrong-code and corrupted-file both surface the SAME generic
+ * message (uniform-failure security decision); a revoked/expired GitHub token
+ * (401 OR network failure) surfaces a distinct message; and the secure-context
+ * precondition — an environment condition, not a secret — is surfaced distinctly
+ * (R-001) up front so it isn't swallowed into a null that masquerades as a wrong
+ * code.
+ */
+export async function resolveImportedCredentials(
+  unsealedCiphertext: string,
+  salt: string,
+  code: string
+): Promise<
+  | { ok: true; bundle: CredentialBundle; identity: GitHubUser }
+  | { ok: false; error: string }
+> {
+  if (!crypto.subtle) {
+    return { ok: false, error: IMPORT_INSECURE_CONTEXT };
+  }
+
+  const decrypted = await decryptWithCode(unsealedCiphertext, salt, code);
+  if (decrypted === null) {
+    return { ok: false, error: IMPORT_DECRYPT_FAILED };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(decrypted);
+  } catch {
+    return { ok: false, error: IMPORT_DECRYPT_FAILED };
+  }
+
+  const bundleResult = CredentialBundleSchema.safeParse(parsedJson);
+  if (!bundleResult.success) {
+    return { ok: false, error: IMPORT_DECRYPT_FAILED };
+  }
+  const bundle = bundleResult.data;
+
+  let resp: Response;
+  try {
+    resp = await fetch("https://api.github.com/user", {
+      headers: { Authorization: `Bearer ${bundle.github.token}` },
+    });
+  } catch {
+    return { ok: false, error: IMPORT_GITHUB_INVALID };
+  }
+  if (!resp.ok) {
+    return { ok: false, error: IMPORT_GITHUB_INVALID };
+  }
+
+  const identity = (await resp.json()) as GitHubUser;
+  return { ok: true, bundle, identity };
+}
+
+/**
+ * Commits resolved credentials + imported config in a strict order. Called ONLY
+ * after user confirmation.
+ *
+ *   (a0) pre-auth (user() === null, the Login-page path): `await
+ *        clearIdentityData()` FIRST so a prior identity's IndexedDB cache + poll
+ *        state can't leak into the just-imported identity. On the Settings page
+ *        user() is non-null, so this is skipped and setAuthFromCredential's own
+ *        identity-switch reset handles isolation.
+ *   (a)  `setAuthFromCredential(token, identity)` — establishes the GitHub
+ *        session (auth-method-agnostic; runs the identity-switch reset cascade
+ *        when the login differs).
+ *   (b)  `setConfig(importedConfig)` — full replacement, AFTER (a) so the reset
+ *        cascade can't clobber the just-imported config (and this corrects the
+ *        transient `authMethod: "pat"` the cascade sets).
+ *   (c)  Jira restore — token-mode: build JiraAuthState locally (no network);
+ *        oauth-mode: POST /api/oauth/jira/refresh to mint a fresh access token.
+ *        Jira restore failure does NOT abort — GitHub identity/config are already
+ *        committed; it pushes a reconnect warning and returns jiraRestored:false.
+ */
+export async function commitImportedSettings(
+  resolved: { bundle: CredentialBundle; identity: GitHubUser },
+  importedConfig: Config
+): Promise<{ jiraRestored: boolean }> {
+  // (a0) pre-auth identity isolation — awaited, so the cache clear + reset
+  // callbacks fully complete before the new identity/config are established.
+  if (user() === null) {
+    await clearIdentityData();
+  }
+
+  // (a) establish the GitHub credential (used for BOTH pat and oauth methods).
+  setAuthFromCredential(resolved.bundle.github.token, resolved.identity);
+
+  // (b) apply the imported config wholesale AFTER identity is established.
+  setConfig(importedConfig);
+
+  // (c) restore Jira.
+  const jira = resolved.bundle.jira;
+  if (jira === null) {
+    return { jiraRestored: true };
+  }
+
+  if (jira.authMethod === "token") {
+    const state: JiraAuthState = {
+      accessToken: jira.sealedApiToken,
+      sealedRefreshToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      cloudId: jira.cloudId,
+      siteUrl: jira.siteUrl,
+      siteName: jira.siteName,
+      email: jira.email,
+    };
+    setJiraAuth(state);
+    return { jiraRestored: true };
+  }
+
+  // oauth-mode: mint a fresh access token from the sealed refresh token. Uses
+  // proxyFetch (X-Requested-With) — handleJiraTokenRefresh calls
+  // validateProxyRequest even though /api/oauth/* is not an isProxyPath route, so
+  // a bare fetch would 403. Body key is snake_case (endpoint contract), NOT the
+  // bundle's camelCase field name.
+  let resp: Response;
+  try {
+    resp = await proxyFetch("/api/oauth/jira/refresh", {
+      method: "POST",
+      body: JSON.stringify({ sealed_refresh_token: jira.sealedRefreshToken }),
+    });
+  } catch {
+    pushNotification(
+      "settings-import-jira",
+      "Your Jira connection couldn't be restored — please reconnect it in Settings.",
+      "warning"
+    );
+    return { jiraRestored: false };
+  }
+
+  if (!resp.ok) {
+    pushNotification(
+      "settings-import-jira",
+      "Your Jira connection couldn't be restored — please reconnect it in Settings.",
+      "warning"
+    );
+    return { jiraRestored: false };
+  }
+
+  const data = (await resp.json()) as {
+    access_token: string;
+    sealed_refresh_token: string;
+    expires_in: number;
+  };
+  const state: JiraAuthState = {
+    accessToken: data.access_token,
+    sealedRefreshToken: data.sealed_refresh_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+    cloudId: jira.cloudId,
+    siteUrl: jira.siteUrl,
+    siteName: jira.siteName,
+  };
+  setJiraAuth(state);
+  return { jiraRestored: true };
 }

--- a/src/app/lib/use-credential-import.ts
+++ b/src/app/lib/use-credential-import.ts
@@ -1,0 +1,173 @@
+import { createSignal } from "solid-js";
+import type { Config } from "../../shared/schemas";
+import type { GitHubUser } from "../stores/auth";
+import { parseImportFile, resolveImportedCredentials, CredentialsSectionSchema } from "./settings-transfer";
+import type { CredentialBundle, CredentialsSection } from "./settings-transfer";
+import { unsealCredentialBundle } from "./proxy";
+
+const READ_ERROR_MESSAGE = "Could not read that file — choose a valid settings export.";
+const DECRYPT_FAILED_MESSAGE = "Couldn't decrypt credentials — check the code and file match.";
+
+export interface ResolvedCredential {
+  bundle: CredentialBundle;
+  identity: GitHubUser;
+}
+
+export interface CreateCredentialImportOptions {
+  /** Terminal message shown when the single-use bundle has expired. Wording
+   *  differs slightly between the pre-auth (Login) and post-auth (Settings)
+   *  surfaces, so each caller supplies its own copy. */
+  expiredMessage: string;
+  /** The selected file could not be read (unreadable/binary file). */
+  onReadError: (message: string) => void;
+  /** parseImportFile rejected the file (malformed JSON / oversized / schema-invalid). */
+  onParseError: (message: string) => void;
+  /** The file parsed but carries no valid `_credentials` section. */
+  onNoCredentials: (config: Config) => void;
+  /** The one-time code resolved successfully against the (possibly cached) ciphertext. */
+  onResolved: (bundle: CredentialBundle, identity: GitHubUser, config: Config) => void;
+}
+
+/**
+ * Shared state machine behind the encrypted-credentials import flow, used by
+ * both the pre-auth Login page and the post-auth Settings page: file
+ * selection → detect an encrypted `_credentials` section → one-time-code
+ * entry → unseal (single network call) → resolve (retryable against the
+ * cached ciphertext). What happens once a credential resolves — show an
+ * identity-confirm step, commit immediately, or something else — is caller
+ * policy via `onResolved`.
+ */
+export function createCredentialImport(opts: CreateCredentialImportOptions) {
+  const [credImport, setCredImport] = createSignal<{ config: Config; credentials: CredentialsSection } | null>(null);
+  const [codeInput, setCodeInput] = createSignal("");
+  const [showCode, setShowCode] = createSignal(false);
+  const [unsealInFlight, setUnsealInFlight] = createSignal(false);
+  const [cachedCiphertext, setCachedCiphertext] = createSignal<string | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  const [terminalError, setTerminalError] = createSignal<string | null>(null);
+  const [resolvedCred, setResolvedCred] = createSignal<ResolvedCredential | null>(null);
+
+  // Generation counter tying an in-flight unseal/resolve to the file that started
+  // it (mirrors auth.ts's _crossTabFetchGen). Bumped on every reset and on every
+  // new file selection; handleCodeSubmit captures it before each await and bails
+  // if it changed, so a Cancel-then-reselect during the multi-second
+  // unseal/resolve window can't strand one file's ciphertext/credential into a
+  // different file's shared signals.
+  let gen = 0;
+
+  function reset() {
+    gen++;
+    setCredImport(null);
+    setCodeInput("");
+    setShowCode(false);
+    setUnsealInFlight(false);
+    setCachedCiphertext(null);
+    setError(null);
+    setTerminalError(null);
+    setResolvedCred(null);
+  }
+
+  async function handleFileSelected(file: File) {
+    reset();
+    let text: string;
+    try {
+      // A read rejection (unreadable/binary file) is treated identically to a
+      // parse failure below — same outcome, no confirmation shown.
+      text = await file.text();
+    } catch {
+      opts.onReadError(READ_ERROR_MESSAGE);
+      return;
+    }
+    const result = parseImportFile(text);
+    if (!result.ok) {
+      opts.onParseError(`Import failed: ${result.errors[0] ?? "invalid settings file"}`);
+      return;
+    }
+    // Detect an encrypted-credentials section via schema validation (NOT a bare
+    // "in" check — a hand-crafted `_credentials: null` would pass that and then
+    // throw on dereference). A malformed/null/non-object one falls through to
+    // the no-credentials callback.
+    const rawCreds =
+      result.rawJson && typeof result.rawJson === "object"
+        ? (result.rawJson as Record<string, unknown>)._credentials
+        : undefined;
+    const credSection = CredentialsSectionSchema.safeParse(rawCreds);
+    if (!credSection.success) {
+      opts.onNoCredentials(result.config);
+      return;
+    }
+    setCredImport({ config: result.config, credentials: credSection.data });
+  }
+
+  async function handleCodeSubmit() {
+    if (unsealInFlight()) return; // in-flight guard: exactly one network unseal
+    const cred = credImport();
+    if (!cred) return;
+    const code = codeInput();
+    setError(null);
+    const capturedGen = gen; // capture before the first await
+
+    let ciphertext = cachedCiphertext();
+    if (ciphertext === null) {
+      // FIRST submission — single-use network unseal (consumes the bundle nonce
+      // server-side). Never retried; wrong-code retries run against the cache.
+      setUnsealInFlight(true);
+      const res = await unsealCredentialBundle(cred.credentials.sealed).finally(() =>
+        setUnsealInFlight(false)
+      );
+      // A changed generation means a Cancel-then-reselect started a different
+      // file while this await was pending; writing any signal now would strand
+      // this file's result into the newly-selected file's state, so stop here.
+      if (capturedGen !== gen) return;
+      if (!res.ok) {
+        if (res.reason === "turnstile" || res.reason === "network" || res.reason === "rate-limited") {
+          // Pre-nonce-consumption failure — the single-use nonce was NOT
+          // consumed, so this is retryable. Keep the code prompt available (do
+          // NOT fall through to the terminal "continue without credentials"
+          // screen); surface a retryable inline message.
+          setError(
+            res.reason === "rate-limited"
+              ? "Too many attempts — wait a moment and try again."
+              : res.reason === "network"
+                ? "Network problem — please try again."
+                : "Verification failed — please try again."
+          );
+          return;
+        }
+        setTerminalError(res.reason === "expired" ? opts.expiredMessage : DECRYPT_FAILED_MESSAGE);
+        return;
+      }
+      ciphertext = res.ciphertext;
+      setCachedCiphertext(ciphertext);
+    }
+
+    // Client-side, retryable against the cached ciphertext (no re-unseal).
+    const resolved = await resolveImportedCredentials(ciphertext, cred.credentials.salt, code);
+    // The resolve await is another window where a Cancel-then-reselect can change
+    // the generation (unsealInFlight is false here); discard the result if so.
+    if (capturedGen !== gen) return;
+    if (!resolved.ok) {
+      setError(resolved.error);
+      return;
+    }
+    opts.onResolved(resolved.bundle, resolved.identity, cred.config);
+  }
+
+  return {
+    credImport,
+    codeInput,
+    setCodeInput,
+    showCode,
+    setShowCode,
+    unsealInFlight,
+    error,
+    terminalError,
+    resolvedCred,
+    setResolvedCred,
+    reset,
+    handleFileSelected,
+    handleCodeSubmit,
+  };
+}
+
+export type CredentialImport = ReturnType<typeof createCredentialImport>;

--- a/src/app/lib/use-credential-import.ts
+++ b/src/app/lib/use-credential-import.ts
@@ -6,7 +6,8 @@ import type { CredentialBundle, CredentialsSection } from "./settings-transfer";
 import { unsealCredentialBundle } from "./proxy";
 
 const READ_ERROR_MESSAGE = "Could not read that file — choose a valid settings export.";
-const DECRYPT_FAILED_MESSAGE = "Couldn't decrypt credentials — check the code and file match.";
+const DECRYPT_FAILED_MESSAGE =
+  "Couldn't restore credentials — this file may already have been used (single-use), or the code/file don't match. Re-export to try again.";
 
 export interface ResolvedCredential {
   bundle: CredentialBundle;

--- a/src/app/lib/use-credential-import.ts
+++ b/src/app/lib/use-credential-import.ts
@@ -22,10 +22,19 @@ export interface CreateCredentialImportOptions {
   onReadError: (message: string) => void;
   /** parseImportFile rejected the file (malformed JSON / oversized / schema-invalid). */
   onParseError: (message: string) => void;
-  /** The file parsed but carries no valid `_credentials` section. */
-  onNoCredentials: (config: Config) => void;
-  /** The one-time code resolved successfully against the (possibly cached) ciphertext. */
-  onResolved: (bundle: CredentialBundle, identity: GitHubUser, config: Config) => void;
+  /**
+   * The file parsed but carries no valid `_credentials` section.
+   * `viewPreferences` is the file's raw (unvalidated) `_viewPreferences`
+   * section, if present — pass it straight through to `applyImportedViewState`
+   * at whatever point the caller commits `config`; it's total/no-throw so
+   * passing `undefined` when absent is safe.
+   */
+  onNoCredentials: (config: Config, viewPreferences: unknown) => void;
+  /**
+   * The one-time code resolved successfully against the (possibly cached)
+   * ciphertext. `viewPreferences` — see `onNoCredentials` above.
+   */
+  onResolved: (bundle: CredentialBundle, identity: GitHubUser, config: Config, viewPreferences: unknown) => void;
 }
 
 /**
@@ -38,7 +47,7 @@ export interface CreateCredentialImportOptions {
  * policy via `onResolved`.
  */
 export function createCredentialImport(opts: CreateCredentialImportOptions) {
-  const [credImport, setCredImport] = createSignal<{ config: Config; credentials: CredentialsSection } | null>(null);
+  const [credImport, setCredImport] = createSignal<{ config: Config; credentials: CredentialsSection; viewPreferences: unknown } | null>(null);
   const [codeInput, setCodeInput] = createSignal("");
   const [showCode, setShowCode] = createSignal(false);
   const [unsealInFlight, setUnsealInFlight] = createSignal(false);
@@ -87,16 +96,19 @@ export function createCredentialImport(opts: CreateCredentialImportOptions) {
     // "in" check — a hand-crafted `_credentials: null` would pass that and then
     // throw on dereference). A malformed/null/non-object one falls through to
     // the no-credentials callback.
-    const rawCreds =
+    const rawFile =
       result.rawJson && typeof result.rawJson === "object"
-        ? (result.rawJson as Record<string, unknown>)._credentials
+        ? (result.rawJson as Record<string, unknown>)
         : undefined;
-    const credSection = CredentialsSectionSchema.safeParse(rawCreds);
+    // Raw (unvalidated) — applyImportedViewState (called by whatever the
+    // caller commits config through) validates it, total/no-throw.
+    const viewPreferences = rawFile?._viewPreferences;
+    const credSection = CredentialsSectionSchema.safeParse(rawFile?._credentials);
     if (!credSection.success) {
-      opts.onNoCredentials(result.config);
+      opts.onNoCredentials(result.config, viewPreferences);
       return;
     }
-    setCredImport({ config: result.config, credentials: credSection.data });
+    setCredImport({ config: result.config, credentials: credSection.data, viewPreferences });
   }
 
   async function handleCodeSubmit() {
@@ -150,7 +162,7 @@ export function createCredentialImport(opts: CreateCredentialImportOptions) {
       setError(resolved.error);
       return;
     }
-    opts.onResolved(resolved.bundle, resolved.identity, cred.config);
+    opts.onResolved(resolved.bundle, resolved.identity, cred.config, cred.viewPreferences);
   }
 
   return {

--- a/src/app/pages/JiraCallback.tsx
+++ b/src/app/pages/JiraCallback.tsx
@@ -96,9 +96,7 @@ export default function JiraCallback() {
 
     // Acquire Turnstile token before exchange. Action MUST be "jira-token" to
     // match the Worker's verifyTurnstile(..., "jira-token") check for
-    // /api/oauth/jira/token (src/worker/index.ts) — previously this inherited the
-    // hardcoded "seal" default, a pre-existing mismatch fixed here now that
-    // acquireTurnstileToken takes an explicit action.
+    // /api/oauth/jira/token (src/worker/index.ts).
     let turnstileToken: string;
     try {
       turnstileToken = await acquireTurnstileToken(import.meta.env.VITE_TURNSTILE_SITE_KEY as string ?? "", "jira-token");

--- a/src/app/pages/JiraCallback.tsx
+++ b/src/app/pages/JiraCallback.tsx
@@ -94,10 +94,14 @@ export default function JiraCallback() {
       return;
     }
 
-    // Acquire Turnstile token before exchange
+    // Acquire Turnstile token before exchange. Action MUST be "jira-token" to
+    // match the Worker's verifyTurnstile(..., "jira-token") check for
+    // /api/oauth/jira/token (src/worker/index.ts) — previously this inherited the
+    // hardcoded "seal" default, a pre-existing mismatch fixed here now that
+    // acquireTurnstileToken takes an explicit action.
     let turnstileToken: string;
     try {
-      turnstileToken = await acquireTurnstileToken(import.meta.env.VITE_TURNSTILE_SITE_KEY as string ?? "");
+      turnstileToken = await acquireTurnstileToken(import.meta.env.VITE_TURNSTILE_SITE_KEY as string ?? "", "jira-token");
     } catch (err) {
       Sentry.captureException(err, { tags: { source: "jira-callback-turnstile" } });
       setError("Human verification failed. Please try again.");

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -390,7 +390,7 @@ export default function LoginPage() {
                             class="input input-bordered input-sm w-full font-mono"
                             aria-label="One-time code"
                             autocomplete="off"
-                            placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                            placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XX"
                             value={credentialImport.codeInput()}
                             onInput={(e) => credentialImport.setCodeInput(e.currentTarget.value)}
                           />

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -92,15 +92,21 @@ export default function LoginPage() {
 
   // ── Import handlers ──────────────────────────────────────────────────────────
 
-  async function finalizeImport(bundle: CredentialBundle, identity: GitHubUser, importedConfig: Config) {
+  async function finalizeImport(
+    bundle: CredentialBundle,
+    identity: GitHubUser,
+    importedConfig: Config,
+    viewPreferences: unknown
+  ) {
     if (importCommitting()) return;
     setImportCommitting(true);
     setImportError(null);
     try {
       // commitImportedSettings awaits clearIdentityData() first when user() is
       // null (pre-auth) — clearing a prior identity's IndexedDB cache + poll
-      // state BEFORE the imported identity/config are established.
-      await commitImportedSettings({ bundle, identity }, importedConfig);
+      // state BEFORE the imported identity/config/view-preferences are
+      // established.
+      await commitImportedSettings({ bundle, identity }, importedConfig, viewPreferences);
       navigate("/", { replace: true });
     } catch {
       setImportError("Something went wrong finishing the import — please try again.");
@@ -121,7 +127,7 @@ export default function LoginPage() {
         "This export doesn't contain credentials — sign in normally first, then use Import on the Settings page to restore your configuration."
       );
     },
-    onResolved: (bundle, identity, importedConfig) => {
+    onResolved: (bundle, identity, importedConfig, viewPreferences) => {
       if (hasExistingLocalConfig(config)) {
         // Prior local state to protect — confirm the identity switch first.
         // Clear any error from a prior failed attempt so it can't render stale
@@ -131,7 +137,7 @@ export default function LoginPage() {
         return;
       }
       // Genuinely fresh/incognito session — skip the dialog, commit straight through.
-      void finalizeImport(bundle, identity, importedConfig);
+      void finalizeImport(bundle, identity, importedConfig, viewPreferences);
     },
   });
 
@@ -164,7 +170,7 @@ export default function LoginPage() {
     const cred = credentialImport.credImport();
     const rc = credentialImport.resolvedCred();
     if (!cred || !rc) return;
-    await finalizeImport(rc.bundle, rc.identity, cred.config);
+    await finalizeImport(rc.bundle, rc.identity, cred.config, cred.viewPreferences);
   }
 
   return (

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -1,13 +1,24 @@
-import { createSignal, onMount, Show } from "solid-js";
+import { createSignal, onMount, Show, Switch, Match } from "solid-js";
 import * as Sentry from "@sentry/solid";
 import { useNavigate } from "@solidjs/router";
 import { setAuthFromPat, type GitHubUser } from "../stores/auth";
+import { config } from "../stores/config";
+import type { Config } from "../../shared/schemas";
 import {
   isValidPatFormat,
   GITHUB_PAT_URL,
   GITHUB_FINE_GRAINED_PAT_URL,
 } from "../lib/pat";
 import { buildAuthorizeUrl } from "../lib/oauth";
+import { unsealCredentialBundle } from "../lib/proxy";
+import {
+  parseImportFile,
+  resolveImportedCredentials,
+  commitImportedSettings,
+  hasExistingLocalConfig,
+  CredentialsSectionSchema,
+} from "../lib/settings-transfer";
+import type { CredentialBundle, CredentialsSection } from "../lib/settings-transfer";
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -29,6 +40,27 @@ export default function LoginPage() {
   const [patInput, setPatInput] = createSignal("");
   const [patError, setPatError] = createSignal<string | null>(null);
   const [submitting, setSubmitting] = createSignal(false);
+
+  // ── Import from backup (pre-auth, Task 7) ────────────────────────────────────
+  // This is a SIBLING entry point to the PAT-form toggle. It has its OWN local
+  // error area because patError()'s <p id="pat-error"> lives only inside the
+  // PAT-form branch and never renders here; and pushNotification()/ToastContainer
+  // only mount inside the authenticated app shell (Header), so a pre-auth toast
+  // would be silently invisible — all errors here MUST use this local area.
+  const [showImport, setShowImport] = createSignal(false);
+  const [importError, setImportError] = createSignal<string | null>(null);
+  // Set when the selected file parses AND carries a valid _credentials section.
+  const [credImport, setCredImport] = createSignal<{ config: Config; credentials: CredentialsSection } | null>(null);
+  const [codeInput, setCodeInput] = createSignal("");
+  const [showCode, setShowCode] = createSignal(false);
+  const [unsealInFlight, setUnsealInFlight] = createSignal(false);
+  const [cachedCiphertext, setCachedCiphertext] = createSignal<string | null>(null);
+  // A terminal (non-retryable) message: the single-use bundle is spent
+  // (expired/invalid) — the code prompt is withdrawn.
+  const [credTerminal, setCredTerminal] = createSignal<string | null>(null);
+  const [resolvedCred, setResolvedCred] = createSignal<{ bundle: CredentialBundle; identity: GitHubUser } | null>(null);
+  const [importCommitting, setImportCommitting] = createSignal(false);
+  let importInputRef: HTMLInputElement | undefined;
 
   function handleLogin() {
     window.location.href = buildAuthorizeUrl();
@@ -74,14 +106,204 @@ export default function LoginPage() {
     }
   }
 
+  // ── Import handlers ──────────────────────────────────────────────────────────
+
+  function resetImportState() {
+    setCredImport(null);
+    setCodeInput("");
+    setShowCode(false);
+    setUnsealInFlight(false);
+    setCachedCiphertext(null);
+    setCredTerminal(null);
+    setResolvedCred(null);
+    setImportError(null);
+  }
+
+  function openImport() {
+    setShowPatForm(false);
+    setPatError(null);
+    setPatInput("");
+    resetImportState();
+    setShowImport(true);
+  }
+
+  function closeImport() {
+    setShowImport(false);
+    resetImportState();
+  }
+
+  async function handleImportFileSelected(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    // Allow re-selecting the same file (change won't fire otherwise).
+    try { input.value = ""; } catch { /* ignore if unsupported */ }
+    if (!file) return;
+    resetImportState();
+    let text: string;
+    try {
+      // A read rejection (unreadable/binary file) is treated the same as a parse
+      // failure — surfaced in the local error area (never pushNotification).
+      text = await file.text();
+    } catch {
+      setImportError("Could not read that file — choose a valid settings export.");
+      return;
+    }
+    const result = parseImportFile(text);
+    if (!result.ok) {
+      // Case (a): malformed JSON / oversized / schema-invalid.
+      setImportError(`Import failed: ${result.errors[0] ?? "invalid settings file"}`);
+      return;
+    }
+    // Detect a credentials section via schema validation (NOT a bare "in" check —
+    // a hand-crafted `_credentials: null` would pass that and then throw on
+    // dereference). A malformed/null/non-object one is treated as case (b).
+    const rawCreds =
+      result.rawJson && typeof result.rawJson === "object"
+        ? (result.rawJson as Record<string, unknown>)._credentials
+        : undefined;
+    const credSection = CredentialsSectionSchema.safeParse(rawCreds);
+    if (!credSection.success) {
+      // Case (b): a valid export with NO credentials — the Login page can only
+      // auto-login from a credentials-bearing file. Point the user at the normal
+      // sign-in + Settings-page import path.
+      setImportError(
+        "This export doesn't contain credentials — sign in normally first, then use Import on the Settings page to restore your configuration."
+      );
+      return;
+    }
+    // Case (c): valid _credentials — prompt for the one-time code (Step 3).
+    setCredImport({ config: result.config, credentials: credSection.data });
+  }
+
+  async function finalizeImport(bundle: CredentialBundle, identity: GitHubUser, importedConfig: Config) {
+    if (importCommitting()) return;
+    setImportCommitting(true);
+    try {
+      // commitImportedSettings awaits clearIdentityData() first when user() is
+      // null (pre-auth) — clearing a prior identity's IndexedDB cache + poll
+      // state BEFORE the imported identity/config are established.
+      await commitImportedSettings({ bundle, identity }, importedConfig);
+      navigate("/", { replace: true });
+    } catch {
+      setImportError("Something went wrong finishing the import — please try again.");
+    } finally {
+      setImportCommitting(false);
+    }
+  }
+
+  async function handleImportCodeSubmit(e?: Event) {
+    e?.preventDefault();
+    if (unsealInFlight()) return; // in-flight guard: exactly one network unseal
+    const ci = credImport();
+    if (!ci) return;
+    const code = codeInput();
+    setImportError(null);
+
+    let ciphertext = cachedCiphertext();
+    if (ciphertext === null) {
+      // FIRST submission — single-use network unseal (consumes the bundle nonce
+      // server-side). Never retried; wrong-code retries run against the cache.
+      setUnsealInFlight(true);
+      const res = await unsealCredentialBundle(ci.credentials.sealed).finally(() =>
+        setUnsealInFlight(false)
+      );
+      if (!res.ok) {
+        if (res.reason === "turnstile") {
+          // Client-side Turnstile hiccup BEFORE any request — the nonce was NOT
+          // consumed, so this is retryable. Keep the code prompt available and
+          // show a retryable inline message (R-101).
+          setImportError("Verification failed — please try again.");
+          return;
+        }
+        // expired/invalid are terminal — the single-use bundle is spent. Show the
+        // message and withdraw the code prompt (re-export to retry).
+        setCredTerminal(
+          res.reason === "expired"
+            ? "This export's credentials have expired — re-export from a machine where you're still signed in, then try again."
+            : "Couldn't decrypt credentials — check the code and file match."
+        );
+        return;
+      }
+      ciphertext = res.ciphertext;
+      setCachedCiphertext(ciphertext);
+    }
+
+    // Client-side, retryable against the cached ciphertext (no re-unseal).
+    const resolved = await resolveImportedCredentials(ciphertext, ci.credentials.salt, code);
+    if (!resolved.ok) {
+      setImportError(resolved.error);
+      return;
+    }
+
+    if (hasExistingLocalConfig(config)) {
+      // Prior local state to protect — confirm the identity switch first.
+      setResolvedCred({ bundle: resolved.bundle, identity: resolved.identity });
+      return;
+    }
+    // Genuinely fresh/incognito session — skip the dialog, commit straight through.
+    await finalizeImport(resolved.bundle, resolved.identity, ci.config);
+  }
+
+  async function handleConfirmImport() {
+    const ci = credImport();
+    const rc = resolvedCred();
+    if (!ci || !rc) return;
+    await finalizeImport(rc.bundle, rc.identity, ci.config);
+  }
+
   return (
     <div class="bg-base-200 min-h-screen flex items-center justify-center">
       <div class="card bg-base-100 shadow-xl max-w-sm w-full mx-4">
         <div class="card-body items-center text-center gap-6">
 
-          <Show
-            when={!showPatForm()}
+          <Switch
             fallback={
+              <>
+                <div class="flex flex-col items-center gap-2">
+                  <h1 class="card-title text-2xl">
+                    GitHub Tracker
+                  </h1>
+                  <p class="text-sm text-base-content/60 text-center">
+                    Track issues, pull requests, and workflow runs across your GitHub
+                    repositories.
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={handleLogin}
+                  class="btn btn-neutral w-full"
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    class="w-5 h-5"
+                    aria-hidden="true"
+                    fill="currentColor"
+                  >
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                  </svg>
+                  Sign in with GitHub
+                </button>
+
+                <div class="divider text-xs text-base-content/40">or</div>
+                <button
+                  type="button"
+                  onClick={() => setShowPatForm(true)}
+                  class="link link-primary text-sm"
+                >
+                  Use a Personal Access Token
+                </button>
+                <button
+                  type="button"
+                  onClick={openImport}
+                  class="link link-primary text-sm"
+                >
+                  Import from backup
+                </button>
+              </>
+            }
+          >
+            <Match when={showPatForm()}>
               <form onSubmit={(e) => void handlePatSubmit(e)} class="w-full flex flex-col gap-4">
                 <h2 class="card-title">Sign in with Token</h2>
 
@@ -155,43 +377,136 @@ export default function LoginPage() {
                   Use OAuth instead
                 </button>
               </form>
-            }
-          >
-            <div class="flex flex-col items-center gap-2">
-              <h1 class="card-title text-2xl">
-                GitHub Tracker
-              </h1>
-              <p class="text-sm text-base-content/60 text-center">
-                Track issues, pull requests, and workflow runs across your GitHub
-                repositories.
-              </p>
-            </div>
+            </Match>
 
-            <button
-              type="button"
-              onClick={handleLogin}
-              class="btn btn-neutral w-full"
-            >
-              <svg
-                viewBox="0 0 16 16"
-                class="w-5 h-5"
-                aria-hidden="true"
-                fill="currentColor"
-              >
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-              </svg>
-              Sign in with GitHub
-            </button>
+            <Match when={showImport()}>
+              <div class="w-full flex flex-col gap-4">
+                <h2 class="card-title">Import from backup</h2>
 
-            <div class="divider text-xs text-base-content/40">or</div>
-            <button
-              type="button"
-              onClick={() => setShowPatForm(true)}
-              class="link link-primary text-sm"
-            >
-              Use a Personal Access Token
-            </button>
-          </Show>
+                <Switch
+                  fallback={
+                    <>
+                      <p class="text-sm text-base-content/70 text-left">
+                        Restore your settings and sign in from a previously exported backup file.
+                      </p>
+                      <input
+                        ref={importInputRef}
+                        type="file"
+                        accept="application/json,.json"
+                        class="hidden"
+                        aria-label="Import backup file"
+                        onChange={(e) => void handleImportFileSelected(e)}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => importInputRef?.click()}
+                        class="btn btn-neutral w-full"
+                      >
+                        Choose backup file
+                      </button>
+                      <Show when={importError()}>
+                        <p role="alert" class="text-error text-xs text-left">{importError()}</p>
+                      </Show>
+                      <button
+                        type="button"
+                        onClick={closeImport}
+                        class="link link-primary text-sm"
+                      >
+                        Back to sign in
+                      </button>
+                    </>
+                  }
+                >
+                  <Match when={resolvedCred()}>
+                    {(rc) => (
+                      <div class="flex flex-col gap-4">
+                        <div class="flex items-center gap-3 text-left">
+                          <img
+                            src={rc().identity.avatar_url}
+                            alt=""
+                            class="h-10 w-10 rounded-full"
+                          />
+                          <p class="text-sm">
+                            This will sign you in as <strong>@{rc().identity.login}</strong> and
+                            replace your current settings — continue?
+                          </p>
+                        </div>
+                        <div class="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={() => void handleConfirmImport()}
+                            disabled={importCommitting()}
+                            aria-busy={importCommitting()}
+                            class="btn btn-sm btn-primary flex-1"
+                          >
+                            {importCommitting() ? "Importing..." : "Continue"}
+                          </button>
+                          <button type="button" onClick={closeImport} class="btn btn-sm btn-ghost">
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </Match>
+
+                  <Match when={credImport()}>
+                    <Show
+                      when={!credTerminal()}
+                      fallback={
+                        <div class="flex flex-col gap-4">
+                          <p role="alert" class="text-error text-xs text-left">{credTerminal()}</p>
+                          <button type="button" onClick={closeImport} class="btn btn-sm btn-neutral">
+                            Back to sign in
+                          </button>
+                        </div>
+                      }
+                    >
+                      <form onSubmit={(e) => void handleImportCodeSubmit(e)} class="flex flex-col gap-4">
+                        <p class="text-sm text-base-content/70 text-left">
+                          Enter the one-time code shown when this file was exported.
+                        </p>
+                        <div class="flex items-center gap-2">
+                          <input
+                            type={showCode() ? "text" : "password"}
+                            class="input input-bordered input-sm w-full font-mono"
+                            aria-label="One-time code"
+                            autocomplete="off"
+                            placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+                            value={codeInput()}
+                            onInput={(e) => setCodeInput(e.currentTarget.value)}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => setShowCode((v) => !v)}
+                            class="btn btn-sm btn-ghost"
+                            aria-pressed={showCode()}
+                          >
+                            {showCode() ? "Hide" : "Show"}
+                          </button>
+                        </div>
+                        <Show when={importError()}>
+                          <p role="alert" class="text-error text-xs text-left">{importError()}</p>
+                        </Show>
+                        <div class="flex gap-2">
+                          <button
+                            type="submit"
+                            disabled={unsealInFlight()}
+                            aria-busy={unsealInFlight()}
+                            class="btn btn-sm btn-primary flex-1"
+                          >
+                            {unsealInFlight() ? "Checking..." : "Restore credentials"}
+                          </button>
+                          <button type="button" onClick={closeImport} class="btn btn-sm btn-ghost">
+                            Cancel
+                          </button>
+                        </div>
+                      </form>
+                    </Show>
+                  </Match>
+                </Switch>
+              </div>
+            </Match>
+          </Switch>
 
         </div>
       </div>

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -10,15 +10,9 @@ import {
   GITHUB_FINE_GRAINED_PAT_URL,
 } from "../lib/pat";
 import { buildAuthorizeUrl } from "../lib/oauth";
-import { unsealCredentialBundle } from "../lib/proxy";
-import {
-  parseImportFile,
-  resolveImportedCredentials,
-  commitImportedSettings,
-  hasExistingLocalConfig,
-  CredentialsSectionSchema,
-} from "../lib/settings-transfer";
-import type { CredentialBundle, CredentialsSection } from "../lib/settings-transfer";
+import { commitImportedSettings, hasExistingLocalConfig } from "../lib/settings-transfer";
+import type { CredentialBundle } from "../lib/settings-transfer";
+import { createCredentialImport } from "../lib/use-credential-import";
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -41,7 +35,7 @@ export default function LoginPage() {
   const [patError, setPatError] = createSignal<string | null>(null);
   const [submitting, setSubmitting] = createSignal(false);
 
-  // ── Import from backup (pre-auth, Task 7) ────────────────────────────────────
+  // ── Import from backup (pre-auth) ─────────────────────────────────────────
   // This is a SIBLING entry point to the PAT-form toggle. It has its OWN local
   // error area because patError()'s <p id="pat-error"> lives only inside the
   // PAT-form branch and never renders here; and pushNotification()/ToastContainer
@@ -49,16 +43,6 @@ export default function LoginPage() {
   // would be silently invisible — all errors here MUST use this local area.
   const [showImport, setShowImport] = createSignal(false);
   const [importError, setImportError] = createSignal<string | null>(null);
-  // Set when the selected file parses AND carries a valid _credentials section.
-  const [credImport, setCredImport] = createSignal<{ config: Config; credentials: CredentialsSection } | null>(null);
-  const [codeInput, setCodeInput] = createSignal("");
-  const [showCode, setShowCode] = createSignal(false);
-  const [unsealInFlight, setUnsealInFlight] = createSignal(false);
-  const [cachedCiphertext, setCachedCiphertext] = createSignal<string | null>(null);
-  // A terminal (non-retryable) message: the single-use bundle is spent
-  // (expired/invalid) — the code prompt is withdrawn.
-  const [credTerminal, setCredTerminal] = createSignal<string | null>(null);
-  const [resolvedCred, setResolvedCred] = createSignal<{ bundle: CredentialBundle; identity: GitHubUser } | null>(null);
   const [importCommitting, setImportCommitting] = createSignal(false);
   let importInputRef: HTMLInputElement | undefined;
 
@@ -108,86 +92,10 @@ export default function LoginPage() {
 
   // ── Import handlers ──────────────────────────────────────────────────────────
 
-  // Generation counter tying an in-flight unseal/resolve to the file that started
-  // it (mirrors auth.ts's _crossTabFetchGen). Bumped on every reset and on every
-  // new file selection; the submit handler captures it before each await and
-  // bails if it changed, so a Cancel-then-reselect during the multi-second
-  // unseal/resolve window can't strand one file's ciphertext/credential into a
-  // different file's shared signals — which pre-auth would auto-login the
-  // abandoned file's identity.
-  let unsealGen = 0;
-
-  function resetImportState() {
-    unsealGen++;
-    setCredImport(null);
-    setCodeInput("");
-    setShowCode(false);
-    setUnsealInFlight(false);
-    setCachedCiphertext(null);
-    setCredTerminal(null);
-    setResolvedCred(null);
-    setImportError(null);
-  }
-
-  function openImport() {
-    setShowPatForm(false);
-    setPatError(null);
-    setPatInput("");
-    resetImportState();
-    setShowImport(true);
-  }
-
-  function closeImport() {
-    setShowImport(false);
-    resetImportState();
-  }
-
-  async function handleImportFileSelected(e: Event) {
-    const input = e.currentTarget as HTMLInputElement;
-    const file = input.files?.[0];
-    // Allow re-selecting the same file (change won't fire otherwise).
-    try { input.value = ""; } catch { /* ignore if unsupported */ }
-    if (!file) return;
-    resetImportState();
-    let text: string;
-    try {
-      // A read rejection (unreadable/binary file) is treated the same as a parse
-      // failure — surfaced in the local error area (never pushNotification).
-      text = await file.text();
-    } catch {
-      setImportError("Could not read that file — choose a valid settings export.");
-      return;
-    }
-    const result = parseImportFile(text);
-    if (!result.ok) {
-      // Case (a): malformed JSON / oversized / schema-invalid.
-      setImportError(`Import failed: ${result.errors[0] ?? "invalid settings file"}`);
-      return;
-    }
-    // Detect a credentials section via schema validation (NOT a bare "in" check —
-    // a hand-crafted `_credentials: null` would pass that and then throw on
-    // dereference). A malformed/null/non-object one is treated as case (b).
-    const rawCreds =
-      result.rawJson && typeof result.rawJson === "object"
-        ? (result.rawJson as Record<string, unknown>)._credentials
-        : undefined;
-    const credSection = CredentialsSectionSchema.safeParse(rawCreds);
-    if (!credSection.success) {
-      // Case (b): a valid export with NO credentials — the Login page can only
-      // auto-login from a credentials-bearing file. Point the user at the normal
-      // sign-in + Settings-page import path.
-      setImportError(
-        "This export doesn't contain credentials — sign in normally first, then use Import on the Settings page to restore your configuration."
-      );
-      return;
-    }
-    // Case (c): valid _credentials — prompt for the one-time code (Step 3).
-    setCredImport({ config: result.config, credentials: credSection.data });
-  }
-
   async function finalizeImport(bundle: CredentialBundle, identity: GitHubUser, importedConfig: Config) {
     if (importCommitting()) return;
     setImportCommitting(true);
+    setImportError(null);
     try {
       // commitImportedSettings awaits clearIdentityData() first when user() is
       // null (pre-auth) — clearing a prior identity's IndexedDB cache + poll
@@ -201,78 +109,62 @@ export default function LoginPage() {
     }
   }
 
-  async function handleImportCodeSubmit(e?: Event) {
-    e?.preventDefault();
-    if (unsealInFlight()) return; // in-flight guard: exactly one network unseal
-    const ci = credImport();
-    if (!ci) return;
-    const code = codeInput();
-    setImportError(null);
-    const gen = unsealGen; // capture before the first await
-
-    let ciphertext = cachedCiphertext();
-    if (ciphertext === null) {
-      // FIRST submission — single-use network unseal (consumes the bundle nonce
-      // server-side). Never retried; wrong-code retries run against the cache.
-      setUnsealInFlight(true);
-      const res = await unsealCredentialBundle(ci.credentials.sealed).finally(() =>
-        setUnsealInFlight(false)
+  const credentialImport = createCredentialImport({
+    expiredMessage:
+      "This export's credentials have expired — re-export from a machine where you're still signed in, then try again.",
+    onReadError: (message) => setImportError(message),
+    onParseError: (message) => setImportError(message),
+    onNoCredentials: () => {
+      // The Login page can only auto-login from a credentials-bearing file.
+      // Point the user at the normal sign-in + Settings-page import path.
+      setImportError(
+        "This export doesn't contain credentials — sign in normally first, then use Import on the Settings page to restore your configuration."
       );
-      // A changed unsealGen means a Cancel-then-reselect started a different file
-      // while this await was pending; writing any signal now (or auto-logging in)
-      // would use the abandoned file's identity, so stop here.
-      if (gen !== unsealGen) return;
-      if (!res.ok) {
-        if (res.reason === "turnstile" || res.reason === "network" || res.reason === "rate-limited") {
-          // Pre-nonce-consumption failure — the nonce was NOT consumed, so this
-          // is retryable. Keep the code prompt available and show a retryable
-          // inline message (do NOT withdraw the prompt).
-          setImportError(
-            res.reason === "rate-limited"
-              ? "Too many attempts — wait a moment and try again."
-              : res.reason === "network"
-                ? "Network problem — please try again."
-                : "Verification failed — please try again."
-          );
-          return;
-        }
-        // expired/invalid are terminal — the single-use bundle is spent. Show the
-        // message and withdraw the code prompt (re-export to retry).
-        setCredTerminal(
-          res.reason === "expired"
-            ? "This export's credentials have expired — re-export from a machine where you're still signed in, then try again."
-            : "Couldn't decrypt credentials — check the code and file match."
-        );
+    },
+    onResolved: (bundle, identity, importedConfig) => {
+      if (hasExistingLocalConfig(config)) {
+        // Prior local state to protect — confirm the identity switch first.
+        // Clear any error from a prior failed attempt so it can't render stale
+        // in the identity-confirm step's alert.
+        setImportError(null);
+        credentialImport.setResolvedCred({ bundle, identity });
         return;
       }
-      ciphertext = res.ciphertext;
-      setCachedCiphertext(ciphertext);
-    }
+      // Genuinely fresh/incognito session — skip the dialog, commit straight through.
+      void finalizeImport(bundle, identity, importedConfig);
+    },
+  });
 
-    // Client-side, retryable against the cached ciphertext (no re-unseal).
-    const resolved = await resolveImportedCredentials(ciphertext, ci.credentials.salt, code);
-    // The resolve await is another window where a Cancel-then-reselect can change
-    // unsealGen (unsealInFlight is false here); discard the result if so.
-    if (gen !== unsealGen) return;
-    if (!resolved.ok) {
-      setImportError(resolved.error);
-      return;
-    }
+  function openImport() {
+    setShowPatForm(false);
+    setPatError(null);
+    setPatInput("");
+    setImportError(null);
+    credentialImport.reset();
+    setShowImport(true);
+  }
 
-    if (hasExistingLocalConfig(config)) {
-      // Prior local state to protect — confirm the identity switch first.
-      setResolvedCred({ bundle: resolved.bundle, identity: resolved.identity });
-      return;
-    }
-    // Genuinely fresh/incognito session — skip the dialog, commit straight through.
-    await finalizeImport(resolved.bundle, resolved.identity, ci.config);
+  function closeImport() {
+    setShowImport(false);
+    setImportError(null);
+    credentialImport.reset();
+  }
+
+  async function handleImportFileSelected(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    // Allow re-selecting the same file (change won't fire otherwise).
+    try { input.value = ""; } catch { /* ignore if unsupported */ }
+    if (!file) return;
+    setImportError(null);
+    await credentialImport.handleFileSelected(file);
   }
 
   async function handleConfirmImport() {
-    const ci = credImport();
-    const rc = resolvedCred();
-    if (!ci || !rc) return;
-    await finalizeImport(rc.bundle, rc.identity, ci.config);
+    const cred = credentialImport.credImport();
+    const rc = credentialImport.resolvedCred();
+    if (!cred || !rc) return;
+    await finalizeImport(rc.bundle, rc.identity, cred.config);
   }
 
   return (
@@ -441,7 +333,7 @@ export default function LoginPage() {
                     </>
                   }
                 >
-                  <Match when={resolvedCred()}>
+                  <Match when={credentialImport.resolvedCred()}>
                     {(rc) => (
                       <div class="flex flex-col gap-4">
                         <div class="flex items-center gap-3 text-left">
@@ -455,6 +347,9 @@ export default function LoginPage() {
                             replace your current settings — continue?
                           </p>
                         </div>
+                        <Show when={importError()}>
+                          <p role="alert" class="text-error text-xs text-left">{importError()}</p>
+                        </Show>
                         <div class="flex gap-2">
                           <button
                             type="button"
@@ -465,7 +360,7 @@ export default function LoginPage() {
                           >
                             {importCommitting() ? "Importing..." : "Continue"}
                           </button>
-                          <button type="button" onClick={closeImport} class="btn btn-sm btn-ghost">
+                          <button type="button" onClick={closeImport} disabled={importCommitting()} class="btn btn-sm btn-ghost">
                             Cancel
                           </button>
                         </div>
@@ -473,54 +368,59 @@ export default function LoginPage() {
                     )}
                   </Match>
 
-                  <Match when={credImport()}>
+                  <Match when={credentialImport.credImport()}>
                     <Show
-                      when={!credTerminal()}
+                      when={!credentialImport.terminalError()}
                       fallback={
                         <div class="flex flex-col gap-4">
-                          <p role="alert" class="text-error text-xs text-left">{credTerminal()}</p>
+                          <p role="alert" class="text-error text-xs text-left">{credentialImport.terminalError()}</p>
                           <button type="button" onClick={closeImport} class="btn btn-sm btn-neutral">
                             Back to sign in
                           </button>
                         </div>
                       }
                     >
-                      <form onSubmit={(e) => void handleImportCodeSubmit(e)} class="flex flex-col gap-4">
+                      <form onSubmit={(e) => { e.preventDefault(); void credentialImport.handleCodeSubmit(); }} class="flex flex-col gap-4">
                         <p class="text-sm text-base-content/70 text-left">
                           Enter the one-time code shown when this file was exported.
                         </p>
                         <div class="flex items-center gap-2">
                           <input
-                            type={showCode() ? "text" : "password"}
+                            type={credentialImport.showCode() ? "text" : "password"}
                             class="input input-bordered input-sm w-full font-mono"
                             aria-label="One-time code"
                             autocomplete="off"
                             placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
-                            value={codeInput()}
-                            onInput={(e) => setCodeInput(e.currentTarget.value)}
+                            value={credentialImport.codeInput()}
+                            onInput={(e) => credentialImport.setCodeInput(e.currentTarget.value)}
                           />
                           <button
                             type="button"
-                            onClick={() => setShowCode((v) => !v)}
+                            onClick={() => credentialImport.setShowCode((v) => !v)}
                             class="btn btn-sm btn-ghost"
-                            aria-pressed={showCode()}
+                            aria-pressed={credentialImport.showCode()}
                           >
-                            {showCode() ? "Hide" : "Show"}
+                            {credentialImport.showCode() ? "Hide" : "Show"}
                           </button>
                         </div>
-                        <Show when={importError()}>
-                          <p role="alert" class="text-error text-xs text-left">{importError()}</p>
+                        {/* credentialImport.error() covers retryable code-submit
+                            failures (turnstile/network/wrong-code); importError()
+                            additionally covers a finalizeImport commit failure on
+                            the skip-the-dialog fast path, which surfaces here since
+                            this form is still the active branch when that happens. */}
+                        <Show when={credentialImport.error() ?? importError()}>
+                          <p role="alert" class="text-error text-xs text-left">{credentialImport.error() ?? importError()}</p>
                         </Show>
                         <div class="flex gap-2">
                           <button
                             type="submit"
-                            disabled={unsealInFlight()}
-                            aria-busy={unsealInFlight()}
+                            disabled={credentialImport.unsealInFlight() || importCommitting()}
+                            aria-busy={credentialImport.unsealInFlight() || importCommitting()}
                             class="btn btn-sm btn-primary flex-1"
                           >
-                            {unsealInFlight() ? "Checking..." : "Restore credentials"}
+                            {credentialImport.unsealInFlight() || importCommitting() ? "Checking..." : "Restore credentials"}
                           </button>
-                          <button type="button" onClick={closeImport} disabled={unsealInFlight()} class="btn btn-sm btn-ghost">
+                          <button type="button" onClick={closeImport} disabled={credentialImport.unsealInFlight() || importCommitting()} class="btn btn-sm btn-ghost">
                             Cancel
                           </button>
                         </div>

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -108,7 +108,17 @@ export default function LoginPage() {
 
   // ── Import handlers ──────────────────────────────────────────────────────────
 
+  // Generation counter tying an in-flight unseal/resolve to the file that started
+  // it (mirrors auth.ts's _crossTabFetchGen). Bumped on every reset and on every
+  // new file selection; the submit handler captures it before each await and
+  // bails if it changed, so a Cancel-then-reselect during the multi-second
+  // unseal/resolve window can't strand one file's ciphertext/credential into a
+  // different file's shared signals — which pre-auth would auto-login the
+  // abandoned file's identity.
+  let unsealGen = 0;
+
   function resetImportState() {
+    unsealGen++;
     setCredImport(null);
     setCodeInput("");
     setShowCode(false);
@@ -198,6 +208,7 @@ export default function LoginPage() {
     if (!ci) return;
     const code = codeInput();
     setImportError(null);
+    const gen = unsealGen; // capture before the first await
 
     let ciphertext = cachedCiphertext();
     if (ciphertext === null) {
@@ -207,12 +218,22 @@ export default function LoginPage() {
       const res = await unsealCredentialBundle(ci.credentials.sealed).finally(() =>
         setUnsealInFlight(false)
       );
+      // A changed unsealGen means a Cancel-then-reselect started a different file
+      // while this await was pending; writing any signal now (or auto-logging in)
+      // would use the abandoned file's identity, so stop here.
+      if (gen !== unsealGen) return;
       if (!res.ok) {
-        if (res.reason === "turnstile") {
-          // Client-side Turnstile hiccup BEFORE any request — the nonce was NOT
-          // consumed, so this is retryable. Keep the code prompt available and
-          // show a retryable inline message (R-101).
-          setImportError("Verification failed — please try again.");
+        if (res.reason === "turnstile" || res.reason === "network" || res.reason === "rate-limited") {
+          // Pre-nonce-consumption failure — the nonce was NOT consumed, so this
+          // is retryable. Keep the code prompt available and show a retryable
+          // inline message (do NOT withdraw the prompt).
+          setImportError(
+            res.reason === "rate-limited"
+              ? "Too many attempts — wait a moment and try again."
+              : res.reason === "network"
+                ? "Network problem — please try again."
+                : "Verification failed — please try again."
+          );
           return;
         }
         // expired/invalid are terminal — the single-use bundle is spent. Show the
@@ -230,6 +251,9 @@ export default function LoginPage() {
 
     // Client-side, retryable against the cached ciphertext (no re-unseal).
     const resolved = await resolveImportedCredentials(ciphertext, ci.credentials.salt, code);
+    // The resolve await is another window where a Cancel-then-reselect can change
+    // unsealGen (unsealInFlight is false here); discard the result if so.
+    if (gen !== unsealGen) return;
     if (!resolved.ok) {
       setImportError(resolved.error);
       return;
@@ -496,7 +520,7 @@ export default function LoginPage() {
                           >
                             {unsealInFlight() ? "Checking..." : "Restore credentials"}
                           </button>
-                          <button type="button" onClick={closeImport} class="btn btn-sm btn-ghost">
+                          <button type="button" onClick={closeImport} disabled={unsealInFlight()} class="btn btn-sm btn-ghost">
                             Cancel
                           </button>
                         </div>

--- a/src/app/stores/auth.ts
+++ b/src/app/stores/auth.ts
@@ -416,72 +416,86 @@ export const crossTabReload = {
 // Uses expireToken() (not clearAuth()) to avoid wiping config/view that may still be valid.
 // Also syncs Jira auth across tabs — critical for rotating refresh tokens: a stale tab
 // holding an already-invalidated token would fail on its next Jira request.
-if (typeof window !== "undefined") {
-  window.addEventListener("storage", (e: StorageEvent) => {
-    if (e.key === AUTH_STORAGE_KEY && e.newValue === null && _token()) {
-      // Re-check: a rapid sign-out/sign-in may have already replaced the token
-      if (localStorage.getItem(AUTH_STORAGE_KEY) !== null) return;
-      expireToken();
-      window.location.replace("/login");
-    } else if (e.key === AUTH_STORAGE_KEY && e.newValue !== null && e.newValue !== _token()) {
-      // Captured BEFORE the token/user update below, so the /user fetch result
-      // can be compared against who THIS tab thought was signed in.
-      const previousLogin = user()?.login;
-      _setToken(e.newValue);
-      const gen = ++_crossTabFetchGen;
-      const newToken = e.newValue;
-      fetch("https://api.github.com/user", {
-        headers: { ...VALIDATE_HEADERS, Authorization: `Bearer ${newToken}` },
-      })
-        .then((r) => { if (!r.ok) { void r.body?.cancel(); return null; } return r.json() as Promise<GitHubUser>; })
-        .then((data) => {
-          if (data && _token() === newToken && _crossTabFetchGen === gen) {
-            // Only a CONFIRMED same-user rotation (a known previous login that
-            // case-insensitively matches the fetched identity) skips the
-            // reload. previousLogin is undefined whenever this tab's user()
-            // was already null — notably after expireToken(), which clears
-            // user() but deliberately PRESERVES config/view so the same user
-            // can silently re-auth. In that state we can't assume continuity:
-            // this tab may still be holding a prior identity's config/view in
-            // memory/localStorage even though user() reads null, so treating
-            // an unconfirmed prior identity as "safe" would let a genuinely
-            // different identity render using that stale data (a
-            // cross-identity bleed). When in doubt, reload.
-            const isSameUserRotation =
-              previousLogin !== undefined && previousLogin.toLowerCase() === data.login.toLowerCase();
-            if (isSameUserRotation) {
-              // Same-identity token rotation — adopt the refreshed user data
-              // in place, same as before. Must NOT reset config/view here.
-              setUser({ login: data.login, avatar_url: data.avatar_url, name: data.name });
-            } else {
-              // A different GitHub identity signed in via another tab (e.g.
-              // Settings > Replace token in that tab), OR this tab has no
-              // confirmable prior identity — the active tab has already
-              // reset config/view, cleared the shared IndexedDB cache, and
-              // written the new identity's token/config/view to localStorage.
-              // This (passive) tab has NOT run any of that, so simply calling
-              // setUser() here could leave it authenticated as the new identity
-              // while still rendering a previous identity's config/view/cached
-              // data. Reload instead so it re-initializes cleanly from what the
-              // active tab already persisted.
-              crossTabReload.reloadForIdentitySwitch();
-            }
+function handleAuthStorage(e: StorageEvent): void {
+  if (e.key === AUTH_STORAGE_KEY && e.newValue === null && _token()) {
+    // Re-check: a rapid sign-out/sign-in may have already replaced the token
+    if (localStorage.getItem(AUTH_STORAGE_KEY) !== null) return;
+    expireToken();
+    window.location.replace("/login");
+  } else if (e.key === AUTH_STORAGE_KEY && e.newValue !== null && e.newValue !== _token()) {
+    // Captured BEFORE the token/user update below, so the /user fetch result
+    // can be compared against who THIS tab thought was signed in.
+    const previousLogin = user()?.login;
+    _setToken(e.newValue);
+    const gen = ++_crossTabFetchGen;
+    const newToken = e.newValue;
+    fetch("https://api.github.com/user", {
+      headers: { ...VALIDATE_HEADERS, Authorization: `Bearer ${newToken}` },
+    })
+      .then((r) => { if (!r.ok) { void r.body?.cancel(); return null; } return r.json() as Promise<GitHubUser>; })
+      .then((data) => {
+        if (data && _token() === newToken && _crossTabFetchGen === gen) {
+          // Only a CONFIRMED same-user rotation (a known previous login that
+          // case-insensitively matches the fetched identity) skips the
+          // reload. previousLogin is undefined whenever this tab's user()
+          // was already null — notably after expireToken(), which clears
+          // user() but deliberately PRESERVES config/view so the same user
+          // can silently re-auth. In that state we can't assume continuity:
+          // this tab may still be holding a prior identity's config/view in
+          // memory/localStorage even though user() reads null, so treating
+          // an unconfirmed prior identity as "safe" would let a genuinely
+          // different identity render using that stale data (a
+          // cross-identity bleed). When in doubt, reload.
+          const isSameUserRotation =
+            previousLogin !== undefined && previousLogin.toLowerCase() === data.login.toLowerCase();
+          if (isSameUserRotation) {
+            // Same-identity token rotation — adopt the refreshed user data
+            // in place, same as before. Must NOT reset config/view here.
+            setUser({ login: data.login, avatar_url: data.avatar_url, name: data.name });
+          } else {
+            // A different GitHub identity signed in via another tab (e.g.
+            // Settings > Replace token in that tab), OR this tab has no
+            // confirmable prior identity — the active tab has already
+            // reset config/view, cleared the shared IndexedDB cache, and
+            // written the new identity's token/config/view to localStorage.
+            // This (passive) tab has NOT run any of that, so simply calling
+            // setUser() here could leave it authenticated as the new identity
+            // while still rendering a previous identity's config/view/cached
+            // data. Reload instead so it re-initializes cleanly from what the
+            // active tab already persisted.
+            crossTabReload.reloadForIdentitySwitch();
           }
-        })
-        .catch(() => {});
-    }
-    if (e.key === JIRA_AUTH_STORAGE_KEY) {
-      try {
-        const raw = e.newValue;
-        if (!raw) {
-          _setJiraAuth(null);
-          return;
         }
-        const parsed = JiraAuthStateSchema.safeParse(JSON.parse(raw) as unknown);
-        _setJiraAuth(parsed.success ? parsed.data : null);
-      } catch {
+      })
+      .catch(() => {});
+  }
+  if (e.key === JIRA_AUTH_STORAGE_KEY) {
+    try {
+      const raw = e.newValue;
+      if (!raw) {
         _setJiraAuth(null);
+        return;
       }
+      const parsed = JiraAuthStateSchema.safeParse(JSON.parse(raw) as unknown);
+      _setJiraAuth(parsed.success ? parsed.data : null);
+    } catch {
+      _setJiraAuth(null);
     }
-  });
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", handleAuthStorage);
+}
+
+/**
+ * Test-only: detaches the module-scope `storage` listener registered above.
+ * Suites re-import this module via `vi.resetModules()`, which attaches a fresh
+ * listener to the shared window on each import; calling this in teardown removes
+ * the current instance's listener so they don't accumulate across tests.
+ */
+export function _resetAuthStorageListenerForTests(): void {
+  if (typeof window !== "undefined") {
+    window.removeEventListener("storage", handleAuthStorage);
+  }
 }

--- a/src/app/stores/auth.ts
+++ b/src/app/stores/auth.ts
@@ -436,25 +436,36 @@ if (typeof window !== "undefined") {
         .then((r) => { if (!r.ok) { void r.body?.cancel(); return null; } return r.json() as Promise<GitHubUser>; })
         .then((data) => {
           if (data && _token() === newToken && _crossTabFetchGen === gen) {
-            const isIdentitySwitch =
-              previousLogin !== undefined && previousLogin.toLowerCase() !== data.login.toLowerCase();
-            if (isIdentitySwitch) {
+            // Only a CONFIRMED same-user rotation (a known previous login that
+            // case-insensitively matches the fetched identity) skips the
+            // reload. previousLogin is undefined whenever this tab's user()
+            // was already null — notably after expireToken(), which clears
+            // user() but deliberately PRESERVES config/view so the same user
+            // can silently re-auth. In that state we can't assume continuity:
+            // this tab may still be holding a prior identity's config/view in
+            // memory/localStorage even though user() reads null, so treating
+            // an unconfirmed prior identity as "safe" would let a genuinely
+            // different identity render using that stale data (a
+            // cross-identity bleed). When in doubt, reload.
+            const isSameUserRotation =
+              previousLogin !== undefined && previousLogin.toLowerCase() === data.login.toLowerCase();
+            if (isSameUserRotation) {
+              // Same-identity token rotation — adopt the refreshed user data
+              // in place, same as before. Must NOT reset config/view here.
+              setUser({ login: data.login, avatar_url: data.avatar_url, name: data.name });
+            } else {
               // A different GitHub identity signed in via another tab (e.g.
-              // Settings > Replace token in that tab) — that tab has already
+              // Settings > Replace token in that tab), OR this tab has no
+              // confirmable prior identity — the active tab has already
               // reset config/view, cleared the shared IndexedDB cache, and
               // written the new identity's token/config/view to localStorage.
               // This (passive) tab has NOT run any of that, so simply calling
-              // setUser() here would leave it authenticated as the new identity
-              // while still rendering the previous identity's config/view/cached
+              // setUser() here could leave it authenticated as the new identity
+              // while still rendering a previous identity's config/view/cached
               // data. Reload instead so it re-initializes cleanly from what the
               // active tab already persisted.
               crossTabReload.reloadForIdentitySwitch();
-              return;
             }
-            // Same-identity token rotation (or first sign-in observed by a
-            // passive tab) — adopt the refreshed user data in place, same as
-            // before. Must NOT reset config/view here.
-            setUser({ login: data.login, avatar_url: data.avatar_url, name: data.name });
           }
         })
         .catch(() => {});

--- a/src/app/stores/auth.ts
+++ b/src/app/stores/auth.ts
@@ -213,23 +213,54 @@ export function setAuthFromPat(token: string, userData: GitHubUser): void {
     resetViewState();
     localStorage.removeItem(CONFIG_STORAGE_KEY);
     localStorage.removeItem(VIEW_STORAGE_KEY);
-    // Clear IndexedDB cache to prevent data leakage between identities.
-    clearCache().catch((err) => {
-      console.warn("[auth] Cache clear failed during identity switch:", err);
-      Sentry.captureException(err, { tags: { source: "auth-identity-switch-cache-clear" } });
-    });
-    // Clear per-user in-memory + cached state (poll data, notifications,
-    // toast dedup, dashboard cache) the same way a real logout does, BEFORE
-    // adopting the new identity below, so the incoming identity doesn't
-    // inherit the outgoing one's data.
-    for (const cb of _onClearCallbacks) {
-      try { cb(); } catch (e) { console.warn("[auth] onAuthCleared callback threw during identity switch:", e); }
-    }
+    // Clear IndexedDB cache + per-identity in-memory state. Fire-and-forget
+    // here (preserving this synchronous path's long-standing non-blocking
+    // behavior — the callback loop still runs synchronously because it precedes
+    // the awaited cache clear inside clearIdentityData). The pre-auth Login-page
+    // import path calls `await clearIdentityData()` directly when it needs a
+    // real ordering guarantee before establishing a new identity.
+    void clearIdentityData();
   }
 
   setAuth({ access_token: token });
   setUser({ login: userData.login, avatar_url: userData.avatar_url, name: userData.name });
   updateConfig({ authMethod: "pat" });
+}
+
+/**
+ * One-line self-documenting alias: an imported credential (PAT or OAuth) is
+ * established via the same identity-agnostic mechanics as a PAT replacement
+ * (store token, store user, detect identity switch, reset per-identity state).
+ * The alias makes that agnosticism visible at the import call site without a
+ * reader tracing into `setAuthFromPat`.
+ */
+export const setAuthFromCredential = setAuthFromPat;
+
+/**
+ * Clears per-identity data: the `onAuthCleared` callback loop (poll data,
+ * notifications, toast dedup, dashboard cache, Jira signal) AND the IndexedDB
+ * dashboard cache. The callbacks run synchronously first, so a fire-and-forget
+ * `void clearIdentityData()` preserves `setAuthFromPat`'s historical synchronous
+ * callback behavior; the IndexedDB `clearCache()` is AWAITED (not
+ * fire-and-forget) so a caller doing `await clearIdentityData()` gets a real
+ * ordering guarantee — required by the pre-auth Login-page import path, where
+ * `setAuthFromPat`'s own cache-clear is inert (`isIdentitySwitch` needs `user()`
+ * non-null) and `expireToken()` never clears IndexedDB.
+ */
+export async function clearIdentityData(): Promise<void> {
+  // Synchronous per-identity resets first (matches the ordering the identity-
+  // switch branch has always had: callbacks complete before the awaited work).
+  for (const cb of _onClearCallbacks) {
+    try { cb(); } catch (e) { console.warn("[auth] onAuthCleared callback threw during identity data clear:", e); }
+  }
+  // IndexedDB cache clear — AWAITED so callers can sequence work strictly after
+  // it (prevents a new identity rendering the previous identity's cached data).
+  try {
+    await clearCache();
+  } catch (err) {
+    console.warn("[auth] Cache clear failed during identity data clear:", err);
+    Sentry.captureException(err, { tags: { source: "auth-identity-data-cache-clear" } });
+  }
 }
 
 const _onClearCallbacks: (() => void)[] = [];

--- a/src/app/stores/auth.ts
+++ b/src/app/stores/auth.ts
@@ -396,6 +396,22 @@ onAuthCleared(() => {
 
 let _crossTabFetchGen = 0;
 
+/**
+ * Cross-tab identity-switch reload seam, extracted as a mutable object method
+ * (not a bare exported function) purely for testability: the storage listener
+ * below always calls through `crossTabReload.reloadForIdentitySwitch()`, so
+ * `vi.spyOn(crossTabReload, "reloadForIdentitySwitch")` from a test intercepts
+ * it — a plain exported function wouldn't be, since the listener's internal
+ * call captures a direct reference to it rather than reading it back off the
+ * module's exports object. This also sidesteps happy-dom's
+ * `window.location.reload` not being reliably spyable directly.
+ */
+export const crossTabReload = {
+  reloadForIdentitySwitch(): void {
+    window.location.reload();
+  },
+};
+
 // Cross-tab auth sync: if another tab clears the token, this tab should also clear.
 // Uses expireToken() (not clearAuth()) to avoid wiping config/view that may still be valid.
 // Also syncs Jira auth across tabs — critical for rotating refresh tokens: a stale tab
@@ -408,6 +424,9 @@ if (typeof window !== "undefined") {
       expireToken();
       window.location.replace("/login");
     } else if (e.key === AUTH_STORAGE_KEY && e.newValue !== null && e.newValue !== _token()) {
+      // Captured BEFORE the token/user update below, so the /user fetch result
+      // can be compared against who THIS tab thought was signed in.
+      const previousLogin = user()?.login;
       _setToken(e.newValue);
       const gen = ++_crossTabFetchGen;
       const newToken = e.newValue;
@@ -417,6 +436,24 @@ if (typeof window !== "undefined") {
         .then((r) => { if (!r.ok) { void r.body?.cancel(); return null; } return r.json() as Promise<GitHubUser>; })
         .then((data) => {
           if (data && _token() === newToken && _crossTabFetchGen === gen) {
+            const isIdentitySwitch =
+              previousLogin !== undefined && previousLogin.toLowerCase() !== data.login.toLowerCase();
+            if (isIdentitySwitch) {
+              // A different GitHub identity signed in via another tab (e.g.
+              // Settings > Replace token in that tab) — that tab has already
+              // reset config/view, cleared the shared IndexedDB cache, and
+              // written the new identity's token/config/view to localStorage.
+              // This (passive) tab has NOT run any of that, so simply calling
+              // setUser() here would leave it authenticated as the new identity
+              // while still rendering the previous identity's config/view/cached
+              // data. Reload instead so it re-initializes cleanly from what the
+              // active tab already persisted.
+              crossTabReload.reloadForIdentitySwitch();
+              return;
+            }
+            // Same-identity token rotation (or first sign-in observed by a
+            // passive tab) — adopt the refreshed user data in place, same as
+            // before. Must NOT reset config/view here.
             setUser({ login: data.login, avatar_url: data.avatar_url, name: data.name });
           }
         })

--- a/src/app/stores/config.ts
+++ b/src/app/stores/config.ts
@@ -28,36 +28,61 @@ export function resolveTheme(theme: ThemeId): string {
   return prefersDark ? AUTO_DARK_THEME : AUTO_LIGHT_THEME;
 }
 
+/**
+ * Migrations applied to RAW (unvalidated) config data BEFORE
+ * `ConfigSchema.safeParse()`. BOTH fixups here MUST run pre-parse — the split
+ * relative to `safeParse` is load-bearing:
+ *  - Invalid-`theme` reset: a bad `theme` value would otherwise fail the whole
+ *    parse for an otherwise-valid config; salvaging it to `"auto"` first lets
+ *    the rest of the record survive validation.
+ *  - Tracked-user `[bot]`-suffix stripping: `VALID_TRACKED_LOGIN` rejects a
+ *    doubled `"renovate[bot][bot]"` suffix, so a post-parse fixup would never
+ *    run for that input (the record would already be rejected). Stripping the
+ *    suffix pre-parse is the only way to self-heal it.
+ * Shared by `loadConfig()` and `parseImportFile()` (src/app/lib/settings-transfer.ts).
+ */
+export function preParseConfigFixups(raw: unknown): unknown {
+  if (raw && typeof raw === "object" && "theme" in raw) {
+    if (!THEME_OPTIONS.includes((raw as Record<string, unknown>).theme as typeof THEME_OPTIONS[number])) {
+      (raw as Record<string, unknown>).theme = "auto";
+    }
+  }
+  // Migrate tracked user logins: strip [bot] suffix from stored logins.
+  // handleTrackBot now stores base names only, but pre-migration data may
+  // have "renovate[bot]" which causes a doubled "renovate[bot][bot]" variant.
+  if (raw && typeof raw === "object" && Array.isArray((raw as Record<string, unknown>).trackedUsers)) {
+    const users = (raw as Record<string, unknown>).trackedUsers as { login?: string }[];
+    for (const u of users) {
+      if (typeof u.login === "string" && /\[bot\]$/i.test(u.login)) {
+        u.login = u.login.replace(/\[bot\]$/i, "");
+      }
+    }
+  }
+  return raw;
+}
+
+/**
+ * Migration applied to a validated Config AFTER `ConfigSchema.safeParse()`.
+ * Only the stale-`defaultTab` cleanup belongs here — it needs the parsed
+ * `customTabs` array to check against.
+ * Shared by `loadConfig()` and `parseImportFile()` (src/app/lib/settings-transfer.ts).
+ */
+export function postParseConfigFixups(config: Config): Config {
+  const validTabIds = new Set<string>([...BUILTIN_TAB_IDS, ...config.customTabs.map((t) => t.id)]);
+  if (!validTabIds.has(config.defaultTab)) {
+    return { ...config, defaultTab: "issues" };
+  }
+  return config;
+}
+
 export function loadConfig(): Config {
   try {
     const raw = localStorage.getItem(CONFIG_STORAGE_KEY);
     if (raw === null) return ConfigSchema.parse({});
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && "theme" in parsed) {
-      if (!THEME_OPTIONS.includes((parsed as Record<string, unknown>).theme as typeof THEME_OPTIONS[number])) {
-        (parsed as Record<string, unknown>).theme = "auto";
-      }
-    }
-    // Migrate tracked user logins: strip [bot] suffix from stored logins.
-    // handleTrackBot now stores base names only, but pre-migration data may
-    // have "renovate[bot]" which causes a doubled "renovate[bot][bot]" variant.
-    if (parsed && typeof parsed === "object" && Array.isArray((parsed as Record<string, unknown>).trackedUsers)) {
-      const users = (parsed as Record<string, unknown>).trackedUsers as { login?: string }[];
-      for (const u of users) {
-        if (typeof u.login === "string" && /\[bot\]$/i.test(u.login)) {
-          u.login = u.login.replace(/\[bot\]$/i, "");
-        }
-      }
-    }
+    const parsed = preParseConfigFixups(JSON.parse(raw) as unknown);
     const result = ConfigSchema.safeParse(parsed);
     if (result.success) {
-      const data = result.data;
-      // Clean up stale defaultTab pointing to a deleted custom tab
-      const validTabIds = new Set<string>([...BUILTIN_TAB_IDS, ...data.customTabs.map((t) => t.id)]);
-      if (!validTabIds.has(data.defaultTab)) {
-        return { ...data, defaultTab: "issues" };
-      }
-      return data;
+      return postParseConfigFixups(result.data);
     }
     return ConfigSchema.parse({});
   } catch {

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -141,6 +141,122 @@ export type IgnoredItem = ViewState["ignoredItems"][number];
 const REPO_STATE_TAB_IDS = ["issues", "pullRequests", "actions", "jiraAssigned"] as const;
 const VIEW_STATE_KEYS = new Set(Object.keys(ViewStateSchema.shape));
 
+/**
+ * Top-level ViewState keys included in a settings export's `_viewPreferences`
+ * section (see `buildExportPayload`/`buildViewPreferencesSection` in
+ * src/app/lib/settings-transfer.ts) and restored by `applyImportedViewState`
+ * below. Lives here (not in settings-transfer.ts) so this module never needs a
+ * runtime import from settings-transfer.ts — settings-transfer.ts already
+ * transitively depends on this module (via stores/config.ts and stores/auth.ts),
+ * so the reverse edge would be a circular import; settings-transfer.ts re-exports
+ * this const for external consumers instead.
+ *
+ * Deliberately a curated allowlist, NOT the full ViewState — three top-level
+ * keys are excluded on purpose:
+ *   - `lastActiveTab`, `globalSort`: transient session state, not a durable
+ *     preference worth restoring on another device.
+ *   - `globalFilter`: a free-typed org/repo search string. Even though it's
+ *     not secret, it's arbitrary user-typed text with no bound on content, so
+ *     it's excluded from the plaintext export on privacy-scrub grounds.
+ * `satisfies readonly (keyof ViewState)[]` is a compile-time guard: if a key
+ * here is ever renamed/removed from ViewStateSchema, this fails to typecheck.
+ * The runtime schema-drift guard test in settings-transfer.test.ts is the
+ * complementary check — it fails when ViewStateSchema gains or loses a
+ * TOP-LEVEL key, forcing a conscious include/exclude decision here.
+ */
+export const EXPORTED_VIEW_PREF_KEYS = [
+  "jiraCustomOrder",
+  "expandedRepos",
+  "lockedRepos",
+  "tabFilters",
+  "customTabFilters",
+  "dependencyExpandedGroups",
+  "showPrRuns",
+  "hideDepDashboard",
+  "ignoredItems",
+  "trackedItems",
+] as const satisfies readonly (keyof ViewState)[];
+
+/**
+ * `ignoredItems`/`trackedItems` are exported WITHOUT their content fields
+ * (`title`, and for trackedItems also `htmlUrl`/`jiraStatus`) — see the
+ * TRACKED_ITEM_EXPORT_KEEP_LIST / IGNORED_ITEM_EXPORT_KEEP_LIST allowlists in
+ * settings-transfer.ts. Both TrackedItemSchema and IgnoredItemSchema require
+ * `title`, so re-validating a stripped entry as-is would reject it outright.
+ * This coerces a MISSING `title` to `""` before validation — defensive: only
+ * touches a plain object that's actually missing the key; anything else
+ * (wrong type, not an object at all) is passed through unchanged for Zod to
+ * reject on its own terms. Accepted UX tradeoff (not a bug): TrackedTab
+ * re-hydrates the real title from live data on next fetch; the Ignored Items
+ * management list shows a blank title until that item is re-encountered.
+ */
+function coerceStrippedItemEntry(raw: unknown): unknown {
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw) && !("title" in raw)) {
+    return { ...raw, title: "" };
+  }
+  return raw;
+}
+
+function coerceStrippedItemsArray(raw: unknown): unknown {
+  return Array.isArray(raw) ? raw.map(coerceStrippedItemEntry) : raw;
+}
+
+/**
+ * Applies an imported `_viewPreferences` section (from a settings-export file)
+ * onto the live view-state store. TOTAL and non-throwing by design — `raw` is
+ * completely untrusted input (a hand-edited or malformed export file), so this
+ * NEVER throws: wholly-malformed input (not a plain object — `null`, an
+ * array, a primitive) is a silent no-op.
+ *
+ * Validates PER-KEY: each of EXPORTED_VIEW_PREF_KEYS is safeParse'd
+ * independently against ViewStateSchema's own field validation (via
+ * `.pick()`, mirroring `readOnDiskState`'s per-field validation above) and
+ * only applied if it passes. One invalid/malformed key is skipped WITHOUT
+ * dropping every other valid key — a version-skewed or hand-edited export
+ * file degrades gracefully instead of failing the whole import.
+ *
+ * Only ever overlays EXPORTED_VIEW_PREF_KEYS — `lastActiveTab`, `globalSort`,
+ * and `globalFilter` are NEVER touched here, mirroring the export side's
+ * exclusion of those transient/privacy-scrubbed fields.
+ *
+ * Silent on invalid input (no notification) — unlike `updateViewState`, which
+ * is user-triggered and warns on rejection. This runs as part of a file
+ * import the user already confirmed; a per-field validation failure here is
+ * an export/import version-skew concern, not something actionable mid-import.
+ *
+ * Deliberately a DISTINCT function from `updateViewState`, not folded into
+ * it: different semantics (`raw: unknown` vs `Partial<ViewState>`, stripped-
+ * entry title coercion, a FIXED allowlist rather than whatever keys the
+ * caller passes, and silent-skip-per-key rather than warn-and-reject-the-
+ * whole-call). Called ONLY from the settings-import paths — identity-scoped,
+ * always AFTER the importing GitHub identity is established (never a
+ * standalone/independent trigger).
+ */
+export function applyImportedViewState(raw: unknown): void {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return;
+  const rawObj = raw as Record<string, unknown>;
+  const patch: Partial<Record<keyof ViewState, unknown>> = {};
+  for (const key of EXPORTED_VIEW_PREF_KEYS) {
+    if (!(key in rawObj)) continue;
+    const value =
+      key === "ignoredItems" || key === "trackedItems"
+        ? coerceStrippedItemsArray(rawObj[key])
+        : rawObj[key];
+    const result = ViewStateSchema.pick({ [key]: true } as Partial<Record<keyof ViewState, true>>).safeParse({
+      [key]: value,
+    });
+    if (result.success) {
+      patch[key] = (result.data as Record<string, unknown>)[key];
+    }
+  }
+  if (Object.keys(patch).length === 0) return;
+  setViewState(
+    produce((draft) => {
+      Object.assign(draft, patch);
+    })
+  );
+}
+
 export function migrateLockedRepos(raw: unknown): unknown {
   if (raw == null) return { issues: [], pullRequests: [], actions: [], jiraAssigned: [] };
   if (Array.isArray(raw)) {

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -8,6 +8,19 @@ const IGNORED_ITEMS_CAP = 500;
 const TRACKED_ITEMS_CAP = 200;
 export const LOCKED_REPOS_CAP = 50;
 export const JIRA_CUSTOM_ORDER_CAP = 500;
+// customTabFilters/expandedRepos are Records, not arrays — Zod v4's z.record()
+// has no built-in .max(), so these are enforced via .refine() below instead.
+// Outer keys are tab IDs (built-ins + customTabs, itself capped at 10 in
+// shared/schemas.ts), generously capped well above any realistic tab count.
+const CUSTOM_TAB_FILTERS_TABS_CAP = 50;
+// Inner keys are filter field names for a single tab's baseType — every
+// *FiltersSchema above has well under 10 fields.
+const CUSTOM_TAB_FILTERS_FIELDS_CAP = 50;
+const EXPANDED_REPOS_TABS_CAP = 50;
+// Inner keys are repoFullName — unlike lockedRepos (a deliberately small
+// pinned subset), this tracks expand/collapse state for every repo in a tab,
+// so it needs headroom well above LOCKED_REPOS_CAP.
+const EXPANDED_REPOS_REPOS_CAP = 1000;
 export const JIRA_CUSTOM_ORDER_KEY_MAX_LENGTH = 50;
 export const JIRA_CUSTOM_ORDER_SCOPE = "assigned" as const;
 export const JIRA_CUSTOM_SORT_FIELD = "custom" as const;
@@ -118,11 +131,22 @@ export const ViewStateSchema = z.object({
   customTabFilters: z.record(
     z.string(),
     z.record(z.string(), z.string())
-  ).default({}),
+      .refine((v) => Object.keys(v).length <= CUSTOM_TAB_FILTERS_FIELDS_CAP, {
+        message: `Too many filter fields for a single tab (max ${CUSTOM_TAB_FILTERS_FIELDS_CAP})`,
+      })
+  ).refine((v) => Object.keys(v).length <= CUSTOM_TAB_FILTERS_TABS_CAP, {
+    message: `Too many tabs with saved filters (max ${CUSTOM_TAB_FILTERS_TABS_CAP})`,
+  }).default({}),
   expandedRepos: z.record(
     z.string(),
-    z.record(z.string(), z.boolean()).default({})
-  ).default({
+    z.record(z.string(), z.boolean())
+      .refine((v) => Object.keys(v).length <= EXPANDED_REPOS_REPOS_CAP, {
+        message: `Too many expanded repos for a single tab (max ${EXPANDED_REPOS_REPOS_CAP})`,
+      })
+      .default({})
+  ).refine((v) => Object.keys(v).length <= EXPANDED_REPOS_TABS_CAP, {
+    message: `Too many tabs with expanded-repo state (max ${EXPANDED_REPOS_TABS_CAP})`,
+  }).default({
     issues: {},
     pullRequests: {},
     actions: {},
@@ -231,30 +255,39 @@ function coerceStrippedItemsArray(raw: unknown): unknown {
  * whole-call). Called ONLY from the settings-import paths — identity-scoped,
  * always AFTER the importing GitHub identity is established (never a
  * standalone/independent trigger).
+ *
+ * Wrapped in a try/catch as belt-and-suspenders: this function is already
+ * total/no-throw for realistic input, but the call site runs AFTER identity
+ * and config are already committed, so a future change here must never be
+ * able to throw past that point.
  */
 export function applyImportedViewState(raw: unknown): void {
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return;
-  const rawObj = raw as Record<string, unknown>;
-  const patch: Partial<Record<keyof ViewState, unknown>> = {};
-  for (const key of EXPORTED_VIEW_PREF_KEYS) {
-    if (!(key in rawObj)) continue;
-    const value =
-      key === "ignoredItems" || key === "trackedItems"
-        ? coerceStrippedItemsArray(rawObj[key])
-        : rawObj[key];
-    const result = ViewStateSchema.pick({ [key]: true } as Partial<Record<keyof ViewState, true>>).safeParse({
-      [key]: value,
-    });
-    if (result.success) {
-      patch[key] = (result.data as Record<string, unknown>)[key];
+  try {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return;
+    const rawObj = raw as Record<string, unknown>;
+    const patch: Partial<Record<keyof ViewState, unknown>> = {};
+    for (const key of EXPORTED_VIEW_PREF_KEYS) {
+      if (!(key in rawObj)) continue;
+      const value =
+        key === "ignoredItems" || key === "trackedItems"
+          ? coerceStrippedItemsArray(rawObj[key])
+          : rawObj[key];
+      const result = ViewStateSchema.pick({ [key]: true } as Partial<Record<keyof ViewState, true>>).safeParse({
+        [key]: value,
+      });
+      if (result.success) {
+        patch[key] = (result.data as Record<string, unknown>)[key];
+      }
     }
+    if (Object.keys(patch).length === 0) return;
+    setViewState(
+      produce((draft) => {
+        Object.assign(draft, patch);
+      })
+    );
+  } catch {
+    // Silent no-op, matching this function's documented silent-skip semantics.
   }
-  if (Object.keys(patch).length === 0) return;
-  setViewState(
-    produce((draft) => {
-      Object.assign(draft, patch);
-    })
-  );
 }
 
 export function migrateLockedRepos(raw: unknown): unknown {

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -28,6 +28,14 @@ export const TrackedItemSchema = z.object({
 
 export type TrackedItem = z.infer<typeof TrackedItemSchema>;
 
+export const IgnoredItemSchema = z.object({
+  id: z.coerce.number(),
+  type: z.enum(["issue", "pullRequest", "workflowRun"]),
+  repo: z.string(),
+  title: z.string(),
+  ignoredAt: z.number(),
+});
+
 export const IssueFiltersSchema = z.object({
   scope: z.enum(["involves_me", "all"]).default("involves_me"),
   role: z.enum(["all", "author", "assignee"]).default("all"),
@@ -83,15 +91,7 @@ export const ViewStateSchema = z.object({
     direction: z.enum(["asc", "desc"]),
   }).default({ field: "updatedAt", direction: "desc" }),
   ignoredItems: z
-    .array(
-      z.object({
-        id: z.coerce.number(),
-        type: z.enum(["issue", "pullRequest", "workflowRun"]),
-        repo: z.string(),
-        title: z.string(),
-        ignoredAt: z.number(),
-      })
-    )
+    .array(IgnoredItemSchema)
     .max(IGNORED_ITEMS_CAP)
     .default([]),
   globalFilter: z

--- a/src/app/stores/view.ts
+++ b/src/app/stores/view.ts
@@ -226,6 +226,24 @@ function coerceStrippedItemsArray(raw: unknown): unknown {
 }
 
 /**
+ * Validates a single top-level ViewState field in isolation, via
+ * `ViewStateSchema.pick({ [key]: true }).safeParse({ [key]: value })`.
+ * Shared by `applyImportedViewState` (import path) and `readOnDiskState`
+ * (cross-tab merge-on-write path) below — both need the same "validate one
+ * field against the live schema, independent of every other field" behavior
+ * so one malformed/version-skewed field can't reject the rest. Every
+ * ViewStateSchema field carries its own `.default(...)`, so a successful
+ * parse never yields `undefined` for `key` — `undefined` here unambiguously
+ * means validation failed.
+ */
+function validateViewStateField<K extends keyof ViewState>(key: K, value: unknown): ViewState[K] | undefined {
+  const result = ViewStateSchema.pick({ [key]: true } as Partial<Record<keyof ViewState, true>>).safeParse({
+    [key]: value,
+  });
+  return result.success ? ((result.data as Record<string, unknown>)[key] as ViewState[K]) : undefined;
+}
+
+/**
  * Applies an imported `_viewPreferences` section (from a settings-export file)
  * onto the live view-state store. TOTAL and non-throwing by design — `raw` is
  * completely untrusted input (a hand-edited or malformed export file), so this
@@ -272,11 +290,9 @@ export function applyImportedViewState(raw: unknown): void {
         key === "ignoredItems" || key === "trackedItems"
           ? coerceStrippedItemsArray(rawObj[key])
           : rawObj[key];
-      const result = ViewStateSchema.pick({ [key]: true } as Partial<Record<keyof ViewState, true>>).safeParse({
-        [key]: value,
-      });
-      if (result.success) {
-        patch[key] = (result.data as Record<string, unknown>)[key];
+      const validated = validateViewStateField(key, value);
+      if (validated !== undefined) {
+        patch[key] = validated;
       }
     }
     if (Object.keys(patch).length === 0) return;
@@ -826,8 +842,8 @@ export function initViewPersistence(): void {
       const filtered: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
         if (!VIEW_STATE_KEYS.has(key)) continue;
-        const result = ViewStateSchema.pick({ [key]: true } as Partial<Record<keyof ViewState, true>>).safeParse({ [key]: value });
-        if (result.success) filtered[key] = (result.data as Record<string, unknown>)[key];
+        const validated = validateViewStateField(key as keyof ViewState, value);
+        if (validated !== undefined) filtered[key] = validated;
       }
       return filtered;
     } catch {

--- a/src/worker/crypto.ts
+++ b/src/worker/crypto.ts
@@ -163,6 +163,102 @@ export async function unsealTokenWithRotation(
   return null;
 }
 
+// ── Expiry-aware credential-bundle sealing ─────────────────────────────────
+// Additive helpers used ONLY by the "credential-export-bundle" purpose. They
+// wrap the plaintext with a server-clock timestamp (for expiry) and a
+// content-fingerprint nonce (for single-use enforcement) before delegating to
+// the existing sealToken/unsealToken primitives. Do NOT modify
+// sealToken/unsealToken/unsealTokenWithRotation — the existing Jira sealing
+// paths must remain untouched. crypto.ts stays a pure, KV-free module: the
+// nonce is surfaced but never checked/consumed here (only index.ts has KV).
+
+/** 30 days — a credential-export bundle expires this long after it is sealed. */
+export const CREDENTIAL_BUNDLE_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Seals a plaintext inside a {createdAt, nonce, payload} wrapper.
+ *
+ * The nonce is a DETERMINISTIC SHA-256 fingerprint of the plaintext (base64url),
+ * NOT a fresh per-call random value — re-sealing the exact same plaintext later
+ * reproduces the identical nonce, which the unseal endpoint relies on to detect
+ * an unseal-then-reseal attempt to renew a bundle's expiry.
+ *
+ * `key` must already be derived by the caller (matching how sealToken is invoked
+ * at the existing call sites).
+ */
+export async function sealWithExpiry(
+  plaintext: string,
+  key: CryptoKey
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(plaintext)
+  );
+  const nonce = toBase64Url(new Uint8Array(digest));
+  const wrapped = JSON.stringify({ createdAt: Date.now(), nonce, payload: plaintext });
+  return sealToken(wrapped, key);
+}
+
+/**
+ * Unseals a token produced by sealWithExpiry, trying current+next keys during
+ * rotation (via unsealTokenWithRotation — same raw-secret-string signature).
+ *
+ * Returns the wrapper's payload, its content-fingerprint nonce, and its seal
+ * timestamp on success (so the caller can consume the nonce AND derive a KV TTL
+ * bounded by the bundle's remaining lifetime). Returns { reason: "expired" } if
+ * the wrapper is older than maxAgeMs, or a single generic { reason: "invalid" }
+ * for EVERY other failure (bad version, wrong key, corrupted ciphertext,
+ * malformed wrapper JSON) — no further distinction, per the security decision.
+ *
+ * Does NOT check or consume the nonce — that is the caller's responsibility
+ * (only index.ts has KV access).
+ */
+export async function unsealWithExpiry(
+  sealed: string,
+  currentKeySecret: string,
+  nextKeySecret: string | undefined,
+  salt: string,
+  info: string,
+  maxAgeMs: number
+): Promise<
+  | { ok: true; payload: string; nonce: string; createdAt: number }
+  | { ok: false; reason: "expired" | "invalid" }
+> {
+  const wrapped = await unsealTokenWithRotation(
+    sealed,
+    currentKeySecret,
+    nextKeySecret,
+    salt,
+    info
+  );
+  if (wrapped === null) return { ok: false, reason: "invalid" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(wrapped);
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return { ok: false, reason: "invalid" };
+  }
+  const { createdAt, nonce, payload } = parsed as Record<string, unknown>;
+  if (
+    typeof createdAt !== "number" ||
+    typeof nonce !== "string" ||
+    typeof payload !== "string"
+  ) {
+    return { ok: false, reason: "invalid" };
+  }
+
+  if (Date.now() - createdAt > maxAgeMs) {
+    return { ok: false, reason: "expired" };
+  }
+
+  return { ok: true, payload, nonce, createdAt };
+}
+
 // ── HMAC session signing ───────────────────────────────────────────────────
 
 /**

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,5 +1,14 @@
 import * as Sentry from "@sentry/cloudflare";
-import { CryptoEnv, deriveKey, sealToken, unsealTokenWithRotation, SEAL_SALT } from "./crypto";
+import {
+  CryptoEnv,
+  deriveKey,
+  sealToken,
+  unsealTokenWithRotation,
+  sealWithExpiry,
+  unsealWithExpiry,
+  CREDENTIAL_BUNDLE_EXPIRY_MS,
+  SEAL_SALT,
+} from "./crypto";
 import { SessionEnv, ensureSession } from "./session";
 import { TurnstileEnv, verifyTurnstile, extractTurnstileToken } from "./turnstile";
 import { validateProxyRequest, validateOrigin } from "./validation";
@@ -16,6 +25,13 @@ interface RateLimiter {
   limit(options: { key: string }): Promise<{ success: boolean }>;
 }
 
+// Local interface — project does not install @cloudflare/workers-types.
+// Matches the subset of Cloudflare's KVNamespace this worker uses (nonce store).
+interface KVNamespace {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+}
+
 export interface Env extends CryptoEnv, SessionEnv, TurnstileEnv {
   ASSETS: { fetch: (request: Request) => Promise<Response> };
   GITHUB_CLIENT_ID: string;
@@ -26,6 +42,10 @@ export interface Env extends CryptoEnv, SessionEnv, TurnstileEnv {
   SENTRY_DSN?: string; // e.g. "https://key@o123456.ingest.sentry.io/7890123"
   SENTRY_SECURITY_TOKEN?: string; // Optional: Sentry security token for Allowed Domains validation
   PROXY_RATE_LIMITER: RateLimiter; // Workers Rate Limiting Binding
+  // Single-use nonce store for /api/proxy/unseal. Optional at the type level so
+  // existing hand-built test Env fixtures (which never exercise unseal) remain
+  // valid; a genuinely missing binding is caught at runtime and surfaced as 503.
+  CREDENTIAL_NONCE_KV?: KVNamespace;
 }
 
 type ErrorCode =
@@ -44,7 +64,9 @@ type ErrorCode =
   | "internal_error"
   | "jira_token_exchange_failed"
   | "jira_refresh_failed"
-  | "jira_proxy_error";
+  | "jira_proxy_error"
+  | "expired"
+  | "invalid";
 
 // Structured logging — Cloudflare auto-indexes JSON fields for querying.
 // NEVER log secrets: codes, tokens, client_secret, cookie values.
@@ -130,6 +152,7 @@ const jiraTenantInfoLimiter = createIpRateLimiter(10, 60_000); // jira tenant in
 const sentryRateLimiter = createIpRateLimiter(15, 60_000);    // sentry tunnel: 15/min
 const cspRateLimiter = createIpRateLimiter(15, 60_000);       // csp report: 15/min
 const proxyPreGateLimiter = createIpRateLimiter(60, 60_000);  // proxy pre-gate: complements CF binding
+const unsealRateLimiter = createIpRateLimiter(5, 60_000);    // credential unseal: 5/min (pre-auth oracle — tighter than proxy pre-gate)
 
 // CF-Connecting-IP is set by Cloudflare's proxy layer in production and by
 // miniflare/workerd in local dev. Always present in any real request path.
@@ -204,7 +227,10 @@ function validateAndGuardProxyRoute(request: Request, env: Env, pathname: string
 }
 
 // ── Sealed-token endpoint ────────────────────────────────────────────────────
-const VALID_PURPOSES = new Set(["jira-api-token", "jira-refresh-token"]);
+const VALID_PURPOSES = new Set(["jira-api-token", "jira-refresh-token", "credential-export-bundle"]);
+// Single-value allowlist for /api/proxy/unseal — deliberately NOT derived from or
+// shared with VALID_PURPOSES, so Jira's sealed tokens can never be unsealed here.
+const UNSEAL_PURPOSE = "credential-export-bundle";
 const ALLOWED_SEARCH_PARAMS = new Set(["jql", "maxResults", "fields", "startAt"]);
 const ALLOWED_ISSUE_PARAMS = new Set(["issueIdsOrKeys", "fields"]);
 
@@ -214,7 +240,7 @@ const _nextKeyCache = new Map<string, CryptoKey>();
 let _nextKeyFingerprint = "";
 
 /** Get or derive the active encryption key for the given purpose, using SEAL_KEY_NEXT if set. */
-async function getJiraEncryptKey(env: Env, purpose: string): Promise<CryptoKey> {
+async function getEncryptKey(env: Env, purpose: string): Promise<CryptoKey> {
   const activeKey = env.SEAL_KEY_NEXT ?? env.SEAL_KEY;
   const fingerprint = activeKey;
   if (fingerprint !== _nextKeyFingerprint) {
@@ -270,9 +296,6 @@ async function handleProxySeal(request: Request, env: Env, sessionId: string): P
   if (typeof token !== "string") {
     return errorResponse("invalid_request", 400);
   }
-  if (token.length > 2048) {
-    return errorResponse("invalid_request", 400);
-  }
   // Purpose field required for token audience binding
   if (typeof purpose !== "string" || purpose.length === 0) {
     return errorResponse("invalid_request", 400);
@@ -280,12 +303,25 @@ async function handleProxySeal(request: Request, env: Env, sessionId: string): P
   if (!VALID_PURPOSES.has(purpose)) {
     return errorResponse("invalid_request", 400);
   }
+  // Purpose-keyed size cap: the credential-export bundle carries a GitHub token
+  // plus Jira credentials envelope-encrypted client-side, so it needs headroom
+  // (4096) for future growth; all other purposes stay at 2048. Checked AFTER the
+  // purpose is validated so the raise is scoped to exactly one purpose.
+  const maxTokenLength = purpose === UNSEAL_PURPOSE ? 4096 : 2048;
+  if (token.length > maxTokenLength) {
+    return errorResponse("invalid_request", 400);
+  }
 
   let sealed: string;
   try {
     // Use SEAL_KEY_NEXT if set (matches token exchange/refresh behavior), falling back to SEAL_KEY.
-    const key = await getJiraEncryptKey(env, "aes-gcm-key:" + purpose);
-    sealed = await sealToken(token, key);
+    const key = await getEncryptKey(env, "aes-gcm-key:" + purpose);
+    // The credential-export bundle is wrapped with a server-clock timestamp +
+    // content-fingerprint nonce (for expiry + single-use); all other purposes
+    // use the plain sealToken path unchanged.
+    sealed = purpose === UNSEAL_PURPOSE
+      ? await sealWithExpiry(token, key)
+      : await sealToken(token, key);
   } catch (err) {
     // Log error server-side — do not expose crypto error details in response
     log("error", "seal_failed", {
@@ -302,6 +338,142 @@ async function handleProxySeal(request: Request, env: Env, sessionId: string): P
   }, request);
 
   return new Response(JSON.stringify({ sealed }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...SECURITY_HEADERS,
+    },
+  });
+}
+
+// ── Credential-bundle unseal endpoint ──────────────────────────────────────
+// Pre-auth-reachable decryption oracle BY CONSTRUCTION. It only ever returns
+// the still-code-encrypted inner ciphertext (payload), NEVER plaintext — the
+// one-time code is verified client-side after unseal. Turnstile + tighter rate
+// limiting are abuse-cost multipliers, not the security boundary. Rejections use
+// a uniform generic errorResponse("invalid", 401) for every reason EXCEPT expiry
+// (errorResponse("expired", 401)), which leaks nothing attacker-exploitable.
+// Outer sealed length cap (6144) is intentionally larger than the seal endpoint's
+// 4096 inner cap: the outer blob is the inner ciphertext (≤4096) plus the
+// {createdAt,nonce} wrapper plus sealToken overhead and base64url expansion.
+const UNSEAL_SEALED_MAX_LENGTH = 6144;
+
+async function handleProxyUnseal(request: Request, env: Env): Promise<Response> {
+  if (request.method !== "POST") {
+    return errorResponse("method_not_allowed", 405);
+  }
+
+  // Missing/misconfigured KV binding is a deploy error — surface it as a 503 up
+  // front (mirroring the rate_limiter_binding_missing pattern) rather than every
+  // import silently failing with the user-facing "check the code and file match."
+  // A binding that EXISTS but throws is handled below (fail closed → invalid).
+  const nonceKv = env.CREDENTIAL_NONCE_KV;
+  if (!nonceKv || typeof nonceKv.get !== "function") {
+    log("error", "unseal_nonce_kv_binding_missing", {}, request);
+    return errorResponse("internal_error", 503);
+  }
+
+  const ip = getClientIp(request);
+  if (!ip) {
+    return errorResponse("invalid_request", 400);
+  }
+
+  // IP rate limit BEFORE Turnstile (cheapest check first) — an over-limit
+  // attacker is rejected without forcing a Turnstile round-trip per request.
+  if (!unsealRateLimiter.check(ip)) {
+    log("warn", "unseal_rate_limited", {}, request);
+    return new Response(JSON.stringify({ error: "rate_limited" }), {
+      status: 429,
+      headers: { "Content-Type": "application/json", "Retry-After": "60", ...SECURITY_HEADERS },
+    });
+  }
+
+  const turnstileToken = extractTurnstileToken(request);
+  if (!turnstileToken) {
+    log("warn", "unseal_turnstile_missing", {}, request);
+    return errorResponse("turnstile_failed", 403);
+  }
+  if (turnstileToken.length > 2048) {
+    log("warn", "unseal_turnstile_token_too_long", { token_length: turnstileToken.length }, request);
+    return errorResponse("turnstile_failed", 403);
+  }
+  const turnstileResult = await verifyTurnstile(turnstileToken, ip, env, "unseal");
+  if (!turnstileResult.success) {
+    log("warn", "unseal_turnstile_failed", { error_codes: turnstileResult.errorCodes }, request);
+    return errorResponse("turnstile_failed", 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("invalid_request", 400);
+  }
+  if (typeof body !== "object" || body === null) {
+    return errorResponse("invalid_request", 400);
+  }
+
+  const sealed = (body as Record<string, unknown>)["sealed"];
+  const purpose = (body as Record<string, unknown>)["purpose"];
+
+  if (typeof sealed !== "string" || sealed.length === 0) {
+    return errorResponse("invalid_request", 400);
+  }
+  // Length guard BEFORE any decode/crypto work (cheapest-check-first).
+  if (sealed.length > UNSEAL_SEALED_MAX_LENGTH) {
+    log("warn", "unseal_sealed_too_long", { sealed_length: sealed.length }, request);
+    return errorResponse("invalid_request", 400);
+  }
+  // Single-value purpose allowlist — any other value is treated identically to a
+  // corrupted blob (generic invalid), so Jira's sealed tokens gain no path here.
+  if (purpose !== UNSEAL_PURPOSE) {
+    return errorResponse("invalid", 401);
+  }
+
+  const result = await unsealWithExpiry(
+    sealed,
+    env.SEAL_KEY,
+    env.SEAL_KEY_NEXT,
+    SEAL_SALT,
+    "aes-gcm-key:credential-export-bundle",
+    CREDENTIAL_BUNDLE_EXPIRY_MS
+  );
+  if (!result.ok) {
+    return errorResponse(result.reason === "expired" ? "expired" : "invalid", 401);
+  }
+
+  // Check-and-consume the content-fingerprint nonce. FAIL CLOSED on any KV error
+  // — never return the payload if the nonce could not be checked-and-recorded,
+  // otherwise a KV outage would silently disable the single-use protection. This
+  // also closes the unseal-then-reseal renewal loophole: resealing the same
+  // payload reproduces the identical nonce (deterministic), so a resealed copy is
+  // rejected as already-consumed even though its own createdAt is fresh.
+  try {
+    const consumed = await nonceKv.get(result.nonce);
+    if (consumed !== null) {
+      log("info", "unseal_nonce_already_consumed", {}, request);
+      return errorResponse("invalid", 401);
+    }
+    // KV rejects sub-60s TTLs, so floor at 60 — a bundle unsealed in the last 60s
+    // of its life (or with small clock skew) would otherwise throw. The nonce
+    // record need not outlive the bundle (an expired bundle is rejected anyway).
+    const expirationTtl = Math.max(
+      60,
+      Math.ceil((result.createdAt + CREDENTIAL_BUNDLE_EXPIRY_MS - Date.now()) / 1000)
+    );
+    await nonceKv.put(result.nonce, "1", { expirationTtl });
+  } catch (err) {
+    log("error", "unseal_nonce_kv_failed", {
+      error: err instanceof Error ? err.message : "unknown",
+    }, request);
+    Sentry.captureException(err, { tags: { source: "worker-unseal-nonce" } });
+    return errorResponse("invalid", 401);
+  }
+
+  log("info", "credential_bundle_unsealed", {}, request);
+
+  // Return ONLY the still-code-encrypted inner ciphertext — never plaintext.
+  return new Response(JSON.stringify({ payload: result.payload }), {
     status: 200,
     headers: {
       "Content-Type": "application/json",
@@ -891,7 +1063,7 @@ async function handleJiraTokenExchange(
 
   let sealedRefreshToken: string;
   try {
-    const key = await getJiraEncryptKey(env, "aes-gcm-key:jira-refresh-token");
+    const key = await getEncryptKey(env, "aes-gcm-key:jira-refresh-token");
     sealedRefreshToken = await sealToken(refreshToken, key);
   } catch (err) {
     log("error", "jira_token_seal_failed", {
@@ -1007,7 +1179,7 @@ async function handleJiraTokenRefresh(
   let newSealedRefreshToken: string;
   try {
     // Always seal with active key (SEAL_KEY_NEXT if set) for natural key rotation
-    const key = await getJiraEncryptKey(env, "aes-gcm-key:jira-refresh-token");
+    const key = await getEncryptKey(env, "aes-gcm-key:jira-refresh-token");
     newSealedRefreshToken = await sealToken(newRefreshToken, key);
   } catch (err) {
     log("error", "jira_refresh_seal_failed", {
@@ -1337,7 +1509,7 @@ async function handleJiraProxy(
   let resealed: string | undefined;
   if (env.SEAL_KEY_NEXT) {
     try {
-      const nextKey = await getJiraEncryptKey(env, "aes-gcm-key:jira-api-token");
+      const nextKey = await getEncryptKey(env, "aes-gcm-key:jira-api-token");
       resealed = await sealToken(apiToken, nextKey);
     } catch {
       // Non-fatal: skip re-seal if it fails
@@ -1502,6 +1674,20 @@ export default Sentry.withSentry(
             });
           }
           return sealResponse;
+        }
+
+        // Credential-bundle unseal endpoint (pre-auth-reachable decryption oracle)
+        if (url.pathname === "/api/proxy/unseal") {
+          const unsealResponse = await handleProxyUnseal(request, env);
+          if (setCookie) {
+            const headers = new Headers(unsealResponse.headers);
+            headers.set("Set-Cookie", setCookie);
+            return new Response(unsealResponse.body, {
+              status: unsealResponse.status,
+              headers,
+            });
+          }
+          return unsealResponse;
         }
 
         if (url.pathname === "/api/jira/proxy") {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -227,10 +227,15 @@ function validateAndGuardProxyRoute(request: Request, env: Env, pathname: string
 }
 
 // ── Sealed-token endpoint ────────────────────────────────────────────────────
-const VALID_PURPOSES = new Set(["jira-api-token", "jira-refresh-token", "credential-export-bundle"]);
-// Single-value allowlist for /api/proxy/unseal — deliberately NOT derived from or
-// shared with VALID_PURPOSES, so Jira's sealed tokens can never be unsealed here.
-const UNSEAL_PURPOSE = "credential-export-bundle";
+// The one purpose string for the credential-export-bundle flow. Single-sourced
+// here so the seal allowlist (VALID_PURPOSES), the seal-side size cap +
+// sealWithExpiry branch, and the unseal-side allowlist all reference ONE value —
+// changing it can never leave the seal and unseal sides silently disagreeing
+// (which would drop bundles back to the 2048 cap + plain sealToken while unseal
+// accepts only the new value). Declared before VALID_PURPOSES so it can be
+// referenced in the Set initializer without hitting the TDZ.
+const CREDENTIAL_BUNDLE_PURPOSE = "credential-export-bundle";
+const VALID_PURPOSES = new Set(["jira-api-token", "jira-refresh-token", CREDENTIAL_BUNDLE_PURPOSE]);
 const ALLOWED_SEARCH_PARAMS = new Set(["jql", "maxResults", "fields", "startAt"]);
 const ALLOWED_ISSUE_PARAMS = new Set(["issueIdsOrKeys", "fields"]);
 
@@ -307,7 +312,7 @@ async function handleProxySeal(request: Request, env: Env, sessionId: string): P
   // plus Jira credentials envelope-encrypted client-side, so it needs headroom
   // (4096) for future growth; all other purposes stay at 2048. Checked AFTER the
   // purpose is validated so the raise is scoped to exactly one purpose.
-  const maxTokenLength = purpose === UNSEAL_PURPOSE ? 4096 : 2048;
+  const maxTokenLength = purpose === CREDENTIAL_BUNDLE_PURPOSE ? 4096 : 2048;
   if (token.length > maxTokenLength) {
     return errorResponse("invalid_request", 400);
   }
@@ -319,7 +324,7 @@ async function handleProxySeal(request: Request, env: Env, sessionId: string): P
     // The credential-export bundle is wrapped with a server-clock timestamp +
     // content-fingerprint nonce (for expiry + single-use); all other purposes
     // use the plain sealToken path unchanged.
-    sealed = purpose === UNSEAL_PURPOSE
+    sealed = purpose === CREDENTIAL_BUNDLE_PURPOSE
       ? await sealWithExpiry(token, key)
       : await sealToken(token, key);
   } catch (err) {
@@ -424,9 +429,10 @@ async function handleProxyUnseal(request: Request, env: Env): Promise<Response> 
     log("warn", "unseal_sealed_too_long", { sealed_length: sealed.length }, request);
     return errorResponse("invalid_request", 400);
   }
-  // Single-value purpose allowlist — any other value is treated identically to a
-  // corrupted blob (generic invalid), so Jira's sealed tokens gain no path here.
-  if (purpose !== UNSEAL_PURPOSE) {
+  // Single-value allowlist — a standalone equality check, NOT an iteration over
+  // VALID_PURPOSES; any other value is treated identically to a corrupted blob
+  // (generic invalid), so Jira's sealed-token purposes gain no path here.
+  if (purpose !== CREDENTIAL_BUNDLE_PURPOSE) {
     return errorResponse("invalid", 401);
   }
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -451,9 +451,13 @@ async function handleProxyUnseal(request: Request, env: Env): Promise<Response> 
   // Check-and-consume the content-fingerprint nonce. FAIL CLOSED on any KV error
   // — never return the payload if the nonce could not be checked-and-recorded,
   // otherwise a KV outage would silently disable the single-use protection. This
-  // also closes the unseal-then-reseal renewal loophole: resealing the same
+  // also blunts the unseal-then-reseal renewal loophole: resealing the same
   // payload reproduces the identical nonce (deterministic), so a resealed copy is
-  // rejected as already-consumed even though its own createdAt is fresh.
+  // rejected as already-consumed even though its own createdAt is fresh. This is
+  // best-effort and bounded by the nonce's TTL below: once the nonce expires from
+  // KV a resealed copy becomes unsealable again. That is harmless — a code-less
+  // unseal only ever yields the inert, still-code-encrypted ciphertext, so
+  // single-use here is an availability guarantee, not a confidentiality one.
   try {
     const consumed = await nonceKv.get(result.nonce);
     if (consumed !== null) {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1317,14 +1317,9 @@ async function handleJiraProxy(
   sessionId: string,
   setCookie: string | undefined
 ): Promise<Response> {
-  if (!env.JIRA_CLIENT_ID) {
-    log("warn", "jira_proxy_missing_client_id", {}, request);
-    return new Response(JSON.stringify({ error: "jira_not_configured", message: "JIRA_CLIENT_ID is not set — add it to .dev.vars (local) or Worker secrets (production)" }), {
-      status: 503,
-      headers: { "Content-Type": "application/json", ...SECURITY_HEADERS },
-    });
-  }
-
+  // No JIRA_CLIENT_ID check: this proxy serves API-token mode, which authenticates
+  // to Atlassian with basic auth (email + the unsealed API token) and never uses
+  // the OAuth client id. Requiring it would wrongly block token-only deployments.
   if (request.method !== "POST") {
     return errorResponse("method_not_allowed", 405);
   }

--- a/tests/app/lib/proxy.test.ts
+++ b/tests/app/lib/proxy.test.ts
@@ -642,3 +642,65 @@ describe("sealApiToken", () => {
     );
   });
 });
+
+// ── unsealCredentialBundle — R-101 turnstile retryability ─────────────────────
+// A CLIENT-side Turnstile-acquisition failure happens BEFORE any request reaches
+// the server, so the bundle's single-use nonce is never consumed and the whole
+// unseal is safely retryable. It MUST map to a distinct { reason: "turnstile" },
+// never the terminal { reason: "invalid" } (which callers treat as a burned
+// bundle).
+
+describe("unsealCredentialBundle — turnstile failure (R-101)", () => {
+  let mod: typeof import("../../../src/app/lib/proxy");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "test-site-key");
+    mod = await loadModule();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("maps a client-side Turnstile acquisition failure to { ok:false, reason:'turnstile' } without sending a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    // Force acquireTurnstileToken to reject before any request: fire the script's
+    // onerror (proxy.ts rejects loadTurnstileScript with "Failed to load ...").
+    vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
+      const el = node as HTMLScriptElement;
+      if (el.tagName === "SCRIPT") {
+        (el as unknown as { onerror: (() => void) | null }).onerror?.();
+        return node;
+      }
+      return node;
+    });
+
+    const res = await mod.unsealCredentialBundle("SEALED-BLOB");
+    expect(res).toEqual({ ok: false, reason: "turnstile" });
+    // No unseal request was ever sent → the server nonce was not consumed.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("is retryable after a turnstile failure — repeated attempts never send a request (nonce never consumed)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
+      const el = node as HTMLScriptElement;
+      if (el.tagName === "SCRIPT") {
+        (el as unknown as { onerror: (() => void) | null }).onerror?.();
+        return node;
+      }
+      return node;
+    });
+
+    const first = await mod.unsealCredentialBundle("SEALED-BLOB");
+    const second = await mod.unsealCredentialBundle("SEALED-BLOB");
+    expect(first).toEqual({ ok: false, reason: "turnstile" });
+    expect(second).toEqual({ ok: false, reason: "turnstile" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/lib/proxy.test.ts
+++ b/tests/app/lib/proxy.test.ts
@@ -704,3 +704,99 @@ describe("unsealCredentialBundle — turnstile failure (R-101)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+// ── unsealCredentialBundle — retryable non-consuming failures (SEC-001/API-001) ──
+// Failures that fire BEFORE the server reaches the single-use nonce leave the
+// bundle valid and must map to a DISTINCT retryable reason, never the terminal
+// { reason: "invalid" } that callers treat as a burned bundle.
+
+describe("unsealCredentialBundle — retryable non-consuming failures (SEC-001/API-001)", () => {
+  let mod: typeof import("../../../src/app/lib/proxy");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "test-site-key");
+    mod = await loadModule();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  // Turnstile succeeds (script onload + execute resolves a token) so the request
+  // reaches fetch, where each test varies the outcome.
+  function setupSuccessfulTurnstile() {
+    const mockTurnstile = makeMockTurnstile();
+    vi.stubGlobal("window", { ...window, turnstile: mockTurnstile });
+    vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
+      const el = node as HTMLScriptElement;
+      if (el.tagName === "SCRIPT") {
+        (el as unknown as { onload: (() => void) | null }).onload?.();
+        return node;
+      }
+      return node;
+    });
+    mockTurnstile.execute.mockImplementation(() => {
+      mockTurnstile._resolveToken("ts-token");
+    });
+  }
+
+  it("maps a thrown proxyFetch to { ok:false, reason:'network' } — retryable, nonce not consumed", async () => {
+    setupSuccessfulTurnstile();
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await mod.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "network" });
+    // A request was attempted but threw before any server response → no nonce burned.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a 429 response to { ok:false, reason:'rate-limited' } — retryable (pre-gate, pre-nonce)", async () => {
+    setupSuccessfulTurnstile();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "rate_limited" }), { status: 429 }),
+    ));
+    expect(await mod.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "rate-limited" });
+  });
+
+  it("maps a 403 turnstile_failed to { ok:false, reason:'network' } — retryable (pre-nonce)", async () => {
+    setupSuccessfulTurnstile();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "turnstile_failed" }), { status: 403 }),
+    ));
+    expect(await mod.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "network" });
+  });
+
+  it("maps a 503 internal_error to { ok:false, reason:'network' } — retryable (pre-nonce)", async () => {
+    setupSuccessfulTurnstile();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "internal_error" }), { status: 503 }),
+    ));
+    expect(await mod.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "network" });
+  });
+
+  it("keeps a genuine 401 { error:'invalid' } TERMINAL (bad blob / consumed nonce)", async () => {
+    setupSuccessfulTurnstile();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid" }), { status: 401 }),
+    ));
+    expect(await mod.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "invalid" });
+  });
+
+  it("still distinguishes { error:'expired' } (terminal) from the retryable reasons", async () => {
+    setupSuccessfulTurnstile();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "expired" }), { status: 401 }),
+    ));
+    expect(await mod.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("maps a 200 { payload } to { ok:true, ciphertext }", async () => {
+    setupSuccessfulTurnstile();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ payload: "INNER" }), { status: 200 }),
+    ));
+    expect(await mod.unsealCredentialBundle("SEALED")).toEqual({ ok: true, ciphertext: "INNER" });
+  });
+});

--- a/tests/app/lib/proxy.test.ts
+++ b/tests/app/lib/proxy.test.ts
@@ -190,14 +190,14 @@ describe("acquireTurnstileToken", () => {
   });
 
   it("throws immediately when siteKey is empty", async () => {
-    await expect(mod.acquireTurnstileToken("")).rejects.toThrow(
+    await expect(mod.acquireTurnstileToken("", "seal")).rejects.toThrow(
       "VITE_TURNSTILE_SITE_KEY not configured",
     );
   });
 
   it("throws immediately when siteKey is undefined-like empty", async () => {
     await expect(
-      mod.acquireTurnstileToken("" as string),
+      mod.acquireTurnstileToken("" as string, "seal"),
     ).rejects.toThrow("VITE_TURNSTILE_SITE_KEY not configured");
   });
 
@@ -240,7 +240,7 @@ describe("acquireTurnstileToken", () => {
       return realHeadAppend(node);
     });
 
-    const tokenPromise = mod.acquireTurnstileToken("test-site-key");
+    const tokenPromise = mod.acquireTurnstileToken("test-site-key", "seal");
 
     // Allow the loadTurnstileScript + render to complete
     await Promise.resolve();
@@ -274,7 +274,7 @@ describe("acquireTurnstileToken", () => {
       return node;
     });
 
-    const tokenPromise = mod.acquireTurnstileToken("test-site-key");
+    const tokenPromise = mod.acquireTurnstileToken("test-site-key", "seal");
 
     await Promise.resolve();
     await Promise.resolve();
@@ -300,7 +300,7 @@ describe("acquireTurnstileToken", () => {
       return node;
     });
 
-    const tokenPromise = mod.acquireTurnstileToken("test-site-key");
+    const tokenPromise = mod.acquireTurnstileToken("test-site-key", "seal");
 
     await Promise.resolve();
     await Promise.resolve();
@@ -326,7 +326,7 @@ describe("acquireTurnstileToken", () => {
       return node;
     });
 
-    const tokenPromise = mod.acquireTurnstileToken("test-site-key");
+    const tokenPromise = mod.acquireTurnstileToken("test-site-key", "seal");
 
     await Promise.resolve();
     await Promise.resolve();
@@ -355,7 +355,7 @@ describe("acquireTurnstileToken", () => {
       return node;
     });
 
-    await expect(mod.acquireTurnstileToken("test-site-key")).rejects.toThrow(
+    await expect(mod.acquireTurnstileToken("test-site-key", "seal")).rejects.toThrow(
       "Invalid sitekey",
     );
   });
@@ -370,7 +370,7 @@ describe("acquireTurnstileToken", () => {
       return node;
     });
 
-    await expect(mod.acquireTurnstileToken("test-site-key")).rejects.toThrow(
+    await expect(mod.acquireTurnstileToken("test-site-key", "seal")).rejects.toThrow(
       "Failed to load Turnstile script",
     );
   });
@@ -411,7 +411,7 @@ describe("acquireTurnstileToken — 30-second outer timeout", () => {
       return node;
     });
 
-    const tokenPromise = mod.acquireTurnstileToken("test-site-key");
+    const tokenPromise = mod.acquireTurnstileToken("test-site-key", "seal");
     // Prevent unhandled rejection during timer advancement
     void tokenPromise.catch(() => {});
 
@@ -458,10 +458,10 @@ describe("acquireTurnstileToken — script reuse", () => {
       return node;
     });
 
-    const token1 = await mod.acquireTurnstileToken("test-site-key");
+    const token1 = await mod.acquireTurnstileToken("test-site-key", "seal");
     expect(token1).toBe("reuse-token");
 
-    const token2 = await mod.acquireTurnstileToken("test-site-key");
+    const token2 = await mod.acquireTurnstileToken("test-site-key", "seal");
     expect(token2).toBe("reuse-token");
 
     const scriptAppends = appendSpy.mock.calls.filter(

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -360,7 +360,7 @@ describe("LoginPage — PAT form validation", () => {
   });
 });
 
-// ── Import from backup (Task 7) ───────────────────────────────────────────────
+// ── Import from backup ────────────────────────────────────────────────────────
 
 describe("LoginPage — Import from backup", () => {
   const CODE = "1111-2222-3333-4444-5555-6666-77"; // 26-char Crockford base32, dashed
@@ -733,9 +733,9 @@ describe("LoginPage — Import from backup", () => {
     expect(clearOrder).toBeLessThan(cfgOrder);
   });
 
-  // ── STRUCT-C-001: generation guard + in-flight close lock ───────────────────
+  // ── generation guard + in-flight close lock ─────────────────────────────────
 
-  it("STRUCT-C-001: a Cancel during resolve discards the stale continuation — no auto-login/navigation as the abandoned identity", async () => {
+  it("a Cancel during resolve discards the stale continuation — no auto-login/navigation as the abandoned identity", async () => {
     mockValidCredsFile();
     vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
     // Defer the resolve so the flow can be abandoned while it is pending.
@@ -767,7 +767,7 @@ describe("LoginPage — Import from backup", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("STRUCT-C-001: Cancel is disabled while the unseal is in flight", async () => {
+  it("Cancel is disabled while the unseal is in flight", async () => {
     mockValidCredsFile();
     let resolveUnseal!: (v: { ok: true; ciphertext: string }) => void;
     vi.mocked(proxyLib.unsealCredentialBundle).mockReturnValue(new Promise((r) => { resolveUnseal = r; }));

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -1,11 +1,48 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { render, screen, waitFor, fireEvent } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-vi.mock("../../src/app/stores/auth", () => ({
-  setAuthFromPat: vi.fn(),
+// Partial mock: keep the REAL user()/token()/clearIdentityData()/setJiraAuth()
+// (the cross-identity test drives the REAL commitImportedSettings through them),
+// but replace the identity setters with spies. setAuthFromCredential is a SEPARATE
+// spy so the import-commit path's call is observable and ordered.
+vi.mock("../../src/app/stores/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/app/stores/auth")>();
+  return {
+    ...actual,
+    setAuthFromPat: vi.fn(),
+    setAuthFromCredential: vi.fn(),
+  };
+});
+
+// Partial mock: keep CredentialsSectionSchema (the component validates
+// `_credentials` with it) + the real commitImportedSettings available to delegate
+// to; stub the flow functions per-test.
+vi.mock("../../src/app/lib/settings-transfer", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/app/lib/settings-transfer")>();
+  return {
+    ...actual,
+    parseImportFile: vi.fn(),
+    resolveImportedCredentials: vi.fn(),
+    commitImportedSettings: vi.fn(),
+    hasExistingLocalConfig: vi.fn(),
+  };
+});
+
+vi.mock("../../src/app/lib/proxy", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/app/lib/proxy")>();
+  return { ...actual, unsealCredentialBundle: vi.fn() };
+});
+
+vi.mock("../../src/app/stores/cache", () => ({
+  clearCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@sentry/solid", () => ({
+  captureException: vi.fn(),
+  withSentryErrorBoundary: vi.fn((c: unknown) => c),
 }));
 
 vi.mock("../../src/app/lib/pat", async (importOriginal) => {
@@ -35,6 +72,12 @@ vi.mock("@solidjs/router", () => ({
 import LoginPage from "../../src/app/pages/LoginPage";
 import * as authStore from "../../src/app/stores/auth";
 import * as patLib from "../../src/app/lib/pat";
+import * as settingsTransfer from "../../src/app/lib/settings-transfer";
+import * as proxyLib from "../../src/app/lib/proxy";
+import * as cacheStore from "../../src/app/stores/cache";
+import * as configStore from "../../src/app/stores/config";
+import { ConfigSchema } from "../../src/shared/schemas";
+import type { CredentialBundle } from "../../src/app/lib/settings-transfer";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -314,5 +357,308 @@ describe("LoginPage — PAT form validation", () => {
       expect(authStore.setAuthFromPat).not.toHaveBeenCalled();
     });
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Import from backup (Task 7) ───────────────────────────────────────────────
+
+describe("LoginPage — Import from backup", () => {
+  const CODE = "1111-2222-3333-4444-5555-6666-7777-8888";
+  const IDENTITY = { login: "newuser", avatar_url: "https://a/new", name: "New User" };
+  const BUNDLE: CredentialBundle = { github: { token: "ghp_new", method: "pat" }, jira: null };
+
+  function baseConfig() {
+    return ConfigSchema.parse({});
+  }
+
+  beforeEach(() => {
+    // clearAllMocks (parent beforeEach) only clears CALL history; reset the flow
+    // stubs' implementations so a mockReturnValue from one test can't leak.
+    vi.mocked(settingsTransfer.parseImportFile).mockReset();
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockReset();
+    vi.mocked(settingsTransfer.commitImportedSettings).mockReset();
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReset();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockReset();
+  });
+
+  async function openImport(user: ReturnType<typeof userEvent.setup>) {
+    render(() => <LoginPage />);
+    await user.click(screen.getByRole("button", { name: "Import from backup" }));
+  }
+
+  // Fires the file-input change; parseImportFile is mocked, so the file content
+  // itself is irrelevant beyond File.text() resolving.
+  function fireFileChange() {
+    const input = screen.getByLabelText("Import backup file");
+    const file = new File(["{}"], "settings.json", { type: "application/json" });
+    fireEvent.change(input, { target: { files: [file] } });
+  }
+
+  function mockValidCredsFile() {
+    vi.mocked(settingsTransfer.parseImportFile).mockReturnValue({
+      ok: true,
+      config: baseConfig(),
+      rawJson: { _credentials: { sealed: "S", salt: "SA" } },
+    });
+  }
+
+  // ── Step 2: file detection + local error area ──────────────────────────────
+
+  it("shows a parse-error message in the local error area (never a toast)", async () => {
+    vi.mocked(settingsTransfer.parseImportFile).mockReturnValue({
+      ok: false,
+      errors: ["File is not valid JSON."],
+    });
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/not valid JSON/i));
+    expect(screen.queryByLabelText("One-time code")).toBeNull();
+  });
+
+  it("shows the sign-in-first guidance for a credentials-less export, with no code prompt", async () => {
+    vi.mocked(settingsTransfer.parseImportFile).mockReturnValue({
+      ok: true,
+      config: baseConfig(),
+      rawJson: { theme: "dark" },
+    });
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(/doesn't contain credentials/i)
+    );
+    expect(screen.queryByLabelText("One-time code")).toBeNull();
+  });
+
+  it("treats a null _credentials as no-credentials (guidance, no TypeError, no code prompt)", async () => {
+    vi.mocked(settingsTransfer.parseImportFile).mockReturnValue({
+      ok: true,
+      config: baseConfig(),
+      rawJson: { _credentials: null },
+    });
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(/doesn't contain credentials/i)
+    );
+    expect(screen.queryByLabelText("One-time code")).toBeNull();
+  });
+
+  it("renders a password-type one-time-code input for a valid _credentials section", async () => {
+    mockValidCredsFile();
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    expect((screen.getByLabelText("One-time code") as HTMLInputElement).type).toBe("password");
+    // No error surfaced on a clean valid-creds detection.
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // ── Step 3: unseal → resolve → conditional confirm → commit → navigate ──────
+
+  it("fresh local config skips the confirmation dialog and navigates directly", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(false);
+    vi.mocked(settingsTransfer.commitImportedSettings).mockResolvedValue({ jiraRestored: true });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
+    expect(settingsTransfer.commitImportedSettings).toHaveBeenCalledWith(
+      { bundle: BUNDLE, identity: IDENTITY },
+      expect.objectContaining({ theme: expect.any(String) })
+    );
+    expect(screen.queryByText(/sign you in as/i)).toBeNull();
+  });
+
+  it("existing local config shows the identity dialog and navigates only after confirm", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(true);
+    vi.mocked(settingsTransfer.commitImportedSettings).mockResolvedValue({ jiraRestored: true });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => screen.getByText(/sign you in as/i));
+    screen.getByText(/@newuser/);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(settingsTransfer.commitImportedSettings).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
+    expect(settingsTransfer.commitImportedSettings).toHaveBeenCalled();
+  });
+
+  it("declining the identity dialog leaves the page in place — no navigation, no commit", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(true);
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+    await waitFor(() => screen.getByText(/sign you in as/i));
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(settingsTransfer.commitImportedSettings).not.toHaveBeenCalled();
+  });
+
+  it("wrong code then correct code: retries against the cached ciphertext, unseals only ONCE", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials)
+      .mockResolvedValueOnce({ ok: false, error: "Couldn't decrypt credentials — check the code and file match." })
+      .mockResolvedValueOnce({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(false);
+    vi.mocked(settingsTransfer.commitImportedSettings).mockResolvedValue({ jiraRestored: true });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    const codeField = screen.getByLabelText("One-time code");
+    await user.type(codeField, "wrong");
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/check the code and file match/i));
+    expect(mockNavigate).not.toHaveBeenCalled();
+    screen.getByLabelText("One-time code"); // still available for retry
+
+    await user.clear(codeField);
+    await user.type(codeField, CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
+
+    expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("an expired unseal shows the distinct expired message and withdraws the code prompt", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: false, reason: "expired" });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/expired/i));
+    expect(screen.queryByLabelText("One-time code")).toBeNull(); // terminal — no retry
+    screen.getByRole("button", { name: "Back to sign in" });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("a revoked GitHub credential surfaces the distinct revoked message and keeps the code prompt", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({
+      ok: false,
+      error: "Imported GitHub credential is no longer valid — it may have been revoked, or the token/session has expired.",
+    });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/no longer valid|revoked/i));
+    screen.getByLabelText("One-time code"); // still available (retryable)
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("R-101: a turnstile failure shows a retryable message, keeps the code prompt, and re-unseals on retry", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle)
+      .mockResolvedValueOnce({ ok: false, reason: "turnstile" })
+      .mockResolvedValueOnce({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(false);
+    vi.mocked(settingsTransfer.commitImportedSettings).mockResolvedValue({ jiraRestored: true });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/verification failed/i));
+    screen.getByLabelText("One-time code"); // NON-terminal — retry still possible
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
+    // Re-unsealed (nonce never consumed on the client-side turnstile failure).
+    expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(2);
+  });
+
+  // ── Must-have: cross-identity IndexedDB isolation (REAL clearIdentityData) ───
+
+  it("cross-identity: clears the prior identity's IndexedDB cache (real clearIdentityData) BEFORE establishing the imported identity/config", async () => {
+    // Delegate to the REAL commitImportedSettings so the pre-auth (user()===null)
+    // clearIdentityData ordering actually executes. Auth is partially mocked so
+    // user()/clearIdentityData() are real; clearCache is mocked (no real IndexedDB).
+    const actualTransfer = await vi.importActual<typeof import("../../src/app/lib/settings-transfer")>(
+      "../../src/app/lib/settings-transfer"
+    );
+    vi.mocked(settingsTransfer.commitImportedSettings).mockImplementation(actualTransfer.commitImportedSettings);
+
+    vi.mocked(settingsTransfer.parseImportFile).mockReturnValue({
+      ok: true,
+      config: ConfigSchema.parse({}),
+      rawJson: { _credentials: { sealed: "S", salt: "SA" } },
+    });
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({
+      ok: true,
+      bundle: { github: { token: "ghp_new", method: "pat" }, jira: null },
+      identity: IDENTITY,
+    });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(false); // skip dialog → immediate commit
+
+    const setConfigSpy = vi.spyOn(configStore, "setConfig");
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
+
+    // clearCache (fired by the REAL clearIdentityData, pre-auth path) ran, and
+    // strictly BEFORE the imported identity/config were established.
+    expect(cacheStore.clearCache).toHaveBeenCalled();
+    expect(authStore.setAuthFromCredential).toHaveBeenCalled();
+    const clearOrder = vi.mocked(cacheStore.clearCache).mock.invocationCallOrder[0];
+    const authOrder = vi.mocked(authStore.setAuthFromCredential).mock.invocationCallOrder[0];
+    const cfgOrder = setConfigSpy.mock.invocationCallOrder[0];
+    expect(clearOrder).toBeLessThan(authOrder);
+    expect(clearOrder).toBeLessThan(cfgOrder);
   });
 });

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -661,4 +661,93 @@ describe("LoginPage — Import from backup", () => {
     expect(clearOrder).toBeLessThan(authOrder);
     expect(clearOrder).toBeLessThan(cfgOrder);
   });
+
+  // ── STRUCT-C-001: generation guard + in-flight close lock ───────────────────
+
+  it("STRUCT-C-001: a Cancel during resolve discards the stale continuation — no auto-login/navigation as the abandoned identity", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    // Defer the resolve so the flow can be abandoned while it is pending.
+    let finishResolve!: (v: { ok: true; bundle: CredentialBundle; identity: typeof IDENTITY }) => void;
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockReturnValueOnce(
+      new Promise((r) => { finishResolve = r as never; })
+    );
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(false); // would otherwise auto-login
+    vi.mocked(settingsTransfer.commitImportedSettings).mockResolvedValue({ jiraRestored: true });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    // Unseal done (unsealInFlight false), resolve in flight — Cancel is enabled.
+    await waitFor(() => expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole("button", { name: "Cancel" })); // abandons the flow (gen++)
+
+    // The stale resolve now completes — the generation guard must discard it, so
+    // no commit and no auto-login/navigation as the abandoned file's identity.
+    finishResolve({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settingsTransfer.commitImportedSettings).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("STRUCT-C-001: Cancel is disabled while the unseal is in flight", async () => {
+    mockValidCredsFile();
+    let resolveUnseal!: (v: { ok: true; ciphertext: string }) => void;
+    vi.mocked(proxyLib.unsealCredentialBundle).mockReturnValue(new Promise((r) => { resolveUnseal = r; }));
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(false);
+    vi.mocked(settingsTransfer.commitImportedSettings).mockResolvedValue({ jiraRestored: true });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() =>
+      expect((screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement).disabled).toBe(true)
+    );
+    resolveUnseal({ ok: true, ciphertext: "CT" });
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
+  });
+
+  it("a retryable network unseal keeps the code prompt (not terminal)", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: false, reason: "network" });
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/network problem/i));
+    screen.getByLabelText("One-time code"); // NON-terminal — retry still possible
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("a commit failure during finalize surfaces an inline error (finalizeImport catch branch)", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(false); // auto-commit path
+    vi.mocked(settingsTransfer.commitImportedSettings).mockRejectedValue(new Error("commit boom"));
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/something went wrong/i));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
 });

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -476,7 +476,8 @@ describe("LoginPage — Import from backup", () => {
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
     expect(settingsTransfer.commitImportedSettings).toHaveBeenCalledWith(
       { bundle: BUNDLE, identity: IDENTITY },
-      expect.objectContaining({ theme: expect.any(String) })
+      expect.objectContaining({ theme: expect.any(String) }),
+      undefined // no _viewPreferences section in this test's mocked file content
     );
     expect(screen.queryByText(/sign you in as/i)).toBeNull();
   });

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -505,6 +505,26 @@ describe("LoginPage — Import from backup", () => {
     expect(settingsTransfer.commitImportedSettings).toHaveBeenCalled();
   });
 
+  it("a commit failure on the identity-confirm path surfaces an inline error and does not navigate", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(true);
+    vi.mocked(settingsTransfer.commitImportedSettings).mockRejectedValue(new Error("commit boom"));
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+    await waitFor(() => screen.getByText(/sign you in as/i));
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => screen.getByText(/something went wrong finishing the import/i));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it("declining the identity dialog leaves the page in place — no navigation, no commit", async () => {
     mockValidCredsFile();
     vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
@@ -522,6 +542,34 @@ describe("LoginPage — Import from backup", () => {
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(settingsTransfer.commitImportedSettings).not.toHaveBeenCalled();
+  });
+
+  it("pr-test-2: concurrent double-click on Continue calls commitImportedSettings EXACTLY once (finalizeImport in-flight guard)", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.hasExistingLocalConfig).mockReturnValue(true);
+    let resolveCommit!: (v: { jiraRestored: boolean }) => void;
+    vi.mocked(settingsTransfer.commitImportedSettings).mockReturnValue(
+      new Promise((r) => { resolveCommit = r; })
+    );
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+    await waitFor(() => screen.getByText(/sign you in as/i));
+
+    const continueBtn = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+    fireEvent.click(continueBtn);
+    continueBtn.disabled = false;
+    fireEvent.click(continueBtn);
+    resolveCommit({ jiraRestored: true });
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }));
+    expect(settingsTransfer.commitImportedSettings).toHaveBeenCalledTimes(1);
   });
 
   it("wrong code then correct code: retries against the cached ciphertext, unseals only ONCE", async () => {

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -619,6 +619,28 @@ describe("LoginPage — Import from backup", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it("an invalid (non-expired) unseal shows the single-use terminal message, distinct from 'expired'", async () => {
+    mockValidCredsFile();
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: false, reason: "invalid" });
+
+    const user = userEvent.setup();
+    await openImport(user);
+    fireFileChange();
+    await waitFor(() => screen.getByLabelText("One-time code"));
+    await user.type(screen.getByLabelText("One-time code"), CODE);
+    await user.click(screen.getByRole("button", { name: "Restore credentials" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toBe(
+        "Couldn't restore credentials — this file may already have been used (single-use), or the code/file don't match. Re-export to try again."
+      )
+    );
+    expect(screen.getByRole("alert").textContent).not.toMatch(/expired/i);
+    expect(screen.queryByLabelText("One-time code")).toBeNull(); // terminal — no retry
+    screen.getByRole("button", { name: "Back to sign in" });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it("a revoked GitHub credential surfaces the distinct revoked message and keeps the code prompt", async () => {
     mockValidCredsFile();
     vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CT" });

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -363,7 +363,7 @@ describe("LoginPage — PAT form validation", () => {
 // ── Import from backup (Task 7) ───────────────────────────────────────────────
 
 describe("LoginPage — Import from backup", () => {
-  const CODE = "1111-2222-3333-4444-5555-6666-7777-8888";
+  const CODE = "1111-2222-3333-4444-5555-6666-77"; // 26-char Crockford base32, dashed
   const IDENTITY = { login: "newuser", avatar_url: "https://a/new", name: "New User" };
   const BUNDLE: CredentialBundle = { github: { token: "ghp_new", method: "pat" }, jira: null };
 

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1500,6 +1500,61 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
     expect(createObjSpy).not.toHaveBeenCalled();
     expect(checkbox.checked).toBe(true);
   });
+
+  it("dismissing the code modal (Cancel) downloads nothing and leaves no residual state", async () => {
+    vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockResolvedValue({
+      sealed: "SEALED", salt: "SALT", oneTimeCode: CODE,
+    });
+    const createObjSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:x");
+    const clickSpy = vi.fn();
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreate(tag);
+      if (tag === "a") vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(clickSpy);
+      return el;
+    });
+
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByRole("checkbox", { name: /include encrypted credentials/i }));
+    await user.click(screen.getByRole("button", { name: "Export" }));
+    await waitFor(() => screen.getByText(/shown only once/i));
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    // No file was downloaded on dismiss. (Kobalte's exit Presence lingers the
+    // modal content in happy-dom, so this asserts the download behavior rather
+    // than the modal's DOM removal.)
+    expect(createObjSpy).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+    // No residual pending download: a fresh export cleanly re-runs the seal flow
+    // (proving handleDismissExportCode cleared exportCode + pendingExportJson).
+    // fireEvent (not userEvent): the dismissed Kobalte modal lingers its
+    // pointer-events:none on <body> in happy-dom, blocking a userEvent click.
+    fireEvent.click(screen.getByRole("button", { name: "Export" }));
+    await waitFor(() => expect(settingsTransfer.buildEncryptedCredentialsSection).toHaveBeenCalledTimes(2));
+  });
+
+  it("a second export while the code modal is open does NOT mint a new code / re-run the seal flow", async () => {
+    const buildSpy = vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockResolvedValue({
+      sealed: "SEALED", salt: "SALT", oneTimeCode: CODE,
+    });
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByRole("checkbox", { name: /include encrypted credentials/i }));
+    const exportBtn = screen.getByRole("button", { name: "Export" });
+    await user.click(exportBtn);
+    await waitFor(() => screen.getByText(/shown only once/i));
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+
+    // The Kobalte Dialog traps + restores focus so the Export button can't be
+    // re-fired behind the modal; the re-entry guard closes the gap for any other
+    // trigger path. Re-fire the handler directly and assert no new code is minted.
+    fireEvent.click(exportBtn);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+    screen.getByText(CODE); // the original code is still the one shown
+  });
 });
 
 // ── Import with encrypted credentials (Task 6) ────────────────────────────────
@@ -1631,7 +1686,7 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     });
   });
 
-  it("'continue without credentials' applies the plaintext config only (no unseal)", async () => {
+  it("'continue without credentials' routes through the shared two-click confirm, then applies plaintext config (no unseal)", async () => {
     const user = userEvent.setup();
     updateConfig({ theme: "light" });
     renderSettings();
@@ -1639,7 +1694,19 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     await waitFor(() => screen.getByLabelText(/one-time code/i));
     await user.click(screen.getByRole("button", { name: /continue without credentials/i }));
 
-    expect(config.theme).toBe("dark"); // plaintext config applied
+    // UI-003: the SAME plaintext two-click confirm the plaintext-import path uses
+    // appears (inline in the Import row) — nothing applied until it's confirmed.
+    // (The Kobalte dialog's exit Presence doesn't unmount synchronously in
+    // happy-dom, so this asserts behavior rather than the code input's removal —
+    // matching the CustomTabModal/NotificationDrawer test convention.)
+    await waitFor(() => screen.getByRole("button", { name: "Yes, import" }));
+    expect(config.theme).toBe("light");
+
+    // fireEvent (not userEvent): the just-closed Kobalte modal lingers its
+    // pointer-events:none on <body> in happy-dom, which would block a userEvent
+    // pointer interaction with this now-inline confirm button.
+    fireEvent.click(screen.getByRole("button", { name: "Yes, import" }));
+    expect(config.theme).toBe("dark"); // plaintext config applied on confirm
     expect(proxyLib.unsealCredentialBundle).not.toHaveBeenCalled();
   });
 
@@ -1651,9 +1718,13 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     await waitFor(() => screen.getByLabelText(/one-time code/i));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.queryByLabelText(/one-time code/i)).toBeNull();
-    expect(config.theme).toBe("light"); // untouched
+    // Config + session untouched, no unseal attempted, and no identity-confirm or
+    // plaintext-confirm was triggered. (Kobalte's exit Presence lingers the code
+    // input in happy-dom, so this asserts behavior rather than DOM removal.)
+    expect(config.theme).toBe("light");
     expect(proxyLib.unsealCredentialBundle).not.toHaveBeenCalled();
+    expect(screen.queryByText(/sign you in as/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Yes, import" })).toBeNull();
   });
 
   it("a null _credentials falls through to the plaintext import path (no code prompt)", async () => {
@@ -1667,5 +1738,137 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     expect(screen.queryByLabelText(/one-time code/i)).toBeNull();
     await user.click(screen.getByRole("button", { name: "Yes, import" }));
     expect(config.theme).toBe("dark");
+  });
+
+  it("STRUCT-C-001: Cancel and 'continue without credentials' are disabled while the unseal is in flight", async () => {
+    let resolveUnseal!: (v: { ok: true; ciphertext: string }) => void;
+    vi.mocked(proxyLib.unsealCredentialBundle).mockReturnValue(new Promise((r) => { resolveUnseal = r; }));
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    // Unseal in flight — the single-use nonce must not be abandonable mid-flight.
+    await waitFor(() =>
+      expect((screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement).disabled).toBe(true)
+    );
+    expect((screen.getByRole("button", { name: /continue without credentials/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Checking..." }) as HTMLButtonElement).disabled).toBe(true);
+
+    resolveUnseal({ ok: true, ciphertext: "CIPHER" });
+    await waitFor(() => screen.getByText(/sign you in as/i));
+  });
+
+  it("STRUCT-C-001: a Cancel-then-reselect during resolve discards the stale continuation (no wrong-identity dialog)", async () => {
+    // Unseal resolves immediately; resolve is deferred so the test can cancel and
+    // reselect a different file while file X's resolve is still pending.
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CIPHER-X" });
+    let finishResolveX!: (v: { ok: true; bundle: typeof BUNDLE; identity: typeof IDENTITY }) => void;
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockReturnValueOnce(
+      new Promise((r) => { finishResolveX = r as never; })
+    );
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile(); // file X
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    // X's unseal done (unsealInFlight false), X's resolve in flight — Cancel enabled.
+    await waitFor(() => expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole("button", { name: "Cancel" })); // abandons file X (gen++)
+
+    // Reselect a different file Y.
+    selectCredFile({ theme: "light" });
+    await waitFor(() => screen.getByLabelText(/one-time code/i)); // Y's code form
+
+    // X's stale resolve now completes — the generation guard must discard it.
+    finishResolveX({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // No identity-confirm dialog appears for the abandoned file's identity, and
+    // no commit happens; the freshly-selected file's code form is still shown.
+    expect(screen.queryByText(/sign you in as/i)).toBeNull();
+    expect(settingsTransfer.commitImportedSettings).not.toHaveBeenCalled();
+    screen.getByLabelText(/one-time code/i);
+  });
+
+  it("a retryable network unseal keeps the code input available (not terminal)", async () => {
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: false, reason: "network" });
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/network problem/i));
+    // Non-terminal: the code input + Submit stay available (no terminal screen).
+    screen.getByLabelText(/one-time code/i);
+    screen.getByRole("button", { name: "Submit" });
+  });
+
+  it("a rate-limited unseal keeps the code input available with a retryable message", async () => {
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: false, reason: "rate-limited" });
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/too many attempts/i));
+    screen.getByLabelText(/one-time code/i);
+  });
+
+  it("a commit failure during cred import pushes a warning (handleConfirmCredImport catch branch)", async () => {
+    const { pushNotification } = await import("../../../src/app/lib/errors");
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CIPHER" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.commitImportedSettings).mockRejectedValue(new Error("commit boom"));
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await waitFor(() => screen.getByText(/sign you in as/i));
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(pushNotification).toHaveBeenCalledWith(
+        "settings-import",
+        expect.stringMatching(/something went wrong/i),
+        "warning"
+      );
+    });
+  });
+
+  it("CR-001: after import, the Repositories editor reflects the imported repos (local copies resynced)", async () => {
+    const user = userEvent.setup();
+    updateConfig({ selectedRepos: [], upstreamRepos: [] });
+    renderSettings();
+    const input = screen.getByLabelText(/import settings file/i);
+    const imported = JSON.stringify({
+      selectedRepos: [
+        { owner: "acme", name: "api", fullName: "acme/api" },
+        { owner: "acme", name: "web", fullName: "acme/web" },
+      ],
+    });
+    fireEvent.change(input, { target: { files: [new File([imported], "s.json", { type: "application/json" })] } });
+    await waitFor(() => screen.getByRole("button", { name: "Yes, import" }));
+    await user.click(screen.getByRole("button", { name: "Yes, import" }));
+
+    expect(config.selectedRepos).toHaveLength(2);
+    // The Repositories summary is driven by the localRepos editor copy; without
+    // the post-import resync it would still read the stale (empty) pre-import set.
+    await waitFor(() => screen.getByText(/2 selected/i));
   });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1449,7 +1449,7 @@ describe("Dependencies settings section", () => {
 // ── Export with encrypted credentials (Task 5) ────────────────────────────────
 
 describe("SettingsPage — Data: Export with encrypted credentials", () => {
-  const CODE = "1111-2222-3333-4444-5555-6666-7777-8888";
+  const CODE = "1111-2222-3333-4444-5555-6666-77"; // 26-char Crockford base32, dashed
 
   it("checking the box + export shows the one-time-code modal and defers download until acknowledged", async () => {
     vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockResolvedValue({
@@ -1560,7 +1560,7 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
 // ── Import with encrypted credentials (Task 6) ────────────────────────────────
 
 describe("SettingsPage — Data: Import with encrypted credentials", () => {
-  const CODE = "1111-2222-3333-4444-5555-6666-7777-8888";
+  const CODE = "1111-2222-3333-4444-5555-6666-77"; // 26-char Crockford base32, dashed
   const IDENTITY = { login: "octo", avatar_url: "https://avatars/octo", name: "Octo" };
   const BUNDLE = { github: { token: "ghp_x", method: "pat" as const }, jira: null };
 

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1582,6 +1582,32 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     screen.getByRole("button", { name: /continue without credentials/i });
   });
 
+  it("R-101: a turnstile failure keeps the code input (retryable) and re-unseals on retry", async () => {
+    // A client-side Turnstile failure happens BEFORE any request, so the nonce is
+    // never consumed — this is retryable, NOT the terminal expired/invalid screen.
+    vi.mocked(proxyLib.unsealCredentialBundle)
+      .mockResolvedValueOnce({ ok: false, reason: "turnstile" })
+      .mockResolvedValueOnce({ ok: true, ciphertext: "CIPHER" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    // Retryable inline error; code input + Submit still present (non-terminal).
+    await waitFor(() => screen.getByText(/verification failed/i));
+    screen.getByLabelText(/one-time code/i);
+    screen.getByRole("button", { name: "Submit" });
+
+    // Retry re-attempts the unseal (nonce never consumed) → success → confirm.
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await waitFor(() => screen.getByText(/sign you in as/i));
+    expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(2);
+  });
+
   it("concurrent double-submit calls unsealCredentialBundle EXACTLY once (in-flight guard)", async () => {
     let resolveUnseal!: (v: { ok: true; ciphertext: string }) => void;
     vi.mocked(proxyLib.unsealCredentialBundle).mockReturnValue(

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1591,7 +1591,8 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     await waitFor(() => {
       expect(settingsTransfer.commitImportedSettings).toHaveBeenCalledWith(
         { bundle: BUNDLE, identity: IDENTITY },
-        expect.objectContaining({ theme: "dark" })
+        expect.objectContaining({ theme: "dark" }),
+        undefined // no _viewPreferences section in this test's file content
       );
     });
   });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1686,6 +1686,35 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     });
   });
 
+  it("pr-test-2: concurrent double-click on Continue calls commitImportedSettings EXACTLY once (in-flight guard)", async () => {
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CIPHER" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    let resolveCommit!: (v: { jiraRestored: boolean }) => void;
+    vi.mocked(settingsTransfer.commitImportedSettings).mockReturnValue(
+      new Promise((r) => { resolveCommit = r; })
+    );
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await waitFor(() => screen.getByText(/sign you in as/i));
+
+    const continueBtn = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+    fireEvent.click(continueBtn);
+    // Force a second dispatch past the (already-applied) disabled attribute to
+    // exercise the in-function re-entry guard directly.
+    continueBtn.disabled = false;
+    fireEvent.click(continueBtn);
+    resolveCommit({ jiraRestored: true });
+
+    await waitFor(() => {
+      expect(settingsTransfer.commitImportedSettings).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("'continue without credentials' routes through the shared two-click confirm, then applies plaintext config (no unseal)", async () => {
     const user = userEvent.setup();
     updateConfig({ theme: "light" });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -466,6 +466,86 @@ describe("SettingsPage — Data: Export settings", () => {
   });
 });
 
+describe("SettingsPage — Data: Import settings", () => {
+  function selectImportFile(content: string, name = "settings.json") {
+    const input = screen.getByLabelText(/import settings file/i);
+    const file = new File([content], name, { type: "application/json" });
+    fireEvent.change(input, { target: { files: [file] } });
+    return file;
+  }
+
+  it("selecting a valid file shows the confirmation step without mutating the config store", async () => {
+    updateConfig({ theme: "light", itemsPerPage: 25 });
+    renderSettings();
+    selectImportFile(JSON.stringify({ theme: "dark", itemsPerPage: 50 }));
+    await waitFor(() => screen.getByText(/replace your current settings/i));
+    // Confirmation shown, but nothing applied yet
+    screen.getByRole("button", { name: "Yes, import" });
+    expect(config.theme).toBe("light");
+    expect(config.itemsPerPage).toBe(25);
+  });
+
+  it("confirming the import replaces config store fields", async () => {
+    const user = userEvent.setup();
+    updateConfig({ theme: "light", itemsPerPage: 25 });
+    renderSettings();
+    selectImportFile(JSON.stringify({ theme: "dark", itemsPerPage: 50 }));
+    await waitFor(() => screen.getByRole("button", { name: "Yes, import" }));
+    await user.click(screen.getByRole("button", { name: "Yes, import" }));
+    expect(config.theme).toBe("dark");
+    expect(config.itemsPerPage).toBe(50);
+    // Confirmation dismissed, Import button restored
+    expect(screen.queryByRole("button", { name: "Yes, import" })).toBeNull();
+    screen.getByRole("button", { name: "Import" });
+  });
+
+  it("canceling the confirmation resets the confirm-state and leaves the config store untouched", async () => {
+    const user = userEvent.setup();
+    updateConfig({ theme: "light" });
+    renderSettings();
+    selectImportFile(JSON.stringify({ theme: "dark" }));
+    await waitFor(() => screen.getByRole("button", { name: "Yes, import" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("button", { name: "Yes, import" })).toBeNull();
+    screen.getByRole("button", { name: "Import" });
+    expect(config.theme).toBe("light");
+  });
+
+  it("selecting a malformed file pushes a warning, shows no confirmation, leaves config unchanged", async () => {
+    const { pushNotification } = await import("../../../src/app/lib/errors");
+    updateConfig({ theme: "light" });
+    renderSettings();
+    selectImportFile("this is not json {{{");
+    await waitFor(() => {
+      expect(pushNotification).toHaveBeenCalledWith(
+        "settings-import",
+        expect.stringMatching(/import failed/i),
+        "warning"
+      );
+    });
+    expect(screen.queryByRole("button", { name: "Yes, import" })).toBeNull();
+    expect(config.theme).toBe("light");
+  });
+
+  it("an unreadable file (File.text rejects) is treated identically to a parse failure", async () => {
+    const { pushNotification } = await import("../../../src/app/lib/errors");
+    updateConfig({ theme: "light" });
+    renderSettings();
+    // A read rejection never reaches parseImportFile — distinct code path.
+    vi.spyOn(File.prototype, "text").mockRejectedValueOnce(new Error("unreadable"));
+    selectImportFile("irrelevant");
+    await waitFor(() => {
+      expect(pushNotification).toHaveBeenCalledWith(
+        "settings-import",
+        expect.stringMatching(/could not read/i),
+        "warning"
+      );
+    });
+    expect(screen.queryByRole("button", { name: "Yes, import" })).toBeNull();
+    expect(config.theme).toBe("light");
+  });
+});
+
 describe("SettingsPage — Data: Reset all", () => {
   it("shows Reset all button initially", () => {
     renderSettings();

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1684,6 +1684,27 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     screen.getByRole("button", { name: /continue without credentials/i });
   });
 
+  it("an invalid (non-expired) unseal shows the single-use terminal message, distinct from 'expired'", async () => {
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: false, reason: "invalid" });
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() =>
+      screen.getByText(
+        "Couldn't restore credentials — this file may already have been used (single-use), or the code/file don't match. Re-export to try again."
+      )
+    );
+    expect(screen.queryByText(/expired/i)).toBeNull();
+    // The code input is gone — the single-use bundle is spent, only the fallback remains.
+    expect(screen.queryByLabelText(/one-time code/i)).toBeNull();
+    screen.getByRole("button", { name: /continue without credentials/i });
+  });
+
   it("R-101: a turnstile failure keeps the code input (retryable) and re-unseals on retry", async () => {
     // A client-side Turnstile failure happens BEFORE any request, so the nonce is
     // never consumed — this is retryable, NOT the terminal expired/invalid screen.

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -461,11 +461,24 @@ describe("SettingsPage — Data: Clear cache", () => {
 });
 
 describe("SettingsPage — Data: Export settings", () => {
-  it("clicking Export triggers download", async () => {
-    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-url");
+  it("clicking Export opens the choice dialog", async () => {
+    renderSettings();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Export" }));
+
+    screen.getByText("Choose what to include in the exported file.");
+    screen.getByRole("button", { name: "Export config only" });
+    screen.getByRole("button", { name: "Export with encrypted credentials" });
+  });
+
+  it("choosing 'Export config only' downloads immediately with no _credentials section", async () => {
+    let capturedBlob: Blob | undefined;
+    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+      capturedBlob = blob as Blob;
+      return "blob:fake-url";
+    });
     const revokeObjectURLSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 
-    // Spy on anchor click
     const clickSpy = vi.fn();
     const origCreate = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
@@ -477,13 +490,28 @@ describe("SettingsPage — Data: Export settings", () => {
     });
 
     renderSettings();
-    const exportBtn = screen.getByText("Export");
     const user = userEvent.setup();
-    await user.click(exportBtn);
+    await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Export config only" }));
 
     expect(createObjectURLSpy).toHaveBeenCalledOnce();
     expect(clickSpy).toHaveBeenCalledOnce();
     expect(revokeObjectURLSpy).toHaveBeenCalledOnce();
+
+    expect(capturedBlob).toBeDefined();
+    const parsed = JSON.parse(await capturedBlob!.text()) as Record<string, unknown>;
+    expect("_credentials" in parsed).toBe(false);
+  });
+
+  it("Cancel in the choice dialog downloads nothing", async () => {
+    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-url");
+
+    renderSettings();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -1115,8 +1143,8 @@ describe("SettingsPage — enableTracking toggle", () => {
   it("includes enableTracking in exported settings JSON", async () => {
     updateConfig({ enableTracking: true });
     renderSettings();
-    const exportBtn = screen.getByRole("button", { name: /export/i });
     const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Export" }));
     const blobParts: BlobPart[] = [];
     const originalBlob = globalThis.Blob;
     globalThis.Blob = class MockBlob extends originalBlob {
@@ -1125,7 +1153,7 @@ describe("SettingsPage — enableTracking toggle", () => {
         if (parts) blobParts.push(...parts);
       }
     } as typeof Blob;
-    await user.click(exportBtn);
+    await user.click(screen.getByRole("button", { name: "Export config only" }));
     globalThis.Blob = originalBlob;
     const json = JSON.parse(blobParts[0] as string);
     expect(json.enableTracking).toBe(true);
@@ -1252,8 +1280,8 @@ describe("SettingsPage — monitor toggle wiring", () => {
     renderSettings();
 
     // Trigger export
-    const exportBtn = screen.getByRole("button", { name: /export/i });
     const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Export" }));
     const blobParts: BlobPart[] = [];
     const originalBlob = globalThis.Blob;
     globalThis.Blob = class MockBlob extends originalBlob {
@@ -1263,7 +1291,7 @@ describe("SettingsPage — monitor toggle wiring", () => {
       }
     } as typeof Blob;
 
-    await user.click(exportBtn);
+    await user.click(screen.getByRole("button", { name: "Export config only" }));
 
     globalThis.Blob = originalBlob;
     const json = JSON.parse(blobParts[0] as string);
@@ -1451,7 +1479,17 @@ describe("Dependencies settings section", () => {
 describe("SettingsPage — Data: Export with encrypted credentials", () => {
   const CODE = "1111-2222-3333-4444-5555-6666-77"; // 26-char Crockford base32, dashed
 
-  it("checking the box + export shows the one-time-code modal and defers download until acknowledged", async () => {
+  it("shows the single-use warning in the choice dialog before the credentials action", async () => {
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByRole("button", { name: "Export" }));
+
+    screen.getByText(
+      "This is a one-time transfer, not a durable backup — the encrypted credentials can be imported once and expire in 30 days."
+    );
+  });
+
+  it("choosing 'Export with encrypted credentials' shows the one-time-code modal and defers download until acknowledged", async () => {
     vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockResolvedValue({
       sealed: "SEALED",
       salt: "SALT",
@@ -1469,8 +1507,8 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
 
     const user = userEvent.setup();
     renderSettings();
-    await user.click(screen.getByRole("checkbox", { name: /include encrypted credentials/i }));
     await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Export with encrypted credentials" }));
 
     await waitFor(() => screen.getByText(/shown only once/i));
     // Modal shows the generated code; download NOT yet triggered.
@@ -1483,22 +1521,22 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
     expect(clickSpy).toHaveBeenCalledOnce();
   });
 
-  it("a seal failure pushes a warning, leaves the checkbox checked, and never downloads", async () => {
+  it("a seal failure pushes a warning, leaves the choice dialog open, and never downloads", async () => {
     const { pushNotification } = await import("../../../src/app/lib/errors");
     vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockRejectedValue(new Error("seal failed"));
     const createObjSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:x");
 
     const user = userEvent.setup();
     renderSettings();
-    const checkbox = screen.getByRole<HTMLInputElement>("checkbox", { name: /include encrypted credentials/i });
-    await user.click(checkbox);
     await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Export with encrypted credentials" }));
 
     await waitFor(() => {
       expect(pushNotification).toHaveBeenCalledWith("settings-export", expect.any(String), "warning");
     });
     expect(createObjSpy).not.toHaveBeenCalled();
-    expect(checkbox.checked).toBe(true);
+    // The choice dialog stays open so the user can retry without reopening it.
+    screen.getByRole("button", { name: "Export with encrypted credentials" });
   });
 
   it("dismissing the code modal (Cancel) downloads nothing and leaves no residual state", async () => {
@@ -1516,8 +1554,8 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
 
     const user = userEvent.setup();
     renderSettings();
-    await user.click(screen.getByRole("checkbox", { name: /include encrypted credentials/i }));
     await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Export with encrypted credentials" }));
     await waitFor(() => screen.getByText(/shown only once/i));
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
@@ -1531,6 +1569,7 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
     // fireEvent (not userEvent): the dismissed Kobalte modal lingers its
     // pointer-events:none on <body> in happy-dom, blocking a userEvent click.
     fireEvent.click(screen.getByRole("button", { name: "Export" }));
+    fireEvent.click(screen.getByRole("button", { name: "Export with encrypted credentials" }));
     await waitFor(() => expect(settingsTransfer.buildEncryptedCredentialsSection).toHaveBeenCalledTimes(2));
   });
 
@@ -1540,15 +1579,22 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
     });
     const user = userEvent.setup();
     renderSettings();
-    await user.click(screen.getByRole("checkbox", { name: /include encrypted credentials/i }));
+    // Captured BEFORE any dialog opens — once the code modal is open, the rest
+    // of the page (including this button) is legitimately aria-hidden, so a
+    // fresh getByRole query for it would correctly fail to find it. Reusing
+    // this reference below dispatches directly on the node, bypassing that
+    // (accurate) accessibility-tree filtering, the same way the real Kobalte
+    // focus trap bypasses it for an actual re-click.
     const exportBtn = screen.getByRole("button", { name: "Export" });
     await user.click(exportBtn);
+    await user.click(screen.getByRole("button", { name: "Export with encrypted credentials" }));
     await waitFor(() => screen.getByText(/shown only once/i));
     expect(buildSpy).toHaveBeenCalledTimes(1);
 
     // The Kobalte Dialog traps + restores focus so the Export button can't be
-    // re-fired behind the modal; the re-entry guard closes the gap for any other
-    // trigger path. Re-fire the handler directly and assert no new code is minted.
+    // re-fired behind the modal; the re-entry guard on handleOpenExportChoice
+    // closes the gap for any other trigger path. Re-fire the Export button
+    // directly and assert the choice dialog doesn't even reopen.
     fireEvent.click(exportBtn);
     await Promise.resolve();
     await Promise.resolve();

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -27,12 +27,31 @@ vi.mock("../../../src/app/stores/auth", () => ({
   clearJiraAuth: vi.fn(),
   setJiraAuth: vi.fn(),
   setAuthFromPat: vi.fn(),
+  setAuthFromCredential: vi.fn(),
+  clearIdentityData: vi.fn().mockResolvedValue(undefined),
   jiraAuth: () => null,
   isJiraAuthenticated: () => false,
   ensureJiraTokenValid: vi.fn(),
   token: vi.fn(() => "fake-token"),
-  user: () => ({ login: "testuser", name: "Test User" }),
+  user: () => ({ login: "testuser", avatar_url: "https://avatars/test", name: "Test User" }),
   onAuthCleared: vi.fn(),
+}));
+
+// Partial mock: keep the real buildExportPayload/parseImportFile/CredentialsSectionSchema
+// (used by the plaintext export/import paths), stub the credential-flow functions.
+vi.mock("../../../src/app/lib/settings-transfer", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/app/lib/settings-transfer")>();
+  return {
+    ...actual,
+    buildEncryptedCredentialsSection: vi.fn(),
+    resolveImportedCredentials: vi.fn(),
+    commitImportedSettings: vi.fn(),
+  };
+});
+
+vi.mock("../../../src/app/lib/proxy", () => ({
+  sealApiToken: vi.fn(),
+  unsealCredentialBundle: vi.fn(),
 }));
 
 vi.mock("@sentry/solid", () => ({
@@ -75,6 +94,8 @@ import { updateConfig, config } from "../../../src/app/stores/config";
 import { viewState, updateViewState } from "../../../src/app/stores/view";
 import { buildOrgAccessUrl } from "../../../src/app/lib/oauth";
 import * as urlModule from "../../../src/app/lib/url";
+import * as settingsTransfer from "../../../src/app/lib/settings-transfer";
+import * as proxyLib from "../../../src/app/lib/proxy";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -543,6 +564,18 @@ describe("SettingsPage — Data: Import settings", () => {
     });
     expect(screen.queryByRole("button", { name: "Yes, import" })).toBeNull();
     expect(config.theme).toBe("light");
+  });
+
+  it("wholesale-replaces config: a pre-set selectedRepos clears when absent from the imported file", async () => {
+    const user = userEvent.setup();
+    updateConfig({ selectedRepos: [{ owner: "o", name: "r", fullName: "o/r" }] });
+    renderSettings();
+    selectImportFile(JSON.stringify({ theme: "dark" })); // no selectedRepos in the imported file
+    await waitFor(() => screen.getByRole("button", { name: "Yes, import" }));
+    await user.click(screen.getByRole("button", { name: "Yes, import" }));
+    // Proves setConfig (wholesale) not updateConfig (partial merge): the prior field is gone.
+    expect(config.selectedRepos).toEqual([]);
+    expect(config.theme).toBe("dark");
   });
 });
 
@@ -1410,5 +1443,203 @@ describe("Dependencies settings section", () => {
     expect(config.dependencies.excludedRepos).toEqual([
       { owner: "org1", name: "repo1", fullName: "org1/repo1" },
     ]);
+  });
+});
+
+// ── Export with encrypted credentials (Task 5) ────────────────────────────────
+
+describe("SettingsPage — Data: Export with encrypted credentials", () => {
+  const CODE = "1111-2222-3333-4444-5555-6666-7777-8888";
+
+  it("checking the box + export shows the one-time-code modal and defers download until acknowledged", async () => {
+    vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockResolvedValue({
+      sealed: "SEALED",
+      salt: "SALT",
+      oneTimeCode: CODE,
+    });
+    const createObjSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:x");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi.fn();
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreate(tag);
+      if (tag === "a") vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(clickSpy);
+      return el;
+    });
+
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByRole("checkbox", { name: /include encrypted credentials/i }));
+    await user.click(screen.getByRole("button", { name: "Export" }));
+
+    await waitFor(() => screen.getByText(/shown only once/i));
+    // Modal shows the generated code; download NOT yet triggered.
+    screen.getByText(CODE);
+    expect(createObjSpy).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /saved my code/i }));
+    expect(createObjSpy).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+  });
+
+  it("a seal failure pushes a warning, leaves the checkbox checked, and never downloads", async () => {
+    const { pushNotification } = await import("../../../src/app/lib/errors");
+    vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockRejectedValue(new Error("seal failed"));
+    const createObjSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:x");
+
+    const user = userEvent.setup();
+    renderSettings();
+    const checkbox = screen.getByRole<HTMLInputElement>("checkbox", { name: /include encrypted credentials/i });
+    await user.click(checkbox);
+    await user.click(screen.getByRole("button", { name: "Export" }));
+
+    await waitFor(() => {
+      expect(pushNotification).toHaveBeenCalledWith("settings-export", expect.any(String), "warning");
+    });
+    expect(createObjSpy).not.toHaveBeenCalled();
+    expect(checkbox.checked).toBe(true);
+  });
+});
+
+// ── Import with encrypted credentials (Task 6) ────────────────────────────────
+
+describe("SettingsPage — Data: Import with encrypted credentials", () => {
+  const CODE = "1111-2222-3333-4444-5555-6666-7777-8888";
+  const IDENTITY = { login: "octo", avatar_url: "https://avatars/octo", name: "Octo" };
+  const BUNDLE = { github: { token: "ghp_x", method: "pat" as const }, jira: null };
+
+  function selectCredFile(extra: Record<string, unknown> = {}) {
+    const input = screen.getByLabelText(/import settings file/i);
+    const content = JSON.stringify({ theme: "dark", ...extra, _credentials: { sealed: "S", salt: "SA" } });
+    const file = new File([content], "settings.json", { type: "application/json" });
+    fireEvent.change(input, { target: { files: [file] } });
+  }
+
+  it("valid _credentials + correct code: unseals once, shows identity confirm, confirm commits", async () => {
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CIPHER" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+    vi.mocked(settingsTransfer.commitImportedSettings).mockResolvedValue({ jiraRestored: true });
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => screen.getByText(/sign you in as/i));
+    expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(1);
+    screen.getByText(/@octo/);
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => {
+      expect(settingsTransfer.commitImportedSettings).toHaveBeenCalledWith(
+        { bundle: BUNDLE, identity: IDENTITY },
+        expect.objectContaining({ theme: "dark" })
+      );
+    });
+  });
+
+  it("wrong code then correct code: retries on cached ciphertext, unseals only ONCE total", async () => {
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CIPHER" });
+    vi.mocked(settingsTransfer.resolveImportedCredentials)
+      .mockResolvedValueOnce({ ok: false, error: "Couldn't decrypt credentials — check the code and file match." })
+      .mockResolvedValueOnce({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+
+    const codeField = screen.getByLabelText(/one-time code/i);
+    await user.type(codeField, "wrong-code");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await waitFor(() => screen.getByText(/check the code and file match/i));
+    expect(screen.queryByText(/sign you in as/i)).toBeNull();
+
+    await user.clear(codeField);
+    await user.type(codeField, CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await waitFor(() => screen.getByText(/sign you in as/i));
+
+    expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("expired unseal shows the distinct expired message with no code-retry prompt", async () => {
+    vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: false, reason: "expired" });
+
+    const user = userEvent.setup();
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.type(screen.getByLabelText(/one-time code/i), CODE);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => screen.getByText(/expired/i));
+    // The code input is gone — the single-use bundle is spent, only the fallback remains.
+    expect(screen.queryByLabelText(/one-time code/i)).toBeNull();
+    screen.getByRole("button", { name: /continue without credentials/i });
+  });
+
+  it("concurrent double-submit calls unsealCredentialBundle EXACTLY once (in-flight guard)", async () => {
+    let resolveUnseal!: (v: { ok: true; ciphertext: string }) => void;
+    vi.mocked(proxyLib.unsealCredentialBundle).mockReturnValue(
+      new Promise((r) => { resolveUnseal = r; })
+    );
+    vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
+
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    const codeField = screen.getByLabelText(/one-time code/i) as HTMLInputElement;
+    fireEvent.input(codeField, { target: { value: CODE } });
+    const form = codeField.closest("form")!;
+    // Two submits fired before the first unseal resolves — guard must dedupe.
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    resolveUnseal({ ok: true, ciphertext: "CIPHER" });
+
+    await waitFor(() => {
+      expect(proxyLib.unsealCredentialBundle).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("'continue without credentials' applies the plaintext config only (no unseal)", async () => {
+    const user = userEvent.setup();
+    updateConfig({ theme: "light" });
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.click(screen.getByRole("button", { name: /continue without credentials/i }));
+
+    expect(config.theme).toBe("dark"); // plaintext config applied
+    expect(proxyLib.unsealCredentialBundle).not.toHaveBeenCalled();
+  });
+
+  it("declining (Cancel) leaves the session and config untouched", async () => {
+    const user = userEvent.setup();
+    updateConfig({ theme: "light" });
+    renderSettings();
+    selectCredFile();
+    await waitFor(() => screen.getByLabelText(/one-time code/i));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByLabelText(/one-time code/i)).toBeNull();
+    expect(config.theme).toBe("light"); // untouched
+    expect(proxyLib.unsealCredentialBundle).not.toHaveBeenCalled();
+  });
+
+  it("a null _credentials falls through to the plaintext import path (no code prompt)", async () => {
+    const user = userEvent.setup();
+    renderSettings();
+    const input = screen.getByLabelText(/import settings file/i);
+    const file = new File([JSON.stringify({ theme: "dark", _credentials: null })], "s.json", { type: "application/json" });
+    fireEvent.change(input, { target: { files: [file] } });
+    // No code prompt; the plaintext two-click confirm appears instead.
+    await waitFor(() => screen.getByRole("button", { name: "Yes, import" }));
+    expect(screen.queryByLabelText(/one-time code/i)).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Yes, import" }));
+    expect(config.theme).toBe("dark");
   });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -1477,7 +1477,7 @@ describe("Dependencies settings section", () => {
   });
 });
 
-// ── Export with encrypted credentials (Task 5) ────────────────────────────────
+// ── Export with encrypted credentials ─────────────────────────────────────────
 
 describe("SettingsPage — Data: Export with encrypted credentials", () => {
   const CODE = "1111-2222-3333-4444-5555-6666-77"; // 26-char Crockford base32, dashed
@@ -1670,7 +1670,7 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
   });
 });
 
-// ── Import with encrypted credentials (Task 6) ────────────────────────────────
+// ── Import with encrypted credentials ─────────────────────────────────────────
 
 describe("SettingsPage — Data: Import with encrypted credentials", () => {
   const CODE = "1111-2222-3333-4444-5555-6666-77"; // 26-char Crockford base32, dashed
@@ -1904,7 +1904,7 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     expect(config.theme).toBe("dark");
   });
 
-  it("STRUCT-C-001: Cancel and 'continue without credentials' are disabled while the unseal is in flight", async () => {
+  it("Cancel and 'continue without credentials' are disabled while the unseal is in flight", async () => {
     let resolveUnseal!: (v: { ok: true; ciphertext: string }) => void;
     vi.mocked(proxyLib.unsealCredentialBundle).mockReturnValue(new Promise((r) => { resolveUnseal = r; }));
     vi.mocked(settingsTransfer.resolveImportedCredentials).mockResolvedValue({ ok: true, bundle: BUNDLE, identity: IDENTITY });
@@ -1927,7 +1927,7 @@ describe("SettingsPage — Data: Import with encrypted credentials", () => {
     await waitFor(() => screen.getByText(/sign you in as/i));
   });
 
-  it("STRUCT-C-001: a Cancel-then-reselect during resolve discards the stale continuation (no wrong-identity dialog)", async () => {
+  it("a Cancel-then-reselect during resolve discards the stale continuation (no wrong-identity dialog)", async () => {
     // Unseal resolves immediately; resolve is deferred so the test can cancel and
     // reselect a different file while file X's resolve is still pending.
     vi.mocked(proxyLib.unsealCredentialBundle).mockResolvedValue({ ok: true, ciphertext: "CIPHER-X" });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -501,6 +501,9 @@ describe("SettingsPage — Data: Export settings", () => {
     expect(capturedBlob).toBeDefined();
     const parsed = JSON.parse(await capturedBlob!.text()) as Record<string, unknown>;
     expect("_credentials" in parsed).toBe(false);
+    // The view-prefs migration (buildViewPreferencesSection) runs regardless of
+    // whether credentials are included — locks that in at the UI entry point.
+    expect("_viewPreferences" in parsed).toBe(true);
   });
 
   it("Cancel in the choice dialog downloads nothing", async () => {
@@ -1600,6 +1603,70 @@ describe("SettingsPage — Data: Export with encrypted credentials", () => {
     await Promise.resolve();
     expect(buildSpy).toHaveBeenCalledTimes(1);
     screen.getByText(CODE); // the original code is still the one shown
+  });
+
+  it("CR-001/UI-001: the choice dialog cannot be dismissed mid-seal, but the code modal opens normally once the seal resolves", async () => {
+    let resolveSeal!: (v: { sealed: string; salt: string; oneTimeCode: string }) => void;
+    vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockReturnValue(
+      new Promise((r) => { resolveSeal = r; })
+    );
+
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Export with encrypted credentials" }));
+
+    // Seal in flight (exporting() === true): every dismissal control is disabled.
+    await waitFor(() => screen.getByRole("button", { name: "Preparing..." }));
+    const preparingBtn = screen.getByRole("button", { name: "Preparing..." });
+    expect(preparingBtn.getAttribute("aria-busy")).toBe("true");
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement;
+    const configOnlyBtn = screen.getByRole("button", { name: "Export config only" }) as HTMLButtonElement;
+    expect(cancelBtn.disabled).toBe(true);
+    expect(configOnlyBtn.disabled).toBe(true);
+
+    // Defense-in-depth: forcing a click past the disabled attribute still
+    // hits the handler's own `if (!exporting())` guard (the same condition
+    // that gates the dialog's onOpenChange for Escape/overlay-click), so the
+    // dialog stays open and no code modal appears while the seal is pending.
+    cancelBtn.disabled = false;
+    fireEvent.click(cancelBtn);
+    screen.getByText("Choose what to include in the exported file."); // still open
+    expect(screen.queryByText(/shown only once/i)).toBeNull();
+
+    // The guard is scoped to the in-flight window only — once the seal
+    // resolves, the one-time-code modal opens exactly as the unblocked flow
+    // would.
+    resolveSeal({ sealed: "SEALED", salt: "SALT", oneTimeCode: CODE });
+    await waitFor(() => screen.getByText(/shown only once/i));
+    screen.getByText(CODE);
+  });
+
+  it("post-await guard: resolving the seal after the component unmounts does not throw or leave a stray code modal", async () => {
+    // Exercises the `if (!showExportChoice()) return` guard in
+    // handleExportWithCredentials: the choice dialog can't be dismissed
+    // through the UI while a seal is in flight (see the test above), but the
+    // whole page can still be torn down out from under the pending await
+    // (e.g. navigating away from Settings) — this proves that doesn't throw
+    // or pop a stray one-time-code modal into the (now-gone) document.
+    let resolveSeal!: (v: { sealed: string; salt: string; oneTimeCode: string }) => void;
+    vi.mocked(settingsTransfer.buildEncryptedCredentialsSection).mockReturnValue(
+      new Promise((r) => { resolveSeal = r; })
+    );
+
+    const user = userEvent.setup();
+    const { unmount } = renderSettings();
+    await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Export with encrypted credentials" }));
+    await waitFor(() => screen.getByRole("button", { name: "Preparing..." }));
+
+    unmount();
+
+    expect(() => resolveSeal({ sealed: "SEALED", salt: "SALT", oneTimeCode: CODE })).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.body.textContent).not.toContain(CODE);
+    expect(document.body.textContent ?? "").not.toMatch(/shown only once/i);
   });
 });
 

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -262,7 +262,7 @@ describe("buildExportPayload", () => {
   });
 });
 
-// ── Task 2: curated, privacy-scrubbed view preferences ────────────────────────
+// ── curated, privacy-scrubbed view preferences ────────────────────────────────
 
 describe("buildExportPayload — _viewPreferences", () => {
   // viewState is a module-level singleton shared across this whole test file —
@@ -414,13 +414,13 @@ describe("parseImportFile", () => {
     }
   });
 
-  it("STRUCT-I-001: rejects a file stamped with a NEWER export version, with a clear message", () => {
+  it("rejects a file stamped with a NEWER export version, with a clear message", () => {
     const result = parseImportFile(JSON.stringify({ _exportVersion: 2, theme: "dark" }));
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.errors[0]).toMatch(/newer version/i);
   });
 
-  it("STRUCT-I-001: accepts version 1 and a missing _exportVersion (treated as v1)", () => {
+  it("accepts version 1 and a missing _exportVersion (treated as v1)", () => {
     expect(parseImportFile(JSON.stringify({ _exportVersion: 1, theme: "dark" })).ok).toBe(true);
     expect(parseImportFile(JSON.stringify({ theme: "dark" })).ok).toBe(true);
     // A round-tripped real export (stamped v1 by buildExportPayload) also parses.
@@ -428,7 +428,7 @@ describe("parseImportFile", () => {
   });
 });
 
-// ── Task 4: client-side envelope encryption ──────────────────────────────────
+// ── client-side envelope encryption ──────────────────────────────────────────
 
 // Mirrors src/app/lib/settings-transfer.ts's Crockford alphabet (excludes I, L, O, U).
 const CODE_DISPLAY_RE = /^([0-9A-HJKMNP-TV-Z]{4}-){5}[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{2}$/;
@@ -624,7 +624,7 @@ describe("encryptWithCode / decryptWithCode", () => {
   });
 });
 
-// ── Task 5: assemble credential bundle ────────────────────────────────────────
+// ── assemble credential bundle ────────────────────────────────────────────────
 
 describe("assembleCredentialBundle / CredentialBundleSchema", () => {
   beforeEach(() => {
@@ -691,7 +691,7 @@ describe("assembleCredentialBundle / CredentialBundleSchema", () => {
   });
 });
 
-// ── Task 5/6: proxy credential seal/unseal helpers ────────────────────────────
+// ── proxy credential seal/unseal helpers ──────────────────────────────────────
 
 /**
  * Installs a Turnstile mock (captures render opts) + a document.createElement
@@ -724,7 +724,7 @@ function installTurnstileHarness(): Array<Record<string, unknown>> {
   return renderOpts;
 }
 
-describe("proxy — sealCredentialBundle / unsealCredentialBundle (Task 5/6)", () => {
+describe("proxy — sealCredentialBundle / unsealCredentialBundle", () => {
   let renderOpts: Array<Record<string, unknown>>;
 
   beforeEach(() => {
@@ -818,7 +818,7 @@ describe("proxy — sealCredentialBundle / unsealCredentialBundle (Task 5/6)", (
   });
 });
 
-// ── Task 5: buildEncryptedCredentialsSection (encrypt-then-seal) ───────────────
+// ── buildEncryptedCredentialsSection (encrypt-then-seal) ───────────────────────
 
 describe("buildEncryptedCredentialsSection", () => {
   beforeEach(() => {
@@ -901,7 +901,7 @@ describe("buildEncryptedCredentialsSection", () => {
   });
 });
 
-// ── Task 6: resolveImportedCredentials ────────────────────────────────────────
+// ── resolveImportedCredentials ────────────────────────────────────────────────
 
 describe("resolveImportedCredentials", () => {
   const bundle: CredentialBundle = { github: { token: "ghp_valid_token", method: "pat" }, jira: null };
@@ -1022,7 +1022,7 @@ describe("resolveImportedCredentials", () => {
   });
 });
 
-// ── Task 6: commitImportedSettings ────────────────────────────────────────────
+// ── commitImportedSettings ────────────────────────────────────────────────────
 
 describe("commitImportedSettings", () => {
   const identity = { login: "newuser", avatar_url: "https://avatars/new", name: "New User" };
@@ -1184,7 +1184,7 @@ describe("commitImportedSettings", () => {
     expect(order).toEqual(["auth", "config"]); // established only after the await
   });
 
-  it("Gap A: pre-auth import resets transient view keys that setAuthFromCredential's (inert) identity-switch cascade would otherwise leave stale", async () => {
+  it("pre-auth import resets transient view keys that setAuthFromCredential's (inert) identity-switch cascade would otherwise leave stale", async () => {
     // Seed a prior session's transient view state, as if a token expired on this
     // browser while these were set — NOT part of the curated export/import set,
     // so setConfig/applyImportedViewState alone would never touch them.
@@ -1259,7 +1259,7 @@ describe("commitImportedSettings", () => {
     dispose();
   });
 
-  it("STRUCT-I-002: a non-positive expires_in yields a sane future expiresAt (default 3600s), not past/NaN", async () => {
+  it("a non-positive expires_in yields a sane future expiresAt (default 3600s), not past/NaN", async () => {
     vi.spyOn(authStore, "user").mockReturnValue(identity);
     vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => {});
     vi.spyOn(configStore, "setConfig").mockImplementation(() => {});
@@ -1284,7 +1284,7 @@ describe("commitImportedSettings", () => {
     expect(Number.isNaN(state.expiresAt)).toBe(false);
   });
 
-  it("STRUCT-I-003: aligns the imported config's jira.authMethod with the tamper-proof bundle authMethod", async () => {
+  it("aligns the imported config's jira.authMethod with the tamper-proof bundle authMethod", async () => {
     vi.spyOn(authStore, "user").mockReturnValue(identity);
     vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => {});
     vi.spyOn(authStore, "setJiraAuth").mockImplementation(() => {});
@@ -1352,7 +1352,7 @@ describe("commitImportedSettings", () => {
   });
 });
 
-// ── Task 3: full export -> import round-trip for view preferences ─────────────
+// ── full export -> import round-trip for view preferences ─────────────────────
 
 describe("commitImportedSettings — view preferences round-trip", () => {
   const identity = { login: "newuser", avatar_url: "https://avatars/new", name: "New User" };
@@ -1442,7 +1442,7 @@ describe("commitImportedSettings — view preferences round-trip", () => {
   });
 });
 
-// ── STRUCT-I-001 counterpart: import-side stripped-item backfill guard ────────
+// ── import-side stripped-item backfill guard ──────────────────────────────────
 //
 // buildExportPayload strips ignoredItems/trackedItems down to
 // TRACKED_ITEM_EXPORT_KEEP_LIST / IGNORED_ITEM_EXPORT_KEEP_LIST (allowlists,
@@ -1457,7 +1457,7 @@ describe("commitImportedSettings — view preferences round-trip", () => {
 // are actually stripped by the current keep-lists, then proves a
 // stripped-then-reimported entry survives — so it fails loudly the moment a
 // newly-required field is stripped without an accompanying coerce fix.
-describe("import-side stripped-item backfill guard (STRUCT-I-001 counterpart)", () => {
+describe("import-side stripped-item backfill guard", () => {
   beforeEach(() => resetViewState());
   afterEach(() => resetViewState());
 
@@ -1539,7 +1539,7 @@ describe("import-side stripped-item backfill guard (STRUCT-I-001 counterpart)", 
   });
 });
 
-// ── Task 7: hasExistingLocalConfig (Login-page confirmation-skip detector) ─────
+// ── hasExistingLocalConfig (Login-page confirmation-skip detector) ─────────────
 
 describe("hasExistingLocalConfig", () => {
   it("returns false for a default/empty config (fresh browser / incognito)", () => {

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { z } from "zod";
 
 // Mock cache so auth's identity-clear path never touches IndexedDB; the pre-auth
 // ordering test controls clearCache's timing directly via this mock.
@@ -55,6 +56,7 @@ import {
   ViewStateSchema,
   TrackedItemSchema,
   IgnoredItemSchema,
+  applyImportedViewState,
 } from "../../src/app/stores/view";
 import { createRoot } from "solid-js";
 
@@ -514,6 +516,59 @@ describe("generateOneTimeCode / decodeOneTimeCode", () => {
     expect(() => decodeOneTimeCode(valid + "0")).toThrow(
       "One-time code is not in the expected format."
     );
+  });
+});
+
+// Known-answer vectors for the Crockford codec. The round-trip test above
+// cross-checks decodeOneTimeCode against a SECOND encoder (crockfordEncode)
+// that implements the identical algorithm — a divergence guard, catching the
+// two implementations disagreeing, but NOT a true anchor: if both encode and
+// decode independently flipped the same bit-packing detail (shift direction,
+// alphabet index order, etc.) the round-trip test would still pass. These two
+// vectors are literal, hand-computed expected values for both directions
+// (decode a known string -> known bytes, AND encode known bytes -> known
+// string), verified against the documented bit-packing: 16 bytes -> a 128-bit
+// big-endian integer -> left-shift 2 bits (128 -> 130 bits, 26 * 5) -> 26
+// base32 digits emitted MSB-first from alphabet "0123456789ABCDEFGHJKMNPQRSTVWXYZ".
+describe("generateOneTimeCode / decodeOneTimeCode — known-answer vectors", () => {
+  it("KAV-1: all-zero 16 bytes <-> \"0000-0000-0000-0000-0000-0000-00\"", () => {
+    // All-zero input -> value 0 -> <<2 is still 0 -> every one of the 26
+    // 5-bit groups is 0b00000 -> alphabet[0] = '0', 26 times.
+    const zeroBytes = new Uint8Array(16);
+    const code = "0000-0000-0000-0000-0000-0000-00";
+
+    // Decode direction: a hand-picked string decodes to the hand-picked bytes.
+    expect(Array.from(decodeOneTimeCode(code))).toEqual(Array.from(zeroBytes));
+
+    // Encode+format direction: generateOneTimeCode's only entropy source is
+    // crypto.getRandomValues, so pinning it to the known vector anchors the
+    // encode + dash-formatting path without needing the private encoder.
+    vi.spyOn(crypto, "getRandomValues").mockImplementation(((arr: Uint8Array) => {
+      arr.set(zeroBytes);
+      return arr;
+    }) as typeof crypto.getRandomValues);
+    expect(generateOneTimeCode()).toBe(code);
+  });
+
+  it("KAV-2: all-0xFF 16 bytes <-> \"ZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZ-ZW\" (non-trivial vector)", () => {
+    // Hand derivation: 16 bytes of 0xFF is a 128-bit integer of all 1s.
+    // <<2 (multiply by 4) produces a 130-bit integer: the top 128 bits stay
+    // 1, and two 0 bits are appended at the LSB end. Splitting into 26
+    // groups of 5 bits MSB-first: the first 25 groups (125 bits) fall
+    // entirely within the all-1s region, so each is 0b11111 = 31 = 'Z'
+    // (the alphabet's last character). The 26th (final) group covers the
+    // remaining 5 bits: the last three original 1-bits followed by the two
+    // appended 0-bits = 0b11100 = 28 = 'W'.
+    const ffBytes = new Uint8Array(16).fill(0xff);
+    const code = "ZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZ-ZW";
+
+    expect(Array.from(decodeOneTimeCode(code))).toEqual(Array.from(ffBytes));
+
+    vi.spyOn(crypto, "getRandomValues").mockImplementation(((arr: Uint8Array) => {
+      arr.set(ffBytes);
+      return arr;
+    }) as typeof crypto.getRandomValues);
+    expect(generateOneTimeCode()).toBe(code);
   });
 });
 
@@ -1129,6 +1184,32 @@ describe("commitImportedSettings", () => {
     expect(order).toEqual(["auth", "config"]); // established only after the await
   });
 
+  it("Gap A: pre-auth import resets transient view keys that setAuthFromCredential's (inert) identity-switch cascade would otherwise leave stale", async () => {
+    // Seed a prior session's transient view state, as if a token expired on this
+    // browser while these were set — NOT part of the curated export/import set,
+    // so setConfig/applyImportedViewState alone would never touch them.
+    updateViewState({
+      lastActiveTab: "actions",
+      globalSort: { field: "title", direction: "asc" },
+      globalFilter: { org: "prior-org", repo: "prior-repo" },
+    });
+
+    vi.spyOn(authStore, "user").mockReturnValue(null); // pre-auth (Login-page import path)
+
+    await commitImportedSettings(
+      { bundle: { github: { token: "ghp_x", method: "pat" }, jira: null }, identity },
+      ConfigSchema.parse({}),
+      { jiraCustomOrder: ["NEW-1"] } // a curated key, to prove it's still applied post-reset
+    );
+
+    // Transient/non-curated keys reset to defaults — no bleed from the prior session.
+    expect(viewState.lastActiveTab).toBe("issues");
+    expect(viewState.globalSort).toEqual({ field: "updatedAt", direction: "desc" });
+    expect(viewState.globalFilter).toEqual({ org: null, repo: null });
+    // The curated key from the import is still applied AFTER the reset.
+    expect(viewState.jiraCustomOrder).toEqual(["NEW-1"]);
+  });
+
   it("identity-switch integration: REAL cascade replaces config/view/jira and persists imported config", async () => {
     vi.spyOn(errorsLib, "pushNotification").mockImplementation(() => {});
     vi.stubGlobal("fetch", vi.fn());
@@ -1358,6 +1439,103 @@ describe("commitImportedSettings — view preferences round-trip", () => {
     expect(viewState.lastActiveTab).toBe("issues");
     expect(viewState.globalSort).toEqual({ field: "updatedAt", direction: "desc" });
     expect(viewState.globalFilter).toEqual({ org: null, repo: null });
+  });
+});
+
+// ── STRUCT-I-001 counterpart: import-side stripped-item backfill guard ────────
+//
+// buildExportPayload strips ignoredItems/trackedItems down to
+// TRACKED_ITEM_EXPORT_KEEP_LIST / IGNORED_ITEM_EXPORT_KEEP_LIST (allowlists,
+// enforced by the schema-drift guard tests at the top of this file). The
+// IMPORT side (applyImportedViewState -> coerceStrippedItemEntry, in
+// src/app/stores/view.ts) only hardcodes backfilling ONE field: a missing
+// `title` defaults to `""`. If a schema ever gains a new REQUIRED field that
+// also gets left off the export keep-list, the stripped entry re-validates as
+// invalid on import and the whole item is silently dropped (per-key
+// safeParse in applyImportedViewState skips the whole array on one bad
+// element). This test derives, for both item schemas, which required fields
+// are actually stripped by the current keep-lists, then proves a
+// stripped-then-reimported entry survives — so it fails loudly the moment a
+// newly-required field is stripped without an accompanying coerce fix.
+describe("import-side stripped-item backfill guard (STRUCT-I-001 counterpart)", () => {
+  beforeEach(() => resetViewState());
+  afterEach(() => resetViewState());
+
+  /** Fields a schema requires — i.e. omitting them (passing `undefined`) fails validation. Optional/`.default()` fields pass `undefined` and are excluded. */
+  function requiredKeys(shape: Record<string, z.ZodTypeAny>): string[] {
+    return Object.keys(shape).filter((key) => !shape[key].safeParse(undefined).success);
+  }
+
+  it("TrackedItemSchema: every stripped-and-required field is backfilled on import (coerceStrippedItemEntry)", () => {
+    // A full item populating every TrackedItemSchema field, so exporting it
+    // reveals exactly which fields the CURRENT keep-list actually keeps.
+    updateViewState({
+      trackedItems: [
+        {
+          id: 1,
+          number: 42,
+          type: "issue",
+          source: "github",
+          repoFullName: "org/repo",
+          title: "Secret title",
+          addedAt: 1000,
+          jiraKey: "PROJ-1",
+          jiraProjectKey: "PROJ",
+          jiraStatus: "In Progress",
+          htmlUrl: "https://github.com/org/repo/issues/1",
+        },
+      ],
+    });
+    const exported = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const strippedEntries = (exported._viewPreferences as Record<string, unknown>)
+      .trackedItems as Record<string, unknown>[];
+    const kept = Object.keys(strippedEntries[0]);
+
+    const required = requiredKeys(TrackedItemSchema.shape);
+    const strippedRequired = required.filter((key) => !kept.includes(key));
+    // Sanity: the guard is only meaningful if the current keep-list actually
+    // strips at least one required field (it does — `title`).
+    expect(strippedRequired.length).toBeGreaterThan(0);
+
+    resetViewState();
+    applyImportedViewState({ trackedItems: strippedEntries });
+    const restored = viewState.trackedItems[0] as Record<string, unknown> | undefined;
+
+    expect(
+      restored !== undefined && TrackedItemSchema.safeParse(restored).success,
+      `TrackedItemSchema field(s) [${strippedRequired.join(", ")}] are required, stripped by ` +
+        "TRACKED_ITEM_EXPORT_KEEP_LIST (src/app/lib/settings-transfer.ts), but NOT backfilled by " +
+        "coerceStrippedItemEntry (src/app/stores/view.ts) — the stripped import fails schema " +
+        "validation and the whole item is silently dropped. Extend coerceStrippedItemEntry to " +
+        "backfill the new field (or add it to the keep-list if it isn't actually PII/content)."
+    ).toBe(true);
+  });
+
+  it("IgnoredItemSchema: every stripped-and-required field is backfilled on import (coerceStrippedItemEntry)", () => {
+    updateViewState({
+      ignoredItems: [{ id: 1, type: "issue", repo: "org/repo", title: "Secret title", ignoredAt: 1000 }],
+    });
+    const exported = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const strippedEntries = (exported._viewPreferences as Record<string, unknown>)
+      .ignoredItems as Record<string, unknown>[];
+    const kept = Object.keys(strippedEntries[0]);
+
+    const required = requiredKeys(IgnoredItemSchema.shape);
+    const strippedRequired = required.filter((key) => !kept.includes(key));
+    expect(strippedRequired.length).toBeGreaterThan(0);
+
+    resetViewState();
+    applyImportedViewState({ ignoredItems: strippedEntries });
+    const restored = viewState.ignoredItems[0] as Record<string, unknown> | undefined;
+
+    expect(
+      restored !== undefined && IgnoredItemSchema.safeParse(restored).success,
+      `IgnoredItemSchema field(s) [${strippedRequired.join(", ")}] are required, stripped by ` +
+        "IGNORED_ITEM_EXPORT_KEEP_LIST (src/app/lib/settings-transfer.ts), but NOT backfilled by " +
+        "coerceStrippedItemEntry (src/app/stores/view.ts) — the stripped import fails schema " +
+        "validation and the whole item is silently dropped. Extend coerceStrippedItemEntry to " +
+        "backfill the new field (or add it to the keep-list if it isn't actually content)."
+    ).toBe(true);
   });
 });
 

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -15,6 +15,7 @@ import { ConfigSchema, JiraConfigSchema } from "../../src/shared/schemas";
 import {
   EXPORT_VERSION,
   EXPORT_DENYLIST,
+  EXPORTED_VIEW_PREF_KEYS,
   MAX_IMPORT_BYTES,
   buildExportPayload,
   parseImportFile,
@@ -47,7 +48,14 @@ import {
   initConfigPersistence,
 } from "../../src/app/stores/config";
 import * as configStore from "../../src/app/stores/config";
-import { viewState, updateViewState } from "../../src/app/stores/view";
+import {
+  viewState,
+  updateViewState,
+  resetViewState,
+  ViewStateSchema,
+  TrackedItemSchema,
+  IgnoredItemSchema,
+} from "../../src/app/stores/view";
 import { createRoot } from "solid-js";
 
 // ── Schema-drift guard update workflow ────────────────────────────────────────
@@ -100,6 +108,46 @@ const EXPECTED_JIRA_KEYS = [
   "siteUrl",
 ];
 
+// Same workflow as EXPECTED_CONFIG_KEYS/EXPECTED_JIRA_KEYS above, for the
+// _viewPreferences export section. A top-level ViewStateSchema key change
+// forces a decision: add it to EXPORTED_VIEW_PREF_KEYS (durable, non-transient,
+// non-privacy-sensitive) or leave it excluded like lastActiveTab/globalSort/
+// globalFilter. A TrackedItemSchema/IgnoredItemSchema field change forces the
+// same decision for the per-entry keep-lists (TRACKED_ITEM_EXPORT_KEEP_LIST /
+// IGNORED_ITEM_EXPORT_KEEP_LIST in settings-transfer.ts) — an allowlist, so an
+// added field is excluded by default until consciously added.
+const EXPECTED_VIEW_STATE_KEYS = [
+  "customTabFilters",
+  "dependencyExpandedGroups",
+  "expandedRepos",
+  "globalFilter",
+  "globalSort",
+  "hideDepDashboard",
+  "ignoredItems",
+  "jiraCustomOrder",
+  "lastActiveTab",
+  "lockedRepos",
+  "showPrRuns",
+  "tabFilters",
+  "trackedItems",
+];
+
+const EXPECTED_TRACKED_ITEM_KEYS = [
+  "addedAt",
+  "htmlUrl",
+  "id",
+  "jiraKey",
+  "jiraProjectKey",
+  "jiraStatus",
+  "number",
+  "repoFullName",
+  "source",
+  "title",
+  "type",
+];
+
+const EXPECTED_IGNORED_ITEM_KEYS = ["id", "ignoredAt", "repo", "title", "type"];
+
 function diffKeys(actual: string[], expected: string[]): { added: string[]; removed: string[] } {
   const expectedSet = new Set(expected);
   const actualSet = new Set(actual);
@@ -138,6 +186,42 @@ describe("settings-transfer — schema-drift guard", () => {
         "whether any ADDED Jira field must also be denylisted."
     ).toBe(true);
   });
+
+  it("ViewStateSchema top-level shape matches the _viewPreferences allowlist snapshot", () => {
+    const actual = Object.keys(ViewStateSchema.shape).sort();
+    const { added, removed } = diffKeys(actual, EXPECTED_VIEW_STATE_KEYS);
+    expect(
+      added.length === 0 && removed.length === 0,
+      `ViewStateSchema top-level keys changed (added: [${added.join(", ")}], removed: [${removed.join(", ")}]). ` +
+        "Before updating EXPECTED_VIEW_STATE_KEYS, decide whether an ADDED key belongs in " +
+        "EXPORTED_VIEW_PREF_KEYS (src/app/lib/settings-transfer.ts) — durable, non-transient, " +
+        "non-privacy-sensitive view state — or should stay excluded like lastActiveTab/globalSort/globalFilter."
+    ).toBe(true);
+  });
+
+  it("TrackedItemSchema shape matches the trackedItems export keep-list snapshot", () => {
+    const actual = Object.keys(TrackedItemSchema.shape).sort();
+    const { added, removed } = diffKeys(actual, EXPECTED_TRACKED_ITEM_KEYS);
+    expect(
+      added.length === 0 && removed.length === 0,
+      `TrackedItemSchema keys changed (added: [${added.join(", ")}], removed: [${removed.join(", ")}]). ` +
+        "Before updating EXPECTED_TRACKED_ITEM_KEYS, decide whether an ADDED field is reference-only " +
+        "(safe to add to TRACKED_ITEM_EXPORT_KEEP_LIST in settings-transfer.ts) or content/PII-adjacent " +
+        "(must stay excluded, like title/htmlUrl/jiraStatus)."
+    ).toBe(true);
+  });
+
+  it("IgnoredItemSchema shape matches the ignoredItems export keep-list snapshot", () => {
+    const actual = Object.keys(IgnoredItemSchema.shape).sort();
+    const { added, removed } = diffKeys(actual, EXPECTED_IGNORED_ITEM_KEYS);
+    expect(
+      added.length === 0 && removed.length === 0,
+      `IgnoredItemSchema keys changed (added: [${added.join(", ")}], removed: [${removed.join(", ")}]). ` +
+        "Before updating EXPECTED_IGNORED_ITEM_KEYS, decide whether an ADDED field is reference-only " +
+        "(safe to add to IGNORED_ITEM_EXPORT_KEEP_LIST in settings-transfer.ts) or content (must stay " +
+        "excluded, like title)."
+    ).toBe(true);
+  });
 });
 
 describe("buildExportPayload", () => {
@@ -147,7 +231,7 @@ describe("buildExportPayload", () => {
     });
     expect(cfg.jira.email).toBe("secret@example.com");
 
-    const out = buildExportPayload(cfg);
+    const out = buildExportPayload(cfg, viewState);
     const jira = out.jira as Record<string, unknown>;
     expect(jira).toBeDefined();
     expect("email" in jira).toBe(false);
@@ -159,7 +243,7 @@ describe("buildExportPayload", () => {
   });
 
   it("stamps the export version", () => {
-    const out = buildExportPayload(ConfigSchema.parse({}));
+    const out = buildExportPayload(ConfigSchema.parse({}), viewState);
     expect(out._exportVersion).toBe(EXPORT_VERSION);
     expect(out._exportVersion).toBe(1);
   });
@@ -169,16 +253,102 @@ describe("buildExportPayload", () => {
     // in SettingsPage.tsx's pre-refactor object literal — their presence is the
     // assertion that actually distinguishes a schema-driven rewrite from a
     // leftover manual literal.
-    const out = buildExportPayload(ConfigSchema.parse({}));
+    const out = buildExportPayload(ConfigSchema.parse({}), viewState);
     expect(Object.prototype.hasOwnProperty.call(out, "onboardingComplete")).toBe(true);
     expect(Object.prototype.hasOwnProperty.call(out, "mcpRelayEnabled")).toBe(true);
     expect(Object.prototype.hasOwnProperty.call(out, "mcpRelayPort")).toBe(true);
   });
 });
 
+// ── Task 2: curated, privacy-scrubbed view preferences ────────────────────────
+
+describe("buildExportPayload — _viewPreferences", () => {
+  // viewState is a module-level singleton shared across this whole test file —
+  // reset it before AND after so these tests neither inherit nor leak state.
+  beforeEach(() => resetViewState());
+  afterEach(() => resetViewState());
+
+  it("includes _viewPreferences with EXACTLY the curated top-level key set", () => {
+    const out = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const prefs = out._viewPreferences as Record<string, unknown>;
+    expect(prefs).toBeDefined();
+    expect(Object.keys(prefs).sort()).toEqual([...EXPORTED_VIEW_PREF_KEYS].sort());
+  });
+
+  it("excludes the transient/privacy keys: lastActiveTab, globalSort, globalFilter", () => {
+    const out = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const prefs = out._viewPreferences as Record<string, unknown>;
+    expect("lastActiveTab" in prefs).toBe(false);
+    expect("globalSort" in prefs).toBe(false);
+    expect("globalFilter" in prefs).toBe(false);
+  });
+
+  it("carries a non-item durable preference through unmodified (jiraCustomOrder)", () => {
+    updateViewState({ jiraCustomOrder: ["PROJ-1", "PROJ-2"] });
+    const out = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const prefs = out._viewPreferences as Record<string, unknown>;
+    expect(prefs.jiraCustomOrder).toEqual(["PROJ-1", "PROJ-2"]);
+  });
+
+  it("scrubs ignoredItems entries to the reference-field allowlist — no title", () => {
+    updateViewState({
+      ignoredItems: [
+        { id: 1, type: "issue", repo: "org/repo", title: "Secret issue title", ignoredAt: 1000 },
+      ],
+    });
+    const out = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const prefs = out._viewPreferences as Record<string, unknown>;
+    const entries = prefs.ignoredItems as Record<string, unknown>[];
+    expect(entries).toHaveLength(1);
+    expect(Object.keys(entries[0]).sort()).toEqual(["id", "ignoredAt", "repo", "type"]);
+    expect("title" in entries[0]).toBe(false);
+    expect(entries[0]).toMatchObject({ id: 1, type: "issue", repo: "org/repo", ignoredAt: 1000 });
+  });
+
+  it("scrubs trackedItems entries to the reference-field allowlist — no title, htmlUrl, or jiraStatus", () => {
+    updateViewState({
+      trackedItems: [
+        {
+          id: 2,
+          number: 42,
+          type: "issue",
+          source: "github",
+          repoFullName: "org/repo",
+          title: "Secret issue title",
+          addedAt: 2000,
+          htmlUrl: "https://github.com/org/repo/issues/42",
+        },
+        {
+          id: 3,
+          type: "jiraIssue",
+          source: "jira",
+          repoFullName: "",
+          title: "Secret jira summary",
+          addedAt: 3000,
+          jiraKey: "PROJ-123",
+          jiraProjectKey: "PROJ",
+          jiraStatus: "In Progress",
+        },
+      ],
+    });
+    const out = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const prefs = out._viewPreferences as Record<string, unknown>;
+    const entries = prefs.trackedItems as Record<string, unknown>[];
+    expect(entries).toHaveLength(2);
+
+    for (const entry of entries) {
+      expect("title" in entry).toBe(false);
+      expect("htmlUrl" in entry).toBe(false);
+      expect("jiraStatus" in entry).toBe(false);
+    }
+    expect(entries[0]).toMatchObject({ id: 2, number: 42, type: "issue", source: "github", repoFullName: "org/repo", addedAt: 2000 });
+    expect(entries[1]).toMatchObject({ id: 3, type: "jiraIssue", source: "jira", jiraKey: "PROJ-123", jiraProjectKey: "PROJ", addedAt: 3000 });
+  });
+});
+
 describe("parseImportFile", () => {
   it("parses a valid export payload produced by buildExportPayload", () => {
-    const payload = buildExportPayload(ConfigSchema.parse({ theme: "dark", itemsPerPage: 50 }));
+    const payload = buildExportPayload(ConfigSchema.parse({ theme: "dark", itemsPerPage: 50 }), viewState);
     const result = parseImportFile(JSON.stringify(payload));
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -252,7 +422,7 @@ describe("parseImportFile", () => {
     expect(parseImportFile(JSON.stringify({ _exportVersion: 1, theme: "dark" })).ok).toBe(true);
     expect(parseImportFile(JSON.stringify({ theme: "dark" })).ok).toBe(true);
     // A round-tripped real export (stamped v1 by buildExportPayload) also parses.
-    expect(parseImportFile(JSON.stringify(buildExportPayload(ConfigSchema.parse({})))).ok).toBe(true);
+    expect(parseImportFile(JSON.stringify(buildExportPayload(ConfigSchema.parse({}), viewState))).ok).toBe(true);
   });
 });
 

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -1271,6 +1271,96 @@ describe("commitImportedSettings", () => {
   });
 });
 
+// ── Task 3: full export -> import round-trip for view preferences ─────────────
+
+describe("commitImportedSettings — view preferences round-trip", () => {
+  const identity = { login: "newuser", avatar_url: "https://avatars/new", name: "New User" };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(cacheStore.clearCache).mockResolvedValue(undefined);
+    authStore.clearAuth(); // clean baseline: token/user null, config/view reset
+  });
+
+  it("restores every curated view preference and scrubs item content, leaving transient keys at their post-import defaults", async () => {
+    // ── Arrange: one non-default value per curated key, on the "exporting" side.
+    updateViewState({
+      jiraCustomOrder: ["PROJ-1", "PROJ-2"],
+      expandedRepos: { issues: { "org/repo": true }, pullRequests: {}, actions: {}, jiraAssigned: {} },
+      lockedRepos: { issues: ["org/locked"], pullRequests: [], actions: [], jiraAssigned: [] },
+      tabFilters: {
+        issues: { scope: "all", role: "author", comments: "has", user: "someone" },
+        pullRequests: { scope: "involves_me", role: "all", reviewDecision: "all", draft: "all", checkStatus: "all", sizeCategory: "all", user: "all" },
+        actions: { conclusion: "all", event: "all" },
+        jiraAssigned: { scope: "assigned", statusCategory: "all", priority: "all", sortField: "custom", sortDirection: "asc" },
+        dependencies: { updateType: "all", bot: "all" },
+      },
+      customTabFilters: { "custom-1": { status: "open" } },
+      dependencyExpandedGroups: ["major", "minor"],
+      showPrRuns: true,
+      hideDepDashboard: false,
+      ignoredItems: [{ id: 1, type: "issue", repo: "org/repo", title: "Secret ignored title", ignoredAt: 1000 }],
+      trackedItems: [
+        { id: 2, number: 42, type: "issue", source: "github", repoFullName: "org/repo", title: "Secret tracked title", addedAt: 2000, htmlUrl: "https://github.com/org/repo/issues/42" },
+      ],
+      // Deliberately non-default so a leak of these excluded keys would be caught.
+      lastActiveTab: "actions",
+      globalSort: { field: "title", direction: "asc" },
+      globalFilter: { org: "some-org", repo: "some-repo" },
+    });
+
+    const payload = buildExportPayload(ConfigSchema.parse({}), viewState);
+    const fileText = JSON.stringify(payload);
+
+    // ── Simulate importing on a fresh machine with no prior view state.
+    resetViewState();
+    expect(viewState.jiraCustomOrder).toEqual([]); // sanity: reset actually cleared it
+
+    const parsed = parseImportFile(fileText);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const rawViewPreferences = (parsed.rawJson as Record<string, unknown>)._viewPreferences;
+
+    // user() mocked to the SAME identity being "imported" so setAuthFromCredential's
+    // identity-switch reset cascade doesn't fire and reset viewState out from under
+    // this test's own assertions (mirrors the "commits identity strictly before
+    // config" tests above).
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    await commitImportedSettings(
+      { bundle: { github: { token: "ghp_x", method: "pat" }, jira: null }, identity },
+      parsed.config,
+      rawViewPreferences
+    );
+
+    // ── Assert: every curated key restored...
+    expect(viewState.jiraCustomOrder).toEqual(["PROJ-1", "PROJ-2"]);
+    expect(viewState.expandedRepos.issues).toEqual({ "org/repo": true });
+    expect(viewState.lockedRepos.issues).toEqual(["org/locked"]);
+    expect(viewState.tabFilters.issues).toMatchObject({ scope: "all", role: "author", comments: "has", user: "someone" });
+    expect(viewState.customTabFilters).toEqual({ "custom-1": { status: "open" } });
+    expect(viewState.dependencyExpandedGroups).toEqual(["major", "minor"]);
+    expect(viewState.showPrRuns).toBe(true);
+    expect(viewState.hideDepDashboard).toBe(false);
+
+    // ...ignored/tracked items restored as REFERENCES ONLY — title stripped on
+    // export, defaulted back to "" on import (not the original secret content).
+    expect(viewState.ignoredItems).toEqual([
+      { id: 1, type: "issue", repo: "org/repo", ignoredAt: 1000, title: "" },
+    ]);
+    expect(viewState.trackedItems).toHaveLength(1);
+    expect(viewState.trackedItems[0]).toMatchObject({
+      id: 2, number: 42, type: "issue", source: "github", repoFullName: "org/repo", addedAt: 2000, title: "",
+    });
+    expect("htmlUrl" in viewState.trackedItems[0]).toBe(false);
+
+    // ...while the excluded/transient keys stay at their POST-RESET defaults —
+    // never restored, proving they were never in the export in the first place.
+    expect(viewState.lastActiveTab).toBe("issues");
+    expect(viewState.globalSort).toEqual({ field: "updatedAt", direction: "desc" });
+    expect(viewState.globalFilter).toEqual({ org: null, repo: null });
+  });
+});
+
 // ── Task 7: hasExistingLocalConfig (Login-page confirmation-skip detector) ─────
 
 describe("hasExistingLocalConfig", () => {

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock cache so auth's identity-clear path never touches IndexedDB; the pre-auth
+// ordering test controls clearCache's timing directly via this mock.
+vi.mock("../../src/app/stores/cache", () => ({
+  clearCache: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@sentry/solid", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  withSentryErrorBoundary: vi.fn((c: unknown) => c),
+}));
+
 import { ConfigSchema, JiraConfigSchema } from "../../src/shared/schemas";
 import {
   EXPORT_VERSION,
@@ -13,7 +25,29 @@ import {
   encryptWithCode,
   decryptWithCode,
   ENVELOPE_VERSION,
+  CredentialBundleSchema,
+  assembleCredentialBundle,
+  buildEncryptedCredentialsSection,
+  resolveImportedCredentials,
+  commitImportedSettings,
 } from "../../src/app/lib/settings-transfer";
+import type { CredentialBundle } from "../../src/app/lib/settings-transfer";
+import * as proxyLib from "../../src/app/lib/proxy";
+import * as authStore from "../../src/app/stores/auth";
+import * as cacheStore from "../../src/app/stores/cache";
+import * as errorsLib from "../../src/app/lib/errors";
+import {
+  config,
+  setConfig,
+  resetConfig,
+  updateConfig,
+  updateJiraConfig,
+  CONFIG_STORAGE_KEY,
+  initConfigPersistence,
+} from "../../src/app/stores/config";
+import * as configStore from "../../src/app/stores/config";
+import { viewState, updateViewState } from "../../src/app/stores/view";
+import { createRoot } from "solid-js";
 
 // ── Schema-drift guard update workflow ────────────────────────────────────────
 // When ConfigSchema / JiraConfigSchema change, the two guard tests below FAIL.
@@ -302,5 +336,518 @@ describe("encryptWithCode / decryptWithCode", () => {
     const c1 = await encryptWithKey("identical plaintext", key);
     const c2 = await encryptWithKey("identical plaintext", key);
     expect(c1).not.toBe(c2);
+  });
+});
+
+// ── Task 5: assemble credential bundle ────────────────────────────────────────
+
+describe("assembleCredentialBundle / CredentialBundleSchema", () => {
+  beforeEach(() => {
+    authStore.clearJiraConfigFull(); // nulls jiraAuth + resets jira config
+    resetConfig();
+  });
+
+  it("PAT-auth user with no Jira produces { github:{token,method:pat}, jira:null }", () => {
+    authStore.setAuth({ access_token: "ghp_patuser" });
+    updateConfig({ authMethod: "pat" });
+    const bundle = assembleCredentialBundle();
+    expect(bundle).toEqual({ github: { token: "ghp_patuser", method: "pat" }, jira: null });
+    expect(CredentialBundleSchema.safeParse(bundle).success).toBe(true);
+  });
+
+  it("OAuth user with Jira OAuth: carries sealedRefreshToken/cloudId/siteUrl/siteName, EXCLUDES plaintext access token", () => {
+    authStore.setAuth({ access_token: "gho_oauthuser" });
+    updateConfig({ authMethod: "oauth" });
+    updateJiraConfig({ enabled: true, authMethod: "oauth" });
+    authStore.setJiraAuth({
+      accessToken: "JIRA-PLAINTEXT-ACCESS-DO-NOT-EXPORT",
+      sealedRefreshToken: "sealed-refresh-blob",
+      expiresAt: Date.now() + 3_600_000,
+      cloudId: "cloud-1",
+      siteUrl: "https://oauth.atlassian.net",
+      siteName: "OAuthSite",
+    });
+    const bundle = assembleCredentialBundle();
+    expect(bundle.jira).toEqual({
+      authMethod: "oauth",
+      sealedRefreshToken: "sealed-refresh-blob",
+      cloudId: "cloud-1",
+      siteUrl: "https://oauth.atlassian.net",
+      siteName: "OAuthSite",
+    });
+    // The short-lived plaintext access token must NOT be present anywhere.
+    expect(JSON.stringify(bundle)).not.toContain("JIRA-PLAINTEXT-ACCESS-DO-NOT-EXPORT");
+    expect(CredentialBundleSchema.safeParse(bundle).success).toBe(true);
+  });
+
+  it("Jira token-mode: carries sealedApiToken/email/cloudId/siteUrl/siteName", () => {
+    authStore.setAuth({ access_token: "ghp_tokenuser" });
+    updateConfig({ authMethod: "pat" });
+    updateJiraConfig({ enabled: true, authMethod: "token" });
+    authStore.setJiraAuth({
+      accessToken: "sealed-api-token-blob",
+      sealedRefreshToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      cloudId: "cloud-2",
+      siteUrl: "https://token.atlassian.net",
+      siteName: "TokenSite",
+      email: "user@example.com",
+    });
+    const bundle = assembleCredentialBundle();
+    expect(bundle.jira).toEqual({
+      authMethod: "token",
+      sealedApiToken: "sealed-api-token-blob",
+      email: "user@example.com",
+      cloudId: "cloud-2",
+      siteUrl: "https://token.atlassian.net",
+      siteName: "TokenSite",
+    });
+    expect(CredentialBundleSchema.safeParse(bundle).success).toBe(true);
+  });
+});
+
+// ── Task 5/6: proxy credential seal/unseal helpers ────────────────────────────
+
+/**
+ * Installs a Turnstile mock (captures render opts) + a document.createElement
+ * spy that auto-fires the injected <script>'s onload so acquireTurnstileToken's
+ * script-load promise resolves. Returns the captured render-opts array.
+ */
+function installTurnstileHarness(): Array<Record<string, unknown>> {
+  const renderOpts: Array<Record<string, unknown>> = [];
+  (window as unknown as { turnstile: unknown }).turnstile = {
+    render: (_c: unknown, opts: Record<string, unknown>) => {
+      renderOpts.push(opts);
+      queueMicrotask(() => (opts.callback as (t: string) => void)("ts-token"));
+      return "widget-id";
+    },
+    execute: () => {},
+    remove: () => {},
+  };
+  // Intercept the <script> append so happy-dom never tries to actually fetch the
+  // Turnstile script (which fires onerror). Fire onload ourselves so
+  // loadTurnstileScript's promise resolves. (Memoized module-side after the
+  // first successful load, so only the first proxy test needs this.)
+  const origAppend = document.head.appendChild.bind(document.head);
+  vi.spyOn(document.head, "appendChild").mockImplementation(((node: Node) => {
+    if ((node as Element).tagName === "SCRIPT") {
+      queueMicrotask(() => (node as HTMLScriptElement).onload?.(new Event("load")));
+      return node;
+    }
+    return origAppend(node as never);
+  }) as typeof document.head.appendChild);
+  return renderOpts;
+}
+
+describe("proxy — sealCredentialBundle / unsealCredentialBundle (Task 5/6)", () => {
+  let renderOpts: Array<Record<string, unknown>>;
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "test-site-key");
+    renderOpts = installTurnstileHarness();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("sealApiToken still requests Turnstile action 'seal' after parameterization", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ sealed: "S" }) }));
+    await proxyLib.sealApiToken("tok", "jira-api-token");
+    expect(renderOpts[0]?.action).toBe("seal");
+  });
+
+  it("sealCredentialBundle sends the right body, requests action 'seal', and returns the sealed blob", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ sealed: "SEALED-BLOB" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    const sealed = await proxyLib.sealCredentialBundle("ENVELOPE-CIPHERTEXT");
+    expect(sealed).toBe("SEALED-BLOB");
+    expect(renderOpts[0]?.action).toBe("seal");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/proxy/seal");
+    expect(JSON.parse(init.body as string)).toEqual({ token: "ENVELOPE-CIPHERTEXT", purpose: "credential-export-bundle" });
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe("fetch");
+  });
+
+  it("sealCredentialBundle throws SealError on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 400, json: async () => ({ error: "invalid_request" }) }));
+    await expect(proxyLib.sealCredentialBundle("x")).rejects.toBeInstanceOf(proxyLib.SealError);
+  });
+
+  it("sealCredentialBundle rejects an oversized ciphertext BEFORE any network call (pre-check)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(proxyLib.sealCredentialBundle("z".repeat(4097))).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("unsealCredentialBundle maps 200 { payload } to { ok:true, ciphertext } and requests action 'unseal'", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ payload: "INNER-CIPHERTEXT" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await proxyLib.unsealCredentialBundle("SEALED");
+    expect(res).toEqual({ ok: true, ciphertext: "INNER-CIPHERTEXT" });
+    expect(renderOpts[0]?.action).toBe("unseal");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/proxy/unseal");
+    expect(JSON.parse(init.body as string)).toEqual({ sealed: "SEALED", purpose: "credential-export-bundle" });
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe("fetch");
+  });
+
+  it("unsealCredentialBundle maps { error:'expired' } to { ok:false, reason:'expired' }", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: "expired" }) }));
+    expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("unsealCredentialBundle maps { error:'invalid' } to { ok:false, reason:'invalid' }", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: "invalid" }) }));
+    expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "invalid" });
+  });
+
+  it("unsealCredentialBundle maps a network failure to { ok:false, reason:'invalid' }", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("network down")));
+    expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "invalid" });
+  });
+});
+
+// ── Task 5: buildEncryptedCredentialsSection (encrypt-then-seal) ───────────────
+
+describe("buildEncryptedCredentialsSection", () => {
+  beforeEach(() => {
+    authStore.clearJiraConfigFull();
+    resetConfig();
+    authStore.setAuth({ access_token: "ghp_SECRET_GITHUB_TOKEN" });
+    updateConfig({ authMethod: "pat" });
+  });
+
+  it("returns sealed + salt in the output and never leaks the one-time code into the stored pair", async () => {
+    vi.spyOn(proxyLib, "sealCredentialBundle").mockResolvedValue("SEALED-OUTPUT");
+    const { sealed, salt, oneTimeCode } = await buildEncryptedCredentialsSection();
+    expect(sealed).toBe("SEALED-OUTPUT");
+    expect(typeof salt).toBe("string");
+    expect(oneTimeCode).toMatch(/^[0-9a-f]{4}(-[0-9a-f]{4}){7}$/);
+    // The one-time code must NOT appear in what gets written to the export file.
+    expect(JSON.stringify({ sealed, salt })).not.toContain(oneTimeCode);
+  });
+
+  it("ENCRYPT-THEN-SEAL: sealCredentialBundle receives ciphertext that decrypts to the bundle, never the raw token", async () => {
+    const sealSpy = vi.spyOn(proxyLib, "sealCredentialBundle").mockResolvedValue("SEALED");
+
+    const { salt, oneTimeCode } = await buildEncryptedCredentialsSection();
+
+    expect(sealSpy).toHaveBeenCalledTimes(1);
+    const sealedArg = sealSpy.mock.calls[0][0];
+    // Negative assertions: the sealed input is opaque ciphertext, not plaintext.
+    expect(sealedArg).not.toContain("ghp_SECRET_GITHUB_TOKEN");
+    expect(sealedArg).not.toContain("\"github\"");
+    expect(sealedArg).not.toContain("\"token\"");
+    // It is EXACTLY encryptWithCode's output: decrypting sealCredentialBundle's
+    // argument with the returned code+salt recovers the original bundle JSON —
+    // proving the ciphertext (not the raw bundle) was handed to seal, i.e.
+    // encrypt happened FIRST, then that exact ciphertext was sealed.
+    const decrypted = await decryptWithCode(sealedArg, salt, oneTimeCode);
+    expect(decrypted).not.toBeNull();
+    const roundTripped = JSON.parse(decrypted!) as CredentialBundle;
+    expect(roundTripped.github.token).toBe("ghp_SECRET_GITHUB_TOKEN");
+  });
+});
+
+// ── Task 6: resolveImportedCredentials ────────────────────────────────────────
+
+describe("resolveImportedCredentials", () => {
+  const bundle: CredentialBundle = { github: { token: "ghp_valid_token", method: "pat" }, jira: null };
+
+  async function makeCiphertext(code: string) {
+    return encryptWithCode(JSON.stringify(bundle), code);
+  }
+
+  it("wrong code and corrupted ciphertext both surface the SAME generic message", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await makeCiphertext(code);
+
+    const wrong = await resolveImportedCredentials(ciphertext, salt, generateOneTimeCode());
+    const corrupted = await resolveImportedCredentials("!!!not-base64-cipher!!!", salt, code);
+    expect(wrong.ok).toBe(false);
+    expect(corrupted.ok).toBe(false);
+    if (!wrong.ok && !corrupted.ok) {
+      expect(wrong.error).toBe(corrupted.error);
+      expect(wrong.error).toMatch(/check the code and file match/i);
+    }
+  });
+
+  it("retries against the SAME cached ciphertext (wrong then correct) with no additional network unseal", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await makeCiphertext(code);
+    const unsealSpy = vi.spyOn(proxyLib, "unsealCredentialBundle");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ login: "u", avatar_url: "a", name: "N" }) }));
+
+    const first = await resolveImportedCredentials(ciphertext, salt, generateOneTimeCode());
+    expect(first.ok).toBe(false);
+    const second = await resolveImportedCredentials(ciphertext, salt, code);
+    expect(second.ok).toBe(true);
+    expect(unsealSpy).not.toHaveBeenCalled(); // pure local decrypt — never re-unseals
+  });
+
+  it("a revoked GitHub token (401) surfaces the distinct revoked-credential message", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await makeCiphertext(code);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }));
+    const res = await resolveImportedCredentials(ciphertext, salt, code);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/no longer valid|revoked/i);
+  });
+
+  it("a /user network failure surfaces the SAME message as the 401 case", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await makeCiphertext(code);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }));
+    const revoked = await resolveImportedCredentials(ciphertext, salt, code);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("offline")));
+    const offline = await resolveImportedCredentials(ciphertext, salt, code);
+    expect(revoked.ok).toBe(false);
+    expect(offline.ok).toBe(false);
+    if (!revoked.ok && !offline.ok) expect(offline.error).toBe(revoked.error);
+  });
+
+  it("valid ciphertext + correct code resolves the full GitHubUser and mutates nothing", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await makeCiphertext(code);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ login: "octocat", avatar_url: "https://avatars/oct", name: "Octo" }),
+    }));
+    const setConfigSpy = vi.spyOn(configStore, "setConfig");
+    const setAuthSpy = vi.spyOn(authStore, "setAuthFromCredential");
+
+    const res = await resolveImportedCredentials(ciphertext, salt, code);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.identity).toEqual({ login: "octocat", avatar_url: "https://avatars/oct", name: "Octo" });
+      expect(res.bundle).toEqual(bundle);
+    }
+    expect(setConfigSpy).not.toHaveBeenCalled();
+    expect(setAuthSpy).not.toHaveBeenCalled();
+  });
+
+  it("R-001: surfaces the secure-context precondition distinctly on the decrypt path", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await makeCiphertext(code); // build BEFORE stubbing crypto
+    const realCrypto = globalThis.crypto;
+    vi.stubGlobal("crypto", { getRandomValues: realCrypto.getRandomValues.bind(realCrypto) }); // no .subtle
+    const res = await resolveImportedCredentials(ciphertext, salt, code);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/secure context/i);
+  });
+});
+
+// ── Task 6: commitImportedSettings ────────────────────────────────────────────
+
+describe("commitImportedSettings", () => {
+  const identity = { login: "newuser", avatar_url: "https://avatars/new", name: "New User" };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(cacheStore.clearCache).mockResolvedValue(undefined);
+    authStore.clearAuth(); // clean baseline: token/user null, config/view reset
+  });
+
+  it("setAuthFromCredential is the same reference as setAuthFromPat (alias not drifted)", () => {
+    expect(authStore.setAuthFromCredential).toBe(authStore.setAuthFromPat);
+  });
+
+  it("commits identity strictly before config for a PAT bundle", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    const order: string[] = [];
+    vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => { order.push("auth"); });
+    vi.spyOn(configStore, "setConfig").mockImplementation(() => { order.push("config"); });
+    const res = await commitImportedSettings(
+      { bundle: { github: { token: "ghp_x", method: "pat" }, jira: null }, identity },
+      ConfigSchema.parse({ authMethod: "pat" })
+    );
+    expect(order).toEqual(["auth", "config"]);
+    expect(res.jiraRestored).toBe(true);
+  });
+
+  it("commits identity strictly before config for an OAuth bundle", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    const order: string[] = [];
+    vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => { order.push("auth"); });
+    vi.spyOn(configStore, "setConfig").mockImplementation(() => { order.push("config"); });
+    vi.spyOn(authStore, "setJiraAuth").mockImplementation(() => {});
+    const res = await commitImportedSettings(
+      { bundle: { github: { token: "gho_x", method: "oauth" }, jira: null }, identity },
+      ConfigSchema.parse({ authMethod: "oauth" })
+    );
+    expect(order).toEqual(["auth", "config"]);
+    expect(res.jiraRestored).toBe(true);
+  });
+
+  it("final config.authMethod matches importedConfig (not the transient 'pat' setAuthFromPat sets)", async () => {
+    // Real setAuthFromCredential + setConfig; seed user() to the same login so no
+    // heavy cascade runs, then assert setConfig's oauth authMethod wins over the
+    // transient "pat" write.
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    await commitImportedSettings(
+      { bundle: { github: { token: "gho_x", method: "oauth" }, jira: null }, identity },
+      ConfigSchema.parse({ authMethod: "oauth" })
+    );
+    expect(config.authMethod).toBe("oauth");
+  });
+
+  it("Jira token-mode: setJiraAuth with sealedApiToken sentinels and zero network calls", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => {});
+    vi.spyOn(configStore, "setConfig").mockImplementation(() => {});
+    const jiraSpy = vi.spyOn(authStore, "setJiraAuth").mockImplementation(() => {});
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await commitImportedSettings(
+      {
+        bundle: {
+          github: { token: "ghp_x", method: "pat" },
+          jira: { authMethod: "token", sealedApiToken: "SEALED-API", email: "e@e.com", cloudId: "c", siteUrl: "https://s.atlassian.net", siteName: "S" },
+        },
+        identity,
+      },
+      ConfigSchema.parse({})
+    );
+    expect(jiraSpy).toHaveBeenCalledWith({
+      accessToken: "SEALED-API",
+      sealedRefreshToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      cloudId: "c",
+      siteUrl: "https://s.atlassian.net",
+      siteName: "S",
+      email: "e@e.com",
+    });
+    expect(res.jiraRestored).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("Jira oauth-mode: refresh (snake_case body + X-Requested-With) then setJiraAuth with computed shape", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => {});
+    vi.spyOn(configStore, "setConfig").mockImplementation(() => {});
+    const jiraSpy = vi.spyOn(authStore, "setJiraAuth").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "NEW-ACCESS", sealed_refresh_token: "NEW-SEALED-RT", expires_in: 3600 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const res = await commitImportedSettings(
+      {
+        bundle: {
+          github: { token: "gho_x", method: "oauth" },
+          jira: { authMethod: "oauth", sealedRefreshToken: "OLD-SEALED-RT", cloudId: "c", siteUrl: "https://s.atlassian.net", siteName: "S" },
+        },
+        identity,
+      },
+      ConfigSchema.parse({})
+    );
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/oauth/jira/refresh");
+    expect(JSON.parse(init.body as string)).toEqual({ sealed_refresh_token: "OLD-SEALED-RT" });
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe("fetch");
+    expect(jiraSpy).toHaveBeenCalledWith({
+      accessToken: "NEW-ACCESS",
+      sealedRefreshToken: "NEW-SEALED-RT",
+      expiresAt: 1_000_000 + 3600 * 1000,
+      cloudId: "c",
+      siteUrl: "https://s.atlassian.net",
+      siteName: "S",
+    });
+    expect(res.jiraRestored).toBe(true);
+  });
+
+  it("Jira oauth refresh failure: warning + jiraRestored:false, no throw, GitHub identity/config not rolled back", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    const authSpy = vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => {});
+    const cfgSpy = vi.spyOn(configStore, "setConfig").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }));
+    const notifySpy = vi.spyOn(errorsLib, "pushNotification").mockImplementation(() => {});
+    const res = await commitImportedSettings(
+      {
+        bundle: {
+          github: { token: "gho_x", method: "oauth" },
+          jira: { authMethod: "oauth", sealedRefreshToken: "OLD-SEALED-RT", cloudId: "c", siteUrl: "https://s.atlassian.net", siteName: "S" },
+        },
+        identity,
+      },
+      ConfigSchema.parse({})
+    );
+    expect(res.jiraRestored).toBe(false);
+    expect(notifySpy).toHaveBeenCalledWith("settings-import-jira", expect.stringMatching(/reconnect/i), "warning");
+    expect(authSpy).toHaveBeenCalled();
+    expect(cfgSpy).toHaveBeenCalled();
+  });
+
+  it("pre-auth (a0): awaits clearIdentityData (real clearCache) before setAuthFromCredential/setConfig (SD-001)", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(null); // pre-auth
+    let resolveClear!: () => void;
+    vi.mocked(cacheStore.clearCache).mockReturnValue(new Promise<void>((r) => { resolveClear = () => r(); }));
+    const order: string[] = [];
+    vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => { order.push("auth"); });
+    vi.spyOn(configStore, "setConfig").mockImplementation(() => { order.push("config"); });
+
+    const p = commitImportedSettings(
+      { bundle: { github: { token: "ghp_x", method: "pat" }, jira: null }, identity },
+      ConfigSchema.parse({})
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual([]); // blocked on the un-resolved clearCache
+    resolveClear();
+    await p;
+    expect(order).toEqual(["auth", "config"]); // established only after the await
+  });
+
+  it("identity-switch integration: REAL cascade replaces config/view/jira and persists imported config", async () => {
+    vi.spyOn(errorsLib, "pushNotification").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn());
+
+    // Seed a prior, different identity + distinguishable per-identity state.
+    authStore.setAuthFromPat("ghp_old", { login: "olduser", avatar_url: "https://a/old", name: "Old" });
+    setConfig(ConfigSchema.parse({ selectedOrgs: ["prior-org"], theme: "dark" }));
+    updateViewState({ lastActiveTab: "actions" });
+    authStore.setJiraAuth({
+      accessToken: "old-access",
+      sealedRefreshToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      cloudId: "old-cloud",
+      siteUrl: "https://old.atlassian.net",
+      siteName: "Old",
+      email: "old@e.com",
+    });
+
+    let dispose!: () => void;
+    createRoot((d) => { dispose = d; initConfigPersistence(); });
+
+    const importedConfig = ConfigSchema.parse({ selectedOrgs: ["new-org"], theme: "light", authMethod: "oauth" });
+    const bundle: CredentialBundle = {
+      github: { token: "ghp_new", method: "oauth" },
+      jira: { authMethod: "token", sealedApiToken: "new-sealed-api", email: "new@e.com", cloudId: "new-cloud", siteUrl: "https://new.atlassian.net", siteName: "New" },
+    };
+
+    await commitImportedSettings({ bundle, identity: { login: "newuser", avatar_url: "https://a/new", name: "New" } }, importedConfig);
+
+    // (1) config deep-equals importedConfig (no prior-identity leftovers, no transient defaults)
+    expect(JSON.parse(JSON.stringify(config))).toEqual(importedConfig);
+    // (2) viewState reset to defaults
+    expect(viewState.lastActiveTab).toBe("issues");
+    // (3) Jira auth matches the imported bundle (cascade cleared it; setJiraAuth restored it)
+    expect(authStore.jiraAuth()).toEqual({
+      accessToken: "new-sealed-api",
+      sealedRefreshToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      cloudId: "new-cloud",
+      siteUrl: "https://new.atlassian.net",
+      siteName: "New",
+      email: "new@e.com",
+    });
+    // (4) localStorage CONFIG persisted with the imported config after the 200ms debounce
+    await new Promise((r) => setTimeout(r, 250));
+    expect(JSON.parse(localStorage.getItem(CONFIG_STORAGE_KEY)!)).toEqual(importedConfig);
+    dispose();
   });
 });

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -258,7 +258,21 @@ describe("parseImportFile", () => {
 
 // ── Task 4: client-side envelope encryption ──────────────────────────────────
 
-const CODE_DISPLAY_RE = /^[0-9a-f]{4}(-[0-9a-f]{4}){7}$/;
+// Mirrors src/app/lib/settings-transfer.ts's Crockford alphabet (excludes I, L, O, U).
+const CODE_DISPLAY_RE = /^([0-9A-HJKMNP-TV-Z]{4}-){5}[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{2}$/;
+
+// Independent reference encoder (NOT imported from src) so the round-trip test
+// below actually cross-checks decodeOneTimeCode against a second implementation,
+// instead of just calling the same code twice.
+function crockfordEncode(bytes: Uint8Array): string {
+  const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+  let value = 0n;
+  for (const b of bytes) value = (value << 8n) | BigInt(b);
+  value <<= 2n;
+  let out = "";
+  for (let i = 25; i >= 0; i--) out += alphabet[Number((value >> BigInt(i * 5)) & 0x1fn)];
+  return out;
+}
 
 // Test-local base64url helpers to construct/mutate wire bytes precisely.
 function b64urlEncode(bytes: Uint8Array): string {
@@ -276,7 +290,7 @@ function b64urlDecode(str: string): Uint8Array {
 }
 
 describe("generateOneTimeCode / decodeOneTimeCode", () => {
-  it("produces the display format (8 dash-separated groups of 4 hex chars)", () => {
+  it("produces the display format (26 Crockford base32 chars, dash-separated in groups of 4)", () => {
     expect(generateOneTimeCode()).toMatch(CODE_DISPLAY_RE);
   });
 
@@ -284,20 +298,52 @@ describe("generateOneTimeCode / decodeOneTimeCode", () => {
     expect(generateOneTimeCode()).not.toBe(generateOneTimeCode());
   });
 
-  it("round-trips: decodeOneTimeCode(generateOneTimeCode()) is the original 16 bytes", () => {
+  it("round-trips: decodeOneTimeCode(generateOneTimeCode()) is the original 16 bytes, and re-encodes identically", () => {
     const code = generateOneTimeCode();
     const bytes = decodeOneTimeCode(code);
     expect(bytes).toBeInstanceOf(Uint8Array);
     expect(bytes.length).toBe(16);
-    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-    expect(hex).toBe(code.replace(/-/g, "").toLowerCase());
+    // Cross-checked against an independent reference encoder, not src's own.
+    expect(crockfordEncode(bytes)).toBe(code.replace(/-/g, ""));
   });
 
-  it("normalizes a manually-perturbed code (uppercased, whitespace, dashes removed) to the same bytes", () => {
+  it("normalizes a manually-perturbed code (lowercased, whitespace/dashes added) to the same bytes", () => {
     const code = generateOneTimeCode();
     const original = decodeOneTimeCode(code);
-    const perturbed = `  ${code.toUpperCase().replace(/-/g, "")}  `;
+    const perturbed = `  ${code.toLowerCase().replace(/-/g, "")}  `;
     expect(Array.from(decodeOneTimeCode(perturbed))).toEqual(Array.from(original));
+  });
+
+  it("applies Crockford's I/L->1, O->0 leniency (mixed case, non-standard dash placement)", () => {
+    // 26 valid Crockford chars containing both '0' and '1' digits.
+    const clean = "0011AABBCCDDEEFFGGHHJJKKMM";
+    const original = decodeOneTimeCode(clean);
+    // Same value retyped with I/L for 1, O/o for 0, mixed case, and dashes that
+    // don't even align to 4-char groups — normalization doesn't care about
+    // grouping, only about stripping dashes/whitespace before mapping.
+    const perturbed = "  oO-IL-aabbccddeeffgghhjjkkmm  ";
+    expect(Array.from(decodeOneTimeCode(perturbed))).toEqual(Array.from(original));
+  });
+
+  it("rejects 'U' — Crockford excludes it and it is never remapped", () => {
+    const bad = "0011AABBCCDDEEFFGGHHJJKKMU"; // valid 25 chars + trailing U
+    expect(() => decodeOneTimeCode(bad)).toThrow("One-time code is not in the expected format.");
+  });
+
+  it("rejects other out-of-alphabet characters", () => {
+    expect(() => decodeOneTimeCode("0011AABBCCDDEEFFGGHHJJKK!!")).toThrow(
+      "One-time code is not in the expected format."
+    );
+  });
+
+  it("rejects the wrong length", () => {
+    const valid = generateOneTimeCode().replace(/-/g, "");
+    expect(() => decodeOneTimeCode(valid.slice(0, 25))).toThrow(
+      "One-time code is not in the expected format."
+    );
+    expect(() => decodeOneTimeCode(valid + "0")).toThrow(
+      "One-time code is not in the expected format."
+    );
   });
 });
 
@@ -306,7 +352,7 @@ describe("deriveEnvelopeKey — secure-context guard", () => {
     const realCrypto = globalThis.crypto;
     vi.stubGlobal("crypto", { getRandomValues: realCrypto.getRandomValues.bind(realCrypto) });
     await expect(
-      deriveEnvelopeKey("0000-0000-0000-0000-0000-0000-0000-0000", new Uint8Array(16))
+      deriveEnvelopeKey("0000-0000-0000-0000-0000-0000-00", new Uint8Array(16))
     ).rejects.toThrow(/secure context/i);
   });
 });
@@ -562,7 +608,7 @@ describe("buildEncryptedCredentialsSection", () => {
     const { sealed, salt, oneTimeCode } = await buildEncryptedCredentialsSection();
     expect(sealed).toBe("SEALED-OUTPUT");
     expect(typeof salt).toBe("string");
-    expect(oneTimeCode).toMatch(/^[0-9a-f]{4}(-[0-9a-f]{4}){7}$/);
+    expect(oneTimeCode).toMatch(CODE_DISPLAY_RE);
     // The one-time code must NOT appear in what gets written to the export file.
     expect(JSON.stringify({ sealed, salt })).not.toContain(oneTimeCode);
   });

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -241,6 +241,19 @@ describe("parseImportFile", () => {
       expect(result.config.theme).toBe("auto");
     }
   });
+
+  it("STRUCT-I-001: rejects a file stamped with a NEWER export version, with a clear message", () => {
+    const result = parseImportFile(JSON.stringify({ _exportVersion: 2, theme: "dark" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors[0]).toMatch(/newer version/i);
+  });
+
+  it("STRUCT-I-001: accepts version 1 and a missing _exportVersion (treated as v1)", () => {
+    expect(parseImportFile(JSON.stringify({ _exportVersion: 1, theme: "dark" })).ok).toBe(true);
+    expect(parseImportFile(JSON.stringify({ theme: "dark" })).ok).toBe(true);
+    // A round-tripped real export (stamped v1 by buildExportPayload) also parses.
+    expect(parseImportFile(JSON.stringify(buildExportPayload(ConfigSchema.parse({})))).ok).toBe(true);
+  });
 });
 
 // ── Task 4: client-side envelope encryption ──────────────────────────────────
@@ -504,8 +517,32 @@ describe("proxy — sealCredentialBundle / unsealCredentialBundle (Task 5/6)", (
     expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "invalid" });
   });
 
-  it("unsealCredentialBundle maps a network failure to { ok:false, reason:'invalid' }", async () => {
+  it("unsealCredentialBundle maps a thrown proxyFetch to { ok:false, reason:'network' } (retryable, no nonce consumed)", async () => {
+    // SEC-001: a network throw means NO server response arrived, so the single-use
+    // nonce was never reached — retryable, NOT the terminal 'invalid'.
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("network down")));
+    expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "network" });
+  });
+
+  it("unsealCredentialBundle maps a 429 to { ok:false, reason:'rate-limited' } (retryable, pre-nonce)", async () => {
+    // API-001: the pre-gate rate limiter fires before Turnstile and long before
+    // nonce access, so the bundle is still valid — retryable.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 429, json: async () => ({ error: "rate_limited" }) }));
+    expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "rate-limited" });
+  });
+
+  it("unsealCredentialBundle maps a 403 turnstile_failed to { ok:false, reason:'network' } (retryable, pre-nonce)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 403, json: async () => ({ error: "turnstile_failed" }) }));
+    expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "network" });
+  });
+
+  it("unsealCredentialBundle maps a 503 internal_error to { ok:false, reason:'network' } (retryable, pre-nonce)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({ error: "internal_error" }) }));
+    expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "network" });
+  });
+
+  it("unsealCredentialBundle keeps a genuine 401 { error:'invalid' } TERMINAL (bad blob / consumed nonce)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: "invalid" }) }));
     expect(await proxyLib.unsealCredentialBundle("SEALED")).toEqual({ ok: false, reason: "invalid" });
   });
 });
@@ -549,6 +586,47 @@ describe("buildEncryptedCredentialsSection", () => {
     expect(decrypted).not.toBeNull();
     const roundTripped = JSON.parse(decrypted!) as CredentialBundle;
     expect(roundTripped.github.token).toBe("ghp_SECRET_GITHUB_TOKEN");
+  });
+
+  it("full round-trip for a Jira-inclusive bundle near the 4096 pre-check boundary (assemble→encrypt→seal)", async () => {
+    updateJiraConfig({ enabled: true, authMethod: "token" });
+    const bigSealed = "S".repeat(2700); // pushes the envelope ciphertext near the 4096 client cap
+    authStore.setJiraAuth({
+      accessToken: bigSealed,
+      sealedRefreshToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      cloudId: "cloud-2",
+      siteUrl: "https://token.atlassian.net",
+      siteName: "TokenSite",
+      email: "user@example.com",
+    });
+
+    // Echo the ciphertext back as the sealed blob so we can decrypt it and prove
+    // the whole assemble→encrypt→seal chain produced a recoverable Jira bundle.
+    let sealedInput = "";
+    vi.spyOn(proxyLib, "sealCredentialBundle").mockImplementation(async (ct: string) => {
+      sealedInput = ct;
+      return ct;
+    });
+
+    const { sealed, salt, oneTimeCode } = await buildEncryptedCredentialsSection();
+    expect(sealed).toBe(sealedInput);
+    // Within — and near — the client 4096 pre-check cap.
+    expect(sealedInput.length).toBeLessThanOrEqual(4096);
+    expect(sealedInput.length).toBeGreaterThan(3000);
+
+    const decrypted = await decryptWithCode(sealed, salt, oneTimeCode);
+    expect(decrypted).not.toBeNull();
+    const bundle = JSON.parse(decrypted!) as CredentialBundle;
+    expect(bundle.github.token).toBe("ghp_SECRET_GITHUB_TOKEN");
+    expect(bundle.jira).toEqual({
+      authMethod: "token",
+      sealedApiToken: bigSealed,
+      email: "user@example.com",
+      cloudId: "cloud-2",
+      siteUrl: "https://token.atlassian.net",
+      siteName: "TokenSite",
+    });
   });
 });
 
@@ -628,6 +706,38 @@ describe("resolveImportedCredentials", () => {
     }
     expect(setConfigSpy).not.toHaveBeenCalled();
     expect(setAuthSpy).not.toHaveBeenCalled();
+  });
+
+  it("QA-002: the /user identity check sends the standard GitHub API headers", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await makeCiphertext(code);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ login: "u", avatar_url: "a", name: "N" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    await resolveImportedCredentials(ciphertext, salt, code);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Accept).toBe("application/vnd.github+json");
+    expect(headers["X-GitHub-Api-Version"]).toBe("2022-11-28");
+    expect(headers.Authorization).toBe("Bearer ghp_valid_token");
+  });
+
+  it("SEC-002: a bundle with a malformed jira.siteUrl fails resolution before any /user call", async () => {
+    // The tightened CredentialBundleSchema (siteUrl .url(), cloudId/siteName
+    // .min(1)) rejects at import via the generic decrypt-failure path, instead of
+    // importing + working in-session then silently vanishing on the next reload
+    // when the stricter JiraAuthStateSchema rejects it.
+    const code = generateOneTimeCode();
+    const malformed = {
+      github: { token: "ghp_valid_token", method: "pat" },
+      jira: { authMethod: "token", sealedApiToken: "s", email: "e@e.com", cloudId: "c", siteUrl: "not-a-url", siteName: "S" },
+    };
+    const { ciphertext, salt } = await encryptWithCode(JSON.stringify(malformed), code);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await resolveImportedCredentials(ciphertext, salt, code);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/check the code and file match/i);
+    expect(fetchMock).not.toHaveBeenCalled(); // schema fails before the identity check
   });
 
   it("R-001: surfaces the secure-context precondition distinctly on the decrypt path", async () => {
@@ -850,6 +960,98 @@ describe("commitImportedSettings", () => {
     await new Promise((r) => setTimeout(r, 250));
     expect(JSON.parse(localStorage.getItem(CONFIG_STORAGE_KEY)!)).toEqual(importedConfig);
     dispose();
+  });
+
+  it("STRUCT-I-002: a non-positive expires_in yields a sane future expiresAt (default 3600s), not past/NaN", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => {});
+    vi.spyOn(configStore, "setConfig").mockImplementation(() => {});
+    const jiraSpy = vi.spyOn(authStore, "setJiraAuth").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "A", sealed_refresh_token: "RT", expires_in: 0 }),
+    }));
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    await commitImportedSettings(
+      {
+        bundle: {
+          github: { token: "gho_x", method: "oauth" },
+          jira: { authMethod: "oauth", sealedRefreshToken: "OLD", cloudId: "c", siteUrl: "https://s.atlassian.net", siteName: "S" },
+        },
+        identity,
+      },
+      ConfigSchema.parse({})
+    );
+    const state = jiraSpy.mock.calls[0][0];
+    expect(state.expiresAt).toBe(1_000_000 + 3600 * 1000); // clamped to the 3600s default
+    expect(Number.isNaN(state.expiresAt)).toBe(false);
+  });
+
+  it("STRUCT-I-003: aligns the imported config's jira.authMethod with the tamper-proof bundle authMethod", async () => {
+    vi.spyOn(authStore, "user").mockReturnValue(identity);
+    vi.spyOn(authStore, "setAuthFromCredential").mockImplementation(() => {});
+    vi.spyOn(authStore, "setJiraAuth").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn());
+    const cfgSpy = vi.spyOn(configStore, "setConfig").mockImplementation(() => {});
+    // Plaintext config claims OAuth, but the sealed bundle is token-mode → the
+    // committed config must follow the bundle so runtime Jira branching matches
+    // the restored credential shape.
+    const importedConfig = ConfigSchema.parse({ jira: { enabled: true, authMethod: "oauth" } });
+    await commitImportedSettings(
+      {
+        bundle: {
+          github: { token: "ghp_x", method: "pat" },
+          jira: { authMethod: "token", sealedApiToken: "SA", email: "e@e.com", cloudId: "c", siteUrl: "https://s.atlassian.net", siteName: "S" },
+        },
+        identity,
+      },
+      importedConfig
+    );
+    const committed = cfgSpy.mock.calls[0][0] as { jira: { authMethod: string } };
+    expect(committed.jira.authMethod).toBe("token");
+  });
+
+  it("QA-003: OAuth-Jira identity-switch (REAL cascade) — final jiraAuth reflects the refreshed token, not the cascade-cleared null", async () => {
+    vi.spyOn(errorsLib, "pushNotification").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "REFRESHED-ACCESS", sealed_refresh_token: "NEW-RT", expires_in: 3600 }),
+    }));
+
+    // Seed a prior, DIFFERENT identity + a prior Jira auth blob so the real
+    // setAuthFromCredential identity-switch cascade runs (and clears jiraAuth).
+    authStore.setAuthFromPat("ghp_old", { login: "olduser", avatar_url: "https://a/old", name: "Old" });
+    authStore.setJiraAuth({
+      accessToken: "old-access",
+      sealedRefreshToken: "old-rt",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      cloudId: "old-cloud",
+      siteUrl: "https://old.atlassian.net",
+      siteName: "Old",
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(2_000_000);
+    const importedConfig = ConfigSchema.parse({ authMethod: "oauth", jira: { enabled: true, authMethod: "oauth" } });
+    const bundle: CredentialBundle = {
+      github: { token: "gho_new", method: "oauth" },
+      jira: { authMethod: "oauth", sealedRefreshToken: "EXPORTED-RT", cloudId: "new-cloud", siteUrl: "https://new.atlassian.net", siteName: "New" },
+    };
+
+    const res = await commitImportedSettings(
+      { bundle, identity: { login: "newuser", avatar_url: "https://a/new", name: "New" } },
+      importedConfig
+    );
+
+    expect(res.jiraRestored).toBe(true);
+    // The cascade nulled jiraAuth; the OAuth refresh restored it with the minted token.
+    expect(authStore.jiraAuth()).toEqual({
+      accessToken: "REFRESHED-ACCESS",
+      sealedRefreshToken: "NEW-RT",
+      expiresAt: 2_000_000 + 3600 * 1000,
+      cloudId: "new-cloud",
+      siteUrl: "https://new.atlassian.net",
+      siteName: "New",
+    });
   });
 });
 

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ConfigSchema, JiraConfigSchema } from "../../src/shared/schemas";
+import {
+  EXPORT_VERSION,
+  EXPORT_DENYLIST,
+  MAX_IMPORT_BYTES,
+  buildExportPayload,
+  parseImportFile,
+  generateOneTimeCode,
+  decodeOneTimeCode,
+  deriveEnvelopeKey,
+  encryptWithKey,
+  encryptWithCode,
+  decryptWithCode,
+  ENVELOPE_VERSION,
+} from "../../src/app/lib/settings-transfer";
+
+// ── Schema-drift guard update workflow ────────────────────────────────────────
+// When ConfigSchema / JiraConfigSchema change, the two guard tests below FAIL.
+// Before touching the snapshot arrays:
+//   1. Read the failure message — it names the added/removed key(s).
+//   2. If a key was ADDED, decide whether it carries a secret or PII.
+//      buildExportPayload() exports EVERY Config field by default, so a
+//      sensitive new field MUST be added to EXPORT_DENYLIST in
+//      src/app/lib/settings-transfer.ts.
+//   3. Only THEN update the EXPECTED_*_KEYS array here to match the schema.
+
+const EXPECTED_CONFIG_KEYS = [
+  "authMethod",
+  "customTabs",
+  "defaultTab",
+  "dependencies",
+  "enableActions",
+  "enableTracking",
+  "hotPollInterval",
+  "itemsPerPage",
+  "jira",
+  "maxRunsPerWorkflow",
+  "maxWorkflowsPerRepo",
+  "mcpRelayEnabled",
+  "mcpRelayPort",
+  "monitoredRepos",
+  "notifications",
+  "onboardingComplete",
+  "refreshInterval",
+  "rememberLastTab",
+  "selectedOrgs",
+  "selectedRepos",
+  "theme",
+  "trackedUsers",
+  "upstreamRepos",
+  "viewDensity",
+];
+
+const EXPECTED_JIRA_KEYS = [
+  "authMethod",
+  "cloudId",
+  "customFields",
+  "customScopes",
+  "email",
+  "enabled",
+  "expandIssueDetails",
+  "issueKeyDetection",
+  "siteName",
+  "siteUrl",
+];
+
+function diffKeys(actual: string[], expected: string[]): { added: string[]; removed: string[] } {
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+  return {
+    added: actual.filter((k) => !expectedSet.has(k)),
+    removed: expected.filter((k) => !actualSet.has(k)),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("settings-transfer — schema-drift guard", () => {
+  it("ConfigSchema top-level shape matches the export snapshot", () => {
+    const actual = Object.keys(ConfigSchema.shape).sort();
+    const { added, removed } = diffKeys(actual, EXPECTED_CONFIG_KEYS);
+    expect(
+      added.length === 0 && removed.length === 0,
+      `ConfigSchema top-level keys changed (added: [${added.join(", ")}], removed: [${removed.join(", ")}]). ` +
+        "Before updating EXPECTED_CONFIG_KEYS, review EXPORT_DENYLIST in " +
+        "src/app/lib/settings-transfer.ts: buildExportPayload() exports EVERY Config field by " +
+        "default, so decide whether any ADDED field carries a secret or PII that must be denylisted."
+    ).toBe(true);
+  });
+
+  it("JiraConfigSchema shape matches the export snapshot", () => {
+    const actual = Object.keys(JiraConfigSchema.shape).sort();
+    const { added, removed } = diffKeys(actual, EXPECTED_JIRA_KEYS);
+    expect(
+      added.length === 0 && removed.length === 0,
+      `JiraConfigSchema keys changed (added: [${added.join(", ")}], removed: [${removed.join(", ")}]). ` +
+        "Before updating EXPECTED_JIRA_KEYS, review EXPORT_DENYLIST in " +
+        "src/app/lib/settings-transfer.ts (jira.email is currently denylisted as PII) and decide " +
+        "whether any ADDED Jira field must also be denylisted."
+    ).toBe(true);
+  });
+});
+
+describe("buildExportPayload", () => {
+  it("omits denylisted jira.email while keeping the rest of the jira object", () => {
+    const cfg = ConfigSchema.parse({
+      jira: { enabled: true, email: "secret@example.com", cloudId: "cloud-123" },
+    });
+    expect(cfg.jira.email).toBe("secret@example.com");
+
+    const out = buildExportPayload(cfg);
+    const jira = out.jira as Record<string, unknown>;
+    expect(jira).toBeDefined();
+    expect("email" in jira).toBe(false);
+    // The rest of the jira object survives the denylist deletion.
+    expect(jira.cloudId).toBe("cloud-123");
+    expect(jira.enabled).toBe(true);
+    // EXPORT_DENYLIST documents exactly what was removed.
+    expect(EXPORT_DENYLIST.jira).toContain("email");
+  });
+
+  it("stamps the export version", () => {
+    const out = buildExportPayload(ConfigSchema.parse({}));
+    expect(out._exportVersion).toBe(EXPORT_VERSION);
+    expect(out._exportVersion).toBe(1);
+  });
+
+  it("includes fields absent from the old hand-maintained export list (proves the spread mechanism)", () => {
+    // onboardingComplete + mcpRelayEnabled exist in ConfigSchema but were NEVER
+    // in SettingsPage.tsx's pre-refactor object literal — their presence is the
+    // assertion that actually distinguishes a schema-driven rewrite from a
+    // leftover manual literal.
+    const out = buildExportPayload(ConfigSchema.parse({}));
+    expect(Object.prototype.hasOwnProperty.call(out, "onboardingComplete")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(out, "mcpRelayEnabled")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(out, "mcpRelayPort")).toBe(true);
+  });
+});
+
+describe("parseImportFile", () => {
+  it("parses a valid export payload produced by buildExportPayload", () => {
+    const payload = buildExportPayload(ConfigSchema.parse({ theme: "dark", itemsPerPage: 50 }));
+    const result = parseImportFile(JSON.stringify(payload));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.theme).toBe("dark");
+      expect(result.config.itemsPerPage).toBe(50);
+    }
+  });
+
+  it("rejects an oversized (ASCII) file WITHOUT calling JSON.parse", () => {
+    const big = "a".repeat(300 * 1024); // 307200 bytes > 256KB
+    const parseSpy = vi.spyOn(JSON, "parse");
+    const result = parseImportFile(big);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors[0]).toMatch(/too large/i);
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  it("measures BYTES not code units — rejects multi-byte content under 256KB code units but over 256KB bytes", () => {
+    // 100Ki CJK chars: length (code units) < 256Ki, UTF-8 byte size (~3x) > 256Ki.
+    const cjk = "语".repeat(100 * 1024);
+    expect(cjk.length).toBeLessThan(MAX_IMPORT_BYTES); // 102400 < 262144
+    expect(new TextEncoder().encode(cjk).length).toBeGreaterThan(MAX_IMPORT_BYTES); // ~307200 > 262144
+
+    const parseSpy = vi.spyOn(JSON, "parse");
+    const result = parseImportFile(cjk);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors[0]).toMatch(/too large/i);
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns a JSON-syntax error for non-JSON text", () => {
+    const result = parseImportFile("this is not json {{{");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors[0]).toMatch(/json/i);
+  });
+
+  it("returns Zod issue messages for structurally-invalid JSON (valid JSON, fails schema)", () => {
+    const result = parseImportFile(JSON.stringify({ refreshInterval: -999 }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors.some((e) => e.includes("refreshInterval"))).toBe(true);
+    }
+  });
+
+  it("carries the pre-parse theme salvage through import (invalid theme, otherwise valid)", () => {
+    const result = parseImportFile(JSON.stringify({ theme: "ultraviolet", refreshInterval: 120 }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.theme).toBe("auto"); // salvaged, not a total fallback
+      expect(result.config.refreshInterval).toBe(120); // proves the rest survived
+    }
+  });
+
+  it("fills schema defaults for a payload missing fields (forward-compatible)", () => {
+    const result = parseImportFile(JSON.stringify({}));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.refreshInterval).toBe(300);
+      expect(result.config.theme).toBe("auto");
+    }
+  });
+});
+
+// ── Task 4: client-side envelope encryption ──────────────────────────────────
+
+const CODE_DISPLAY_RE = /^[0-9a-f]{4}(-[0-9a-f]{4}){7}$/;
+
+// Test-local base64url helpers to construct/mutate wire bytes precisely.
+function b64urlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+function b64urlDecode(str: string): Uint8Array {
+  const norm = str.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = (4 - (norm.length % 4)) % 4;
+  const bin = atob(norm + "=".repeat(pad));
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+describe("generateOneTimeCode / decodeOneTimeCode", () => {
+  it("produces the display format (8 dash-separated groups of 4 hex chars)", () => {
+    expect(generateOneTimeCode()).toMatch(CODE_DISPLAY_RE);
+  });
+
+  it("produces a different code on consecutive calls", () => {
+    expect(generateOneTimeCode()).not.toBe(generateOneTimeCode());
+  });
+
+  it("round-trips: decodeOneTimeCode(generateOneTimeCode()) is the original 16 bytes", () => {
+    const code = generateOneTimeCode();
+    const bytes = decodeOneTimeCode(code);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBe(16);
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+    expect(hex).toBe(code.replace(/-/g, "").toLowerCase());
+  });
+
+  it("normalizes a manually-perturbed code (uppercased, whitespace, dashes removed) to the same bytes", () => {
+    const code = generateOneTimeCode();
+    const original = decodeOneTimeCode(code);
+    const perturbed = `  ${code.toUpperCase().replace(/-/g, "")}  `;
+    expect(Array.from(decodeOneTimeCode(perturbed))).toEqual(Array.from(original));
+  });
+});
+
+describe("deriveEnvelopeKey — secure-context guard", () => {
+  it("rejects with the secure-context message when crypto.subtle is unavailable", async () => {
+    const realCrypto = globalThis.crypto;
+    vi.stubGlobal("crypto", { getRandomValues: realCrypto.getRandomValues.bind(realCrypto) });
+    await expect(
+      deriveEnvelopeKey("0000-0000-0000-0000-0000-0000-0000-0000", new Uint8Array(16))
+    ).rejects.toThrow(/secure context/i);
+  });
+});
+
+describe("encryptWithCode / decryptWithCode", () => {
+  it("round-trips the plaintext exactly", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await encryptWithCode("hello, credential bundle", code);
+    expect(await decryptWithCode(ciphertext, salt, code)).toBe("hello, credential bundle");
+  });
+
+  it("returns null when decrypting with the wrong code", async () => {
+    const { ciphertext, salt } = await encryptWithCode("top secret", generateOneTimeCode());
+    expect(await decryptWithCode(ciphertext, salt, generateOneTimeCode())).toBeNull();
+  });
+
+  it("returns null when the ciphertext is tampered (single flipped bit)", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await encryptWithCode("top secret", code);
+    const bytes = b64urlDecode(ciphertext);
+    bytes[bytes.length - 1] ^= 0x01; // flip a bit in the GCM tag/body
+    expect(await decryptWithCode(b64urlEncode(bytes), salt, code)).toBeNull();
+  });
+
+  it("returns null when the version byte is unrecognized", async () => {
+    const code = generateOneTimeCode();
+    const { ciphertext, salt } = await encryptWithCode("top secret", code);
+    const bytes = b64urlDecode(ciphertext);
+    expect(bytes[0]).toBe(ENVELOPE_VERSION); // sanity: real version
+    bytes[0] = 0x02; // corrupt version byte
+    expect(await decryptWithCode(b64urlEncode(bytes), salt, code)).toBeNull();
+  });
+
+  it("uses a fresh IV per call — same key + same plaintext yields different ciphertexts", async () => {
+    // MUST isolate the IV: derive the key ONCE (fixed salt) and call the
+    // lower-level encryptWithKey twice, so a reused/hardcoded IV would fail here.
+    // (Calling encryptWithCode twice would mask an IV-reuse bug via its
+    // fresh-random-salt-per-call changing the derived key each time.)
+    const salt = new Uint8Array(16); // fixed salt
+    const key = await deriveEnvelopeKey(generateOneTimeCode(), salt);
+    const c1 = await encryptWithKey("identical plaintext", key);
+    const c2 = await encryptWithKey("identical plaintext", key);
+    expect(c1).not.toBe(c2);
+  });
+});

--- a/tests/lib/settings-transfer.test.ts
+++ b/tests/lib/settings-transfer.test.ts
@@ -30,6 +30,7 @@ import {
   buildEncryptedCredentialsSection,
   resolveImportedCredentials,
   commitImportedSettings,
+  hasExistingLocalConfig,
 } from "../../src/app/lib/settings-transfer";
 import type { CredentialBundle } from "../../src/app/lib/settings-transfer";
 import * as proxyLib from "../../src/app/lib/proxy";
@@ -849,5 +850,38 @@ describe("commitImportedSettings", () => {
     await new Promise((r) => setTimeout(r, 250));
     expect(JSON.parse(localStorage.getItem(CONFIG_STORAGE_KEY)!)).toEqual(importedConfig);
     dispose();
+  });
+});
+
+// ── Task 7: hasExistingLocalConfig (Login-page confirmation-skip detector) ─────
+
+describe("hasExistingLocalConfig", () => {
+  it("returns false for a default/empty config (fresh browser / incognito)", () => {
+    const cfg = ConfigSchema.parse({});
+    expect(cfg.onboardingComplete).toBe(false);
+    expect(cfg.selectedRepos).toEqual([]);
+    expect(cfg.selectedOrgs).toEqual([]);
+    expect(hasExistingLocalConfig(cfg)).toBe(false);
+  });
+
+  it("returns true when onboardingComplete is true even with empty repo/org arrays", () => {
+    const cfg = ConfigSchema.parse({ onboardingComplete: true });
+    expect(cfg.selectedRepos).toEqual([]);
+    expect(cfg.selectedOrgs).toEqual([]);
+    expect(hasExistingLocalConfig(cfg)).toBe(true);
+  });
+
+  it("returns true for non-empty selectedRepos even when onboardingComplete is false", () => {
+    const cfg = ConfigSchema.parse({
+      onboardingComplete: false,
+      selectedRepos: [{ owner: "acme", name: "api", fullName: "acme/api" }],
+    });
+    expect(cfg.onboardingComplete).toBe(false);
+    expect(hasExistingLocalConfig(cfg)).toBe(true);
+  });
+
+  it("returns true for non-empty selectedOrgs even when onboardingComplete is false", () => {
+    const cfg = ConfigSchema.parse({ onboardingComplete: false, selectedOrgs: ["acme"] });
+    expect(hasExistingLocalConfig(cfg)).toBe(true);
   });
 });

--- a/tests/pages/JiraCallback.test.tsx
+++ b/tests/pages/JiraCallback.test.tsx
@@ -327,6 +327,22 @@ describe("JiraCallback", () => {
     expect(headers["cf-turnstile-response"]).toBe("test-turnstile-tok");
   });
 
+  it("acquires the Turnstile token with action 'jira-token' (not the old inherited 'seal' default)", async () => {
+    setupValidState();
+    setWindowSearch({ code: "jira-code", state: "valid-jira-state" });
+    mockSuccessfulExchange();
+    vi.mocked(JiraClient.getAccessibleResources).mockResolvedValue([makeResource()]);
+
+    renderCallback();
+
+    await waitFor(() => {
+      expect(vi.mocked(proxyLib.acquireTurnstileToken)).toHaveBeenCalledWith(
+        expect.any(String),
+        "jira-token"
+      );
+    });
+  });
+
   // ── Multi-site picker ─────────────────────────────────────────────────────
 
   it("shows site picker when multiple Jira sites returned", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -37,6 +37,24 @@ globalThis.clearTimeout = ((id?: ReturnType<typeof setTimeout>) => {
   originalClearTimeout(id);
 }) as typeof clearTimeout;
 
+// happy-dom implements requestAnimationFrame via TIMER.setImmediate (Node's
+// check phase), which can resolve *after* the zero-delay setTimeout chain
+// @testing-library/user-event uses internally to pace synthetic events. Kobalte's
+// Dialog schedules its exit-side cleanup (undoing the aria-hidden it applies to
+// background content while a modal is open, and restoring document.body's
+// pointer-events) via `setTimeout(() => requestAnimationFrame(fn))`. When the rAF
+// hop lags behind userEvent's own timer chain, `await user.click(...)` on a modal's
+// dismiss button can resolve before that cleanup runs, leaving the rest of the page
+// aria-hidden/pointer-events:none for whatever assertion or interaction comes next
+// in the same test. Rerouting rAF through a microtask keeps callback ordering
+// deterministic relative to userEvent's chain without making rAF fully synchronous
+// (real timestamp preserved so time-based animation loops, e.g. SettingsTOC's
+// smooth-scroll easing, still terminate normally when a test doesn't stub rAF).
+globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+  Promise.resolve().then(() => cb(performance.now()));
+  return 0;
+}) as typeof requestAnimationFrame;
+
 afterEach(() => {
   for (const id of pendingTimers) {
     originalClearTimeout(id);

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -548,7 +548,7 @@ describe("cross-tab auth sync", () => {
     expect(mod.token()).toBe("ghs_abc");
   });
 
-  it("fires /user fetch on token replacement and updates user() on success", async () => {
+  it("fires /user fetch on token replacement, but reloads instead of adopting the identity when this tab has no confirmable prior identity (user() null)", async () => {
     const userData = { login: "replaceduser", avatar_url: "https://avatars.githubusercontent.com/u/2", name: "Replaced" };
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -556,7 +556,10 @@ describe("cross-tab auth sync", () => {
       json: () => Promise.resolve(userData),
     });
     vi.stubGlobal("fetch", fetchMock);
+    const reloadSpy = vi.spyOn(mod.crossTabReload, "reloadForIdentitySwitch").mockImplementation(() => {});
 
+    // Token-only auth, deliberately no user() set — mirrors a tab with no
+    // confirmable prior identity (e.g. post-expireToken()).
     mod.setAuth({ access_token: "ghs_abc" });
 
     window.dispatchEvent(new StorageEvent("storage", {
@@ -578,7 +581,12 @@ describe("cross-tab auth sync", () => {
         }),
       })
     );
-    expect(mod.user()?.login).toBe("replaceduser");
+    // With no confirmable prior identity, the fetched identity is NOT
+    // adopted in place — this tab reloads instead so it re-initializes
+    // cleanly rather than risk rendering a different identity against
+    // whatever config/view it's still holding.
+    expect(reloadSpy).toHaveBeenCalledOnce();
+    expect(mod.user()).toBeNull();
   });
 
   it("user preserved when /user fetch fails after token replacement", async () => {
@@ -654,6 +662,42 @@ describe("cross-tab auth sync", () => {
     // Config/view are untouched by a same-identity rotation (no reset triggered).
     expect(localStorageMock.getItem("github-tracker:config")).toBe('{"theme":"dark"}');
     expect(localStorageMock.getItem("github-tracker:view")).toBe('{"lastActiveTab":"actions"}');
+  });
+
+  it("Gap B (bleed): reloads instead of adopting a DIFFERENT identity when this tab's user() is null after expireToken() (prior identity's config/view retained)", async () => {
+    const reloadSpy = vi.spyOn(mod.crossTabReload, "reloadForIdentitySwitch").mockImplementation(() => {});
+
+    // Authenticate as X and seed non-default config/view for that identity.
+    mod.setAuthFromPat("ghp_x", { login: "userx", avatar_url: "https://avatars.githubusercontent.com/u/1", name: "User X" });
+    localStorageMock.setItem("github-tracker:config", '{"theme":"dark"}');
+    localStorageMock.setItem("github-tracker:view", '{"lastActiveTab":"actions"}');
+
+    // This tab's token becomes invalid (e.g. revoked/expired). expireToken()
+    // clears user() to null but deliberately PRESERVES config/view so the
+    // same user can silently re-auth.
+    mod.expireToken();
+    expect(mod.user()).toBeNull();
+
+    // A DIFFERENT identity (Y) signs in via another tab.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ login: "usery", avatar_url: "https://avatars.githubusercontent.com/u/2", name: "User Y" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    window.dispatchEvent(new StorageEvent("storage", {
+      key: "github-tracker:auth-token",
+      newValue: "ghp_y",
+    }));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Bleed prevented: with previousLogin unconfirmable (user() was null),
+    // the fix reloads rather than quietly adopting identity Y while this tab
+    // still holds identity X's config/view in memory/localStorage.
+    expect(reloadSpy).toHaveBeenCalledOnce();
+    expect(mod.user()).toBeNull();
   });
 
   it("does not call expireToken when no token is set in memory", () => {

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -577,6 +577,61 @@ describe("cross-tab auth sync", () => {
     expect(mod.token()).toBe("ghs_replacement");
   });
 
+  it("Gap B: reloads the tab when the cross-tab token belongs to a DIFFERENT identity (not just a token rotation)", async () => {
+    const reloadSpy = vi.spyOn(mod.crossTabReload, "reloadForIdentitySwitch").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ login: "newidentity", avatar_url: "https://avatars.githubusercontent.com/u/9", name: "New Identity" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mod.setAuthFromPat("ghs_old", { login: "olduser", avatar_url: "https://avatars.githubusercontent.com/u/1", name: "Old" });
+
+    window.dispatchEvent(new StorageEvent("storage", {
+      key: "github-tracker:auth-token",
+      newValue: "ghs_new_identity_token",
+    }));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(reloadSpy).toHaveBeenCalledOnce();
+    // setUser is deliberately NOT called for an identity switch — the tab
+    // reloads instead, so user() is left as whatever it was before (a real
+    // reload would replace the whole page with the new identity's state).
+    expect(mod.user()?.login).toBe("olduser");
+    // Token IS still updated synchronously regardless (unchanged pre-fetch behavior).
+    expect(mod.token()).toBe("ghs_new_identity_token");
+  });
+
+  it("Gap B: does NOT reload on a same-identity token rotation (case-insensitive login match) and leaves config/view untouched", async () => {
+    const reloadSpy = vi.spyOn(mod.crossTabReload, "reloadForIdentitySwitch").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ login: "SAMEUSER", avatar_url: "https://avatars.githubusercontent.com/u/1", name: "Same User" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mod.setAuthFromPat("ghs_old", { login: "sameuser", avatar_url: "https://avatars.githubusercontent.com/u/1", name: "Same User" });
+    localStorageMock.setItem("github-tracker:config", '{"theme":"dark"}');
+    localStorageMock.setItem("github-tracker:view", '{"lastActiveTab":"actions"}');
+
+    window.dispatchEvent(new StorageEvent("storage", {
+      key: "github-tracker:auth-token",
+      newValue: "ghs_rotated",
+    }));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    // Rotation still adopts the refreshed user data, same as before this fix.
+    expect(mod.user()?.login).toBe("SAMEUSER");
+    // Config/view are untouched by a same-identity rotation (no reset triggered).
+    expect(localStorageMock.getItem("github-tracker:config")).toBe('{"theme":"dark"}');
+    expect(localStorageMock.getItem("github-tracker:view")).toBe('{"lastActiveTab":"actions"}');
+  });
+
   it("does not call expireToken when no token is set in memory", () => {
     // No setAuth call — token signal is null, guard `_token()` prevents action
     localStorageMock.removeItem("github-tracker:auth-token");

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -465,32 +465,25 @@ describe("cross-tab auth sync", () => {
     vi.resetModules();
     mod = await import("../../src/app/stores/auth");
     // Safe default fetch stub for every test in this describe block. auth.ts
-    // registers its "storage" listener as a module-level side effect, and
-    // `vi.resetModules()` + re-import (every beforeEach, in EVERY describe in
-    // this file) creates a fresh module instance with its OWN closed-over
-    // token/user signals — but the underlying happy-dom `window` is shared for
-    // the whole test FILE, and nothing ever calls `removeEventListener`, so
-    // every one of those listeners stays attached for the rest of the file's
-    // run. A LATER test's `dispatchEvent(new StorageEvent(...))` therefore
-    // also re-fires every EARLIER test's now-stale listener whenever that
-    // stale listener's frozen `_token()` differs from the dispatched value —
-    // which is nearly always, since each stale instance is frozen at whatever
-    // token ITS OWN test last set. Without a fetch stub always active, one of
-    // those stale listeners can fall through to a REAL, un-awaited network
-    // call to api.github.com that's still in-flight when the file tears down,
-    // which happy-dom then aborts — throwing unhandled AbortError/
-    // ERR_INVALID_STATE errors that make the whole run flaky. Individual
+    // registers its "storage" listener as a module-level side effect; the
+    // afterEach below detaches it via `_resetAuthStorageListenerForTests()`, so
+    // within this describe each `vi.resetModules()` + re-import swaps the listener
+    // rather than piling new ones onto the shared happy-dom `window`. The stub still guards the
+    // current test's own listener: its cross-tab branch fires an un-awaited
+    // `/user` fetch that, without a stub, would hit the real network and abort
+    // on teardown (throwing unhandled AbortError/ERR_INVALID_STATE). Individual
     // tests below override this with their own `vi.stubGlobal("fetch", ...)`
     // when they care about the specific response.
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: () => Promise.resolve({}) }));
   });
 
   afterEach(async () => {
-    // Flush pending microtasks BEFORE restoring globals, so every listener
-    // triggered by this test's dispatch (fresh AND stale — see beforeEach)
-    // fully settles against the still-active mock rather than racing
-    // `vi.unstubAllGlobals()` below and falling through to the real fetch.
+    // Flush pending microtasks BEFORE restoring globals, so the /user fetch
+    // this test's storage listener kicked off fully settles against the
+    // still-active mock rather than racing `vi.unstubAllGlobals()` below and
+    // falling through to the real fetch.
     await new Promise((r) => setTimeout(r, 50));
+    mod._resetAuthStorageListenerForTests();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -609,7 +602,7 @@ describe("cross-tab auth sync", () => {
     expect(mod.token()).toBe("ghs_replacement");
   });
 
-  it("Gap B: reloads the tab when the cross-tab token belongs to a DIFFERENT identity (not just a token rotation)", async () => {
+  it("reloads the tab when the cross-tab token belongs to a DIFFERENT identity (not just a token rotation)", async () => {
     const reloadSpy = vi.spyOn(mod.crossTabReload, "reloadForIdentitySwitch").mockImplementation(() => {});
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -636,7 +629,7 @@ describe("cross-tab auth sync", () => {
     expect(mod.token()).toBe("ghs_new_identity_token");
   });
 
-  it("Gap B: does NOT reload on a same-identity token rotation (case-insensitive login match) and leaves config/view untouched", async () => {
+  it("does NOT reload on a same-identity token rotation (case-insensitive login match) and leaves config/view untouched", async () => {
     const reloadSpy = vi.spyOn(mod.crossTabReload, "reloadForIdentitySwitch").mockImplementation(() => {});
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -664,7 +657,7 @@ describe("cross-tab auth sync", () => {
     expect(localStorageMock.getItem("github-tracker:view")).toBe('{"lastActiveTab":"actions"}');
   });
 
-  it("Gap B (bleed): reloads instead of adopting a DIFFERENT identity when this tab's user() is null after expireToken() (prior identity's config/view retained)", async () => {
+  it("reloads instead of adopting a DIFFERENT identity when this tab's user() is null after expireToken() (prior identity's config/view retained)", async () => {
     const reloadSpy = vi.spyOn(mod.crossTabReload, "reloadForIdentitySwitch").mockImplementation(() => {});
 
     // Authenticate as X and seed non-default config/view for that identity.
@@ -1194,6 +1187,10 @@ describe("cross-tab Jira auth sync", () => {
   });
 
   afterEach(() => {
+    // Detach this test's module-scope "storage" listener so re-imports don't
+    // accumulate listeners on the shared window (same reason as the GitHub
+    // cross-tab describe above).
+    mod._resetAuthStorageListenerForTests();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/tests/stores/auth.test.ts
+++ b/tests/stores/auth.test.ts
@@ -464,9 +464,33 @@ describe("cross-tab auth sync", () => {
     localStorageMock.clear();
     vi.resetModules();
     mod = await import("../../src/app/stores/auth");
+    // Safe default fetch stub for every test in this describe block. auth.ts
+    // registers its "storage" listener as a module-level side effect, and
+    // `vi.resetModules()` + re-import (every beforeEach, in EVERY describe in
+    // this file) creates a fresh module instance with its OWN closed-over
+    // token/user signals — but the underlying happy-dom `window` is shared for
+    // the whole test FILE, and nothing ever calls `removeEventListener`, so
+    // every one of those listeners stays attached for the rest of the file's
+    // run. A LATER test's `dispatchEvent(new StorageEvent(...))` therefore
+    // also re-fires every EARLIER test's now-stale listener whenever that
+    // stale listener's frozen `_token()` differs from the dispatched value —
+    // which is nearly always, since each stale instance is frozen at whatever
+    // token ITS OWN test last set. Without a fetch stub always active, one of
+    // those stale listeners can fall through to a REAL, un-awaited network
+    // call to api.github.com that's still in-flight when the file tears down,
+    // which happy-dom then aborts — throwing unhandled AbortError/
+    // ERR_INVALID_STATE errors that make the whole run flaky. Individual
+    // tests below override this with their own `vi.stubGlobal("fetch", ...)`
+    // when they care about the specific response.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401, json: () => Promise.resolve({}) }));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Flush pending microtasks BEFORE restoring globals, so every listener
+    // triggered by this test's dispatch (fresh AND stale — see beforeEach)
+    // fully settles against the still-active mock rather than racing
+    // `vi.unstubAllGlobals()` below and falling through to the real fetch.
+    await new Promise((r) => setTimeout(r, 50));
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/tests/stores/config.test.ts
+++ b/tests/stores/config.test.ts
@@ -3,6 +3,7 @@ import {
   ConfigSchema, TrackedUserSchema, loadConfig, config, updateConfig, resetConfig, setMonitoredRepo,
   addCustomTab, updateCustomTab, removeCustomTab, reorderCustomTab, getCustomTab, isBuiltinTab,
   CustomTabSchema, updateJiraCustomFields, updateJiraCustomScopes,
+  preParseConfigFixups, postParseConfigFixups,
 } from "../../src/app/stores/config";
 import type { CustomTab } from "../../src/app/stores/config";
 import { clearJiraAuth, clearJiraConfigFull } from "../../src/app/stores/auth";
@@ -312,6 +313,86 @@ describe("loadConfig", () => {
     );
     const cfg = loadConfig();
     expect(cfg.defaultTab).toBe("my-tab");
+  });
+});
+
+// ── Extracted config migration fixups (preParseConfigFixups / postParseConfigFixups) ──
+// These functions are the reusable migration logic shared by loadConfig() and
+// settings-transfer.ts's parseImportFile(). The pre-parse/post-parse split
+// relative to ConfigSchema.safeParse() is load-bearing (see their doc comments).
+describe("preParseConfigFixups", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("salvages an invalid theme in place while leaving valid fields untouched", () => {
+    const raw = preParseConfigFixups({ theme: "nope", refreshInterval: 120 }) as Record<string, unknown>;
+    expect(raw.theme).toBe("auto");
+    expect(raw.refreshInterval).toBe(120);
+  });
+
+  it("strips a doubled [bot] suffix from tracked user logins", () => {
+    const raw = preParseConfigFixups({
+      trackedUsers: [{ login: "renovate[bot][bot]" }],
+    }) as { trackedUsers: { login: string }[] };
+    expect(raw.trackedUsers[0].login).toBe("renovate[bot]");
+  });
+
+  it("via loadConfig(): an invalid theme is salvaged (not a total fallback), other fields survive", () => {
+    // "all other fields valid" — only theme is invalid. refreshInterval:120 (a
+    // non-default) surviving proves the salvage path, not a wholesale fallback to
+    // ConfigSchema defaults (which would yield refreshInterval:300).
+    localStorageMock.setItem(STORAGE_KEY, JSON.stringify({ theme: "invalid-value", refreshInterval: 120 }));
+    const cfg = loadConfig();
+    expect(cfg.theme).toBe("auto");
+    expect(cfg.refreshInterval).toBe(120);
+  });
+
+  it("via loadConfig(): a RAW doubled [bot][bot] login is stripped to a single [bot] and survives parse", () => {
+    // Constructed as RAW pre-parse input: a doubled suffix cannot pass safeParse
+    // on its own (VALID_TRACKED_LOGIN allows only ONE optional [bot]), so this
+    // record would be rejected entirely if the fixup were misplaced post-parse.
+    localStorageMock.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        trackedUsers: [
+          { login: "renovate[bot][bot]", avatarUrl: "https://avatars.githubusercontent.com/u/1", name: null },
+        ],
+      })
+    );
+    const cfg = loadConfig();
+    expect(cfg.trackedUsers).toHaveLength(1);
+    expect(cfg.trackedUsers[0].login).toBe("renovate[bot]");
+  });
+});
+
+describe("postParseConfigFixups", () => {
+  it("resets a defaultTab referencing a deleted custom tab to the schema default", () => {
+    // ConfigSchema itself does NOT reject a defaultTab that names a nonexistent
+    // tab (it's just a string), so this fixup must run post-parse.
+    const parsed = ConfigSchema.parse({
+      defaultTab: "deleted-tab-id",
+      customTabs: [
+        { id: "other-tab", name: "Other", baseType: "issues", orgScope: [], repoScope: [], filterPreset: {}, exclusive: false },
+      ],
+    });
+    expect(parsed.defaultTab).toBe("deleted-tab-id");
+    expect(postParseConfigFixups(parsed).defaultTab).toBe("issues");
+  });
+
+  it("preserves a defaultTab that references an existing custom tab", () => {
+    const parsed = ConfigSchema.parse({
+      defaultTab: "keep-tab",
+      customTabs: [
+        { id: "keep-tab", name: "Keep", baseType: "issues", orgScope: [], repoScope: [], filterPreset: {}, exclusive: false },
+      ],
+    });
+    expect(postParseConfigFixups(parsed).defaultTab).toBe("keep-tab");
+  });
+
+  it("preserves a built-in defaultTab", () => {
+    const parsed = ConfigSchema.parse({ defaultTab: "pullRequests" });
+    expect(postParseConfigFixups(parsed).defaultTab).toBe("pullRequests");
   });
 });
 

--- a/tests/stores/view.test.ts
+++ b/tests/stores/view.test.ts
@@ -1510,7 +1510,7 @@ describe("loadViewState — cap-guard integration", () => {
   });
 });
 
-// ── Task 3: import + apply curated view preferences ───────────────────────────
+// ── import + apply curated view preferences ───────────────────────────────────
 
 describe("applyImportedViewState", () => {
   beforeEach(() => {

--- a/tests/stores/view.test.ts
+++ b/tests/stores/view.test.ts
@@ -28,6 +28,8 @@ import {
   untrackJiraItem,
   moveJiraItem,
   setJiraCustomOrder,
+  applyImportedViewState,
+  EXPORTED_VIEW_PREF_KEYS,
 } from "../../src/app/stores/view";
 import type { IgnoredItem, TrackedItem, ViewState } from "../../src/app/stores/view";
 import { getNotifications, clearNotifications } from "../../src/app/lib/errors";
@@ -1505,5 +1507,102 @@ describe("loadViewState — cap-guard integration", () => {
 
     expect(mod.viewState.jiraCustomOrder).toEqual([]);
     expect(mod.viewState.lastActiveTab).toBe("jiraAssigned");
+  });
+});
+
+// ── Task 3: import + apply curated view preferences ───────────────────────────
+
+describe("applyImportedViewState", () => {
+  beforeEach(() => {
+    clearNotifications();
+  });
+
+  it("overlays curated keys present in the input", () => {
+    applyImportedViewState({ jiraCustomOrder: ["PROJ-1", "PROJ-2"], showPrRuns: true });
+    expect(viewState.jiraCustomOrder).toEqual(["PROJ-1", "PROJ-2"]);
+    expect(viewState.showPrRuns).toBe(true);
+  });
+
+  it("never touches lastActiveTab, globalSort, or globalFilter, even when present in the input", () => {
+    applyImportedViewState({
+      lastActiveTab: "actions",
+      globalSort: { field: "title", direction: "asc" },
+      globalFilter: { org: "evil-org", repo: "evil-repo" },
+      showPrRuns: true,
+    });
+    // The excluded keys stay at their pre-call (default) values...
+    expect(viewState.lastActiveTab).toBe("issues");
+    expect(viewState.globalSort).toEqual({ field: "updatedAt", direction: "desc" });
+    expect(viewState.globalFilter).toEqual({ org: null, repo: null });
+    // ...while a curated key in the SAME call still applies.
+    expect(viewState.showPrRuns).toBe(true);
+  });
+
+  it("defaults a stripped (missing) ignoredItems title to ''", () => {
+    applyImportedViewState({
+      ignoredItems: [{ id: 1, type: "issue", repo: "org/repo", ignoredAt: 1000 }],
+    });
+    expect(viewState.ignoredItems).toEqual([
+      { id: 1, type: "issue", repo: "org/repo", ignoredAt: 1000, title: "" },
+    ]);
+  });
+
+  it("defaults a stripped (missing) trackedItems title to '', leaving htmlUrl/jiraStatus absent", () => {
+    applyImportedViewState({
+      trackedItems: [
+        { id: 2, number: 42, type: "issue", source: "github", repoFullName: "org/repo", addedAt: 2000 },
+      ],
+    });
+    expect(viewState.trackedItems).toHaveLength(1);
+    expect(viewState.trackedItems[0]).toMatchObject({
+      id: 2,
+      number: 42,
+      type: "issue",
+      source: "github",
+      repoFullName: "org/repo",
+      addedAt: 2000,
+      title: "",
+    });
+    expect("htmlUrl" in viewState.trackedItems[0]).toBe(false);
+    expect("jiraStatus" in viewState.trackedItems[0]).toBe(false);
+  });
+
+  it.each([null, undefined, "a string", 42, [], ["also", "an", "array"]])(
+    "is a total silent no-op for wholly-malformed input: %p",
+    (malformed) => {
+      const before = JSON.parse(JSON.stringify(viewState));
+      expect(() => applyImportedViewState(malformed)).not.toThrow();
+      expect(JSON.parse(JSON.stringify(viewState))).toEqual(before);
+      expect(getNotifications()).toHaveLength(0);
+    }
+  );
+
+  it("skips an individually-invalid key without dropping other valid keys in the same call", () => {
+    applyImportedViewState({
+      showPrRuns: true,
+      // tabFilters must be an object; a string fails ViewStateSchema validation
+      // for this key and must be skipped, not thrown or allowed to corrupt state.
+      tabFilters: "not-an-object",
+    });
+    expect(viewState.showPrRuns).toBe(true);
+    // Untouched — still the schema default, not corrupted by the invalid input.
+    expect(viewState.tabFilters.issues.scope).toBe("involves_me");
+  });
+
+  it("never pushes a notification, unlike updateViewState's warn-on-reject behavior", () => {
+    applyImportedViewState({ tabFilters: "not-an-object", showPrRuns: "not-a-boolean" });
+    expect(getNotifications()).toHaveLength(0);
+  });
+
+  it("leaves an absent curated key untouched rather than resetting it to schema defaults", () => {
+    setJiraCustomOrder(["PRE-EXISTING"]);
+    applyImportedViewState({ showPrRuns: true }); // jiraCustomOrder absent from input
+    expect(viewState.jiraCustomOrder).toEqual(["PRE-EXISTING"]);
+  });
+
+  it("EXPORTED_VIEW_PREF_KEYS excludes lastActiveTab, globalSort, and globalFilter", () => {
+    expect(EXPORTED_VIEW_PREF_KEYS).not.toContain("lastActiveTab");
+    expect(EXPORTED_VIEW_PREF_KEYS).not.toContain("globalSort");
+    expect(EXPORTED_VIEW_PREF_KEYS).not.toContain("globalFilter");
   });
 });

--- a/tests/worker/crypto.test.ts
+++ b/tests/worker/crypto.test.ts
@@ -289,6 +289,40 @@ describe("sealWithExpiry / unsealWithExpiry", () => {
     if (!result.ok) expect(result.reason).toBe("expired");
   });
 
+  it("accepts a bundle exactly at the maxAgeMs boundary (strict '>' comparison is inclusive of the exact instant)", async () => {
+    // Freeze the clock so createdAt and the internal Date.now() check inside
+    // unsealWithExpiry read the identical instant — otherwise real time elapsed
+    // during the crypto operations below would push the age past maxAgeMs and
+    // make this boundary test flaky.
+    const key = await deriveKey(KEY_A, SEAL_SALT, BUNDLE_INFO, "encrypt");
+    const payload = "boundary-inner";
+    const nonce = toBase64Url(
+      new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(payload)))
+    );
+    const now = Date.now();
+    const createdAt = now - CREDENTIAL_BUNDLE_EXPIRY_MS; // Date.now() - createdAt === maxAgeMs exactly
+    const sealed = await sealToken(JSON.stringify({ createdAt, nonce, payload }), key);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      const result = await unsealWithExpiry(
+        sealed,
+        KEY_A,
+        undefined,
+        SEAL_SALT,
+        BUNDLE_INFO,
+        CREDENTIAL_BUNDLE_EXPIRY_MS
+      );
+      // age === maxAgeMs exactly; the strict `>` check does not reject this —
+      // only strictly-greater ages expire.
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.payload).toBe(payload);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("returns reason 'invalid' for a bit-flipped ciphertext", async () => {
     const key = await deriveKey(KEY_A, SEAL_SALT, BUNDLE_INFO, "encrypt");
     const sealed = await sealWithExpiry("inner", key);

--- a/tests/worker/crypto.test.ts
+++ b/tests/worker/crypto.test.ts
@@ -7,6 +7,10 @@ import {
   sealToken,
   unsealToken,
   unsealTokenWithRotation,
+  sealWithExpiry,
+  unsealWithExpiry,
+  CREDENTIAL_BUNDLE_EXPIRY_MS,
+  SEAL_SALT,
   signSession,
   verifySession,
 } from "../../src/worker/crypto";
@@ -218,6 +222,120 @@ describe("unsealTokenWithRotation", () => {
       "aes-gcm-key"
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("sealWithExpiry / unsealWithExpiry", () => {
+  const BUNDLE_INFO = "aes-gcm-key:credential-export-bundle";
+
+  it("round-trips payload, and surfaces a stable nonce + the seal createdAt", async () => {
+    const key = await deriveKey(KEY_A, SEAL_SALT, BUNDLE_INFO, "encrypt");
+    const before = Date.now();
+    const sealed = await sealWithExpiry("inner-ciphertext", key);
+    const after = Date.now();
+    const result = await unsealWithExpiry(
+      sealed,
+      KEY_A,
+      undefined,
+      SEAL_SALT,
+      BUNDLE_INFO,
+      CREDENTIAL_BUNDLE_EXPIRY_MS
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload).toBe("inner-ciphertext");
+      expect(typeof result.nonce).toBe("string");
+      expect(result.nonce.length).toBeGreaterThan(0);
+      // createdAt is surfaced so the caller can derive a KV TTL from it.
+      expect(result.createdAt).toBeGreaterThanOrEqual(before);
+      expect(result.createdAt).toBeLessThanOrEqual(after);
+    }
+  });
+
+  it("produces a DETERMINISTIC nonce for identical plaintext across independent seals", async () => {
+    // This is the property the reseal-detection in the unseal endpoint depends on:
+    // resealing the same plaintext must reproduce the same content fingerprint.
+    const key = await deriveKey(KEY_A, SEAL_SALT, BUNDLE_INFO, "encrypt");
+    const s1 = await sealWithExpiry("same-inner-payload", key);
+    const s2 = await sealWithExpiry("same-inner-payload", key);
+    // Outer blobs differ (fresh IV + createdAt), but the inner nonce is stable.
+    expect(s1).not.toBe(s2);
+    const r1 = await unsealWithExpiry(s1, KEY_A, undefined, SEAL_SALT, BUNDLE_INFO, CREDENTIAL_BUNDLE_EXPIRY_MS);
+    const r2 = await unsealWithExpiry(s2, KEY_A, undefined, SEAL_SALT, BUNDLE_INFO, CREDENTIAL_BUNDLE_EXPIRY_MS);
+    expect(r1.ok && r2.ok).toBe(true);
+    if (r1.ok && r2.ok) {
+      expect(r1.nonce).toBe(r2.nonce);
+    }
+  });
+
+  it("returns reason 'expired' when createdAt is older than maxAgeMs", async () => {
+    // Hand-craft a wrapper with an old createdAt (sealWithExpiry always uses now()).
+    const key = await deriveKey(KEY_A, SEAL_SALT, BUNDLE_INFO, "encrypt");
+    const payload = "inner";
+    const nonce = toBase64Url(
+      new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(payload)))
+    );
+    const oldCreatedAt = Date.now() - CREDENTIAL_BUNDLE_EXPIRY_MS - 1000;
+    const sealed = await sealToken(JSON.stringify({ createdAt: oldCreatedAt, nonce, payload }), key);
+    const result = await unsealWithExpiry(
+      sealed,
+      KEY_A,
+      undefined,
+      SEAL_SALT,
+      BUNDLE_INFO,
+      CREDENTIAL_BUNDLE_EXPIRY_MS
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("expired");
+  });
+
+  it("returns reason 'invalid' for a bit-flipped ciphertext", async () => {
+    const key = await deriveKey(KEY_A, SEAL_SALT, BUNDLE_INFO, "encrypt");
+    const sealed = await sealWithExpiry("inner", key);
+    const bytes = fromBase64Url(sealed);
+    bytes[14] ^= 0xff; // corrupt the ciphertext portion → GCM auth tag fails
+    const result = await unsealWithExpiry(
+      toBase64Url(bytes),
+      KEY_A,
+      undefined,
+      SEAL_SALT,
+      BUNDLE_INFO,
+      CREDENTIAL_BUNDLE_EXPIRY_MS
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid");
+  });
+
+  it("returns reason 'invalid' for a blob sealed under a different purpose's key", async () => {
+    const sealKey = await deriveKey(KEY_A, SEAL_SALT, "aes-gcm-key:jira-api-token", "encrypt");
+    const sealed = await sealWithExpiry("inner", sealKey);
+    const result = await unsealWithExpiry(
+      sealed,
+      KEY_A,
+      undefined,
+      SEAL_SALT,
+      BUNDLE_INFO,
+      CREDENTIAL_BUNDLE_EXPIRY_MS
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid");
+  });
+
+  it("returns reason 'invalid' for a plain sealToken blob (no wrapper JSON)", async () => {
+    // A blob sealed by the plain sealToken path (correct key) decrypts to a
+    // non-JSON string, which must fail the wrapper parse as a generic invalid.
+    const key = await deriveKey(KEY_A, SEAL_SALT, BUNDLE_INFO, "encrypt");
+    const sealed = await sealToken("not-a-json-wrapper", key);
+    const result = await unsealWithExpiry(
+      sealed,
+      KEY_A,
+      undefined,
+      SEAL_SALT,
+      BUNDLE_INFO,
+      CREDENTIAL_BUNDLE_EXPIRY_MS
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid");
   });
 });
 

--- a/tests/worker/jira-oauth.test.ts
+++ b/tests/worker/jira-oauth.test.ts
@@ -527,9 +527,12 @@ describe("POST /api/jira/proxy — Jira API proxy", () => {
     vi.restoreAllMocks();
   });
 
-  // ── 404 when unconfigured ─────────────────────────────────────────────────
+  // ── API-token proxy does not require JIRA_CLIENT_ID ───────────────────────
 
-  it("returns 503 when JIRA_CLIENT_ID is not configured", async () => {
+  it("works without JIRA_CLIENT_ID — API-token proxying uses basic auth, not the OAuth client id", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ issues: [], total: 0, maxResults: 10, startAt: 0 }), { status: 200 })
+    );
     const req = makeJiraProxyRequest({
       endpoint: "search",
       cloudId: VALID_CLOUD_ID,
@@ -538,9 +541,7 @@ describe("POST /api/jira/proxy — Jira API proxy", () => {
       params: { jql: "assignee = currentUser()", maxResults: 10 },
     });
     const res = await worker.fetch(req, makeEnv({ JIRA_CLIENT_ID: undefined }));
-    expect(res.status).toBe(503);
-    const json = await res.json() as Record<string, unknown>;
-    expect(json["error"]).toBe("jira_not_configured");
+    expect(res.status).toBe(200);
   });
 
   // ── Endpoint allowlist ────────────────────────────────────────────────────

--- a/tests/worker/seal.test.ts
+++ b/tests/worker/seal.test.ts
@@ -20,6 +20,8 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     SEAL_KEY: TEST_SEAL_KEY,
     TURNSTILE_SECRET_KEY: "test-turnstile-secret",
     PROXY_RATE_LIMITER: { limit: vi.fn().mockResolvedValue({ success: true }) },
+    // Seal endpoint never touches KV; a stub satisfies the Env type shape.
+    CREDENTIAL_NONCE_KV: { get: vi.fn(), put: vi.fn() },
     ...overrides,
   };
 }
@@ -516,6 +518,65 @@ describe("Worker /api/proxy/seal endpoint", () => {
     const json = await res.json() as Record<string, unknown>;
     expect(typeof json["sealed"]).toBe("string");
     expect((json["sealed"] as string).length).toBeGreaterThan(0);
+  });
+
+  // ── credential-export-bundle purpose + purpose-keyed size cap ──────────────
+
+  it("valid request with purpose 'credential-export-bundle' (realistic size) returns 200 with sealed token", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, action: "seal" }), { status: 200 })
+    );
+
+    // ~900 chars — a realistic envelope-encrypted bundle ciphertext.
+    const req = makeSealRequest({ body: { token: "c".repeat(900), purpose: "credential-export-bundle" } });
+    const res = await worker.fetch(req, makeEnv());
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as Record<string, unknown>;
+    expect(typeof json["sealed"]).toBe("string");
+    expect((json["sealed"] as string).length).toBeGreaterThan(0);
+    expect(json["sealed"]).not.toMatch(/[+/=]/);
+  });
+
+  it("credential-export-bundle accepts a payload between 2048 and 4096 chars (purpose-specific raise)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, action: "seal" }), { status: 200 })
+    );
+
+    // 3000 chars — over the 2048 global cap, under the 4096 purpose-specific cap.
+    const req = makeSealRequest({ body: { token: "c".repeat(3000), purpose: "credential-export-bundle" } });
+    const res = await worker.fetch(req, makeEnv());
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as Record<string, unknown>;
+    expect(typeof json["sealed"]).toBe("string");
+  });
+
+  it("credential-export-bundle rejects a payload over 4096 chars with invalid_request", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, action: "seal" }), { status: 200 })
+    );
+
+    const req = makeSealRequest({ body: { token: "c".repeat(4097), purpose: "credential-export-bundle" } });
+    const res = await worker.fetch(req, makeEnv());
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as Record<string, unknown>;
+    expect(json["error"]).toBe("invalid_request");
+  });
+
+  it("jira-api-token payload between 2049 and 4096 chars is STILL rejected (raise is purpose-keyed)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, action: "seal" }), { status: 200 })
+    );
+
+    // 3000 chars — allowed for credential-export-bundle, but NOT for jira purposes.
+    const req = makeSealRequest({ body: { token: "a".repeat(3000), purpose: "jira-api-token" } });
+    const res = await worker.fetch(req, makeEnv());
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as Record<string, unknown>;
+    expect(json["error"]).toBe("invalid_request");
   });
 
   // ── SEAL_KEY rotation / cache invalidation ────────────────────────────────

--- a/tests/worker/unseal.test.ts
+++ b/tests/worker/unseal.test.ts
@@ -398,6 +398,53 @@ describe("Worker /api/proxy/unseal endpoint", () => {
     expect(json["payload"]).toBeUndefined();
   });
 
+  // (14) Concurrent unseal race — documents the TOCTOU availability-only guarantee ──
+  it("allows both requests of a forced-race concurrent unseal to succeed (single-use is best-effort, not atomic)", async () => {
+    // Forces the actual TOCTOU window in handleProxyUnseal: get-then-put is not
+    // atomic (Cloudflare KV has no compare-and-set). This gate makes the race
+    // deterministic instead of relying on incidental Promise.all interleaving —
+    // whichever request's get() call arrives first is held open until the SECOND
+    // request's get() call has also run, so both observe "not yet consumed"
+    // before either puts. Per the code comment above nonceKv.get/put in index.ts,
+    // this is accepted: a race only ever yields the same still-code-encrypted
+    // (inert) ciphertext, so single-use here is an availability guarantee, not a
+    // confidentiality one.
+    const store = new Map<string, string>();
+    let getCalls = 0;
+    let releaseFirstGet!: () => void;
+    const secondGetArrived = new Promise<void>((resolve) => {
+      releaseFirstGet = resolve;
+    });
+    const kv = {
+      get: vi.fn(async (key: string): Promise<string | null> => {
+        getCalls++;
+        if (getCalls === 1) {
+          await secondGetArrived;
+        } else if (getCalls === 2) {
+          releaseFirstGet();
+        }
+        return store.has(key) ? (store.get(key) as string) : null;
+      }),
+      put: vi.fn(async (key: string, value: string): Promise<void> => {
+        store.set(key, value);
+      }),
+    };
+    const env = makeEnv({ CREDENTIAL_NONCE_KV: kv });
+    const sealed = await sealViaEndpoint(env, "racing-payload");
+
+    const [first, second] = await Promise.all([
+      worker.fetch(makeUnsealRequest({ sealed }), env),
+      worker.fetch(makeUnsealRequest({ sealed }), env),
+    ]);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    const firstJson = (await first.json()) as Record<string, unknown>;
+    const secondJson = (await second.json()) as Record<string, unknown>;
+    expect(firstJson["payload"]).toBe("racing-payload");
+    expect(secondJson["payload"]).toBe("racing-payload");
+  });
+
   // ── Bonus: missing binding surfaces as a deploy error, not a silent import fail ──
   it("returns 503 internal_error when the CREDENTIAL_NONCE_KV binding is missing", async () => {
     const env = makeEnv({ CREDENTIAL_NONCE_KV: undefined as unknown as Env["CREDENTIAL_NONCE_KV"] });

--- a/tests/worker/unseal.test.ts
+++ b/tests/worker/unseal.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker, { type Env } from "../../src/worker/index";
+import {
+  deriveKey,
+  sealToken,
+  toBase64Url,
+  fromBase64Url,
+  SEAL_SALT,
+  CREDENTIAL_BUNDLE_EXPIRY_MS,
+} from "../../src/worker/crypto";
+import { ALLOWED_ORIGIN } from "./helpers";
+
+// "test-seal-key" base64-encoded — same value makeEnv wires into SEAL_KEY, so
+// hand-crafted blobs (expired / near-expiry fixtures) match the endpoint's key.
+const TEST_SEAL_KEY = "dGVzdC1zZWFsLWtleQ==";
+const TEST_SESSION_KEY = "dGVzdC1zZXNzaW9uLWtleQ==";
+const BUNDLE_INFO = "aes-gcm-key:credential-export-bundle";
+
+let _ipCounter = 0;
+// Unique IP per request avoids the module-level in-memory rate limiters
+// (unsealRateLimiter 5/min, proxyPreGateLimiter 60/min) leaking across requests.
+// Distinct 10.6.x range from seal.test.ts's 10.4.x to avoid cross-file collision.
+function nextIp(): string {
+  return `10.6.0.${++_ipCounter}`;
+}
+
+// ── Map-backed in-memory KV fake ────────────────────────────────────────────
+// Persists a put so a later get in the SAME test observes it (a plain vi.fn()
+// would not persist and would silently pass-but-not-test the single-use and
+// reseal-renewal scenarios). Mirrors Cloudflare KV's rejection of sub-60s TTLs
+// so the Math.max(60, …) floor is genuinely exercised. Optionally throws to
+// exercise the fail-closed path.
+function makeNonceKv(opts: { throwOnGet?: boolean; throwOnPut?: boolean } = {}) {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: vi.fn(async (key: string): Promise<string | null> => {
+      if (opts.throwOnGet) throw new Error("kv get failed");
+      return store.has(key) ? (store.get(key) as string) : null;
+    }),
+    put: vi.fn(async (key: string, value: string, options?: { expirationTtl?: number }): Promise<void> => {
+      if (opts.throwOnPut) throw new Error("kv put failed");
+      if (options?.expirationTtl !== undefined && options.expirationTtl < 60) {
+        throw new Error(`Invalid expiration_ttl of ${options.expirationTtl}. Expiration TTL must be at least 60.`);
+      }
+      store.set(key, value);
+    }),
+  };
+}
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ASSETS: { fetch: async () => new Response("asset") },
+    GITHUB_CLIENT_ID: "test_client_id",
+    GITHUB_CLIENT_SECRET: "test_client_secret",
+    ALLOWED_ORIGIN,
+    SESSION_KEY: TEST_SESSION_KEY,
+    SEAL_KEY: TEST_SEAL_KEY,
+    TURNSTILE_SECRET_KEY: "test-turnstile-secret",
+    PROXY_RATE_LIMITER: { limit: vi.fn().mockResolvedValue({ success: true }) },
+    CREDENTIAL_NONCE_KV: makeNonceKv(),
+    ...overrides,
+  };
+}
+
+function makeUnsealRequest(options: {
+  sealed?: unknown;
+  purpose?: unknown;
+  origin?: string;
+  ip?: string;
+  addXRequestedWith?: boolean;
+  addContentType?: boolean;
+  turnstileToken?: string;
+  method?: string;
+  rawBody?: string;
+} = {}): Request {
+  const {
+    origin = ALLOWED_ORIGIN,
+    ip = nextIp(),
+    addXRequestedWith = true,
+    addContentType = true,
+    turnstileToken = "valid-turnstile-token",
+    method = "POST",
+  } = options;
+
+  const headers: Record<string, string> = { "CF-Connecting-IP": ip };
+  if (origin) headers["Origin"] = origin;
+  if (addXRequestedWith) headers["X-Requested-With"] = "fetch";
+  if (addContentType) headers["Content-Type"] = "application/json";
+  if (turnstileToken) headers["cf-turnstile-response"] = turnstileToken;
+
+  let body: string | undefined;
+  if (options.rawBody !== undefined) {
+    body = options.rawBody;
+  } else if (method !== "GET") {
+    const b: Record<string, unknown> = {
+      sealed: "sealed" in options ? options.sealed : "placeholder-sealed-blob",
+      purpose: "purpose" in options ? options.purpose : "credential-export-bundle",
+    };
+    body = JSON.stringify(b);
+  }
+
+  return new Request("https://gh.gordoncode.dev/api/proxy/unseal", { method, headers, body });
+}
+
+/** Seal a payload through the real /api/proxy/seal endpoint and return the sealed blob. */
+async function sealViaEndpoint(env: Env, token: string, purpose = "credential-export-bundle"): Promise<string> {
+  const req = new Request("https://gh.gordoncode.dev/api/proxy/seal", {
+    method: "POST",
+    headers: {
+      "CF-Connecting-IP": nextIp(),
+      "Origin": ALLOWED_ORIGIN,
+      "X-Requested-With": "fetch",
+      "Content-Type": "application/json",
+      "cf-turnstile-response": "valid-turnstile-token",
+    },
+    body: JSON.stringify({ token, purpose }),
+  });
+  const res = await worker.fetch(req, env);
+  const json = (await res.json()) as Record<string, unknown>;
+  if (typeof json["sealed"] !== "string") {
+    throw new Error(`seal failed (status ${res.status}): ${JSON.stringify(json)}`);
+  }
+  return json["sealed"] as string;
+}
+
+/** Hand-craft a credential-export-bundle blob with an arbitrary createdAt (for expiry fixtures). */
+async function craftBundle(payload: string, createdAt: number): Promise<string> {
+  const key = await deriveKey(TEST_SEAL_KEY, SEAL_SALT, BUNDLE_INFO, "encrypt");
+  const nonce = toBase64Url(
+    new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(payload)))
+  );
+  return sealToken(JSON.stringify({ createdAt, nonce, payload }), key);
+}
+
+describe("Worker /api/proxy/unseal endpoint", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    // Default Turnstile mock: success WITHOUT an action field, so it passes both
+    // the seal endpoint's "seal" check and the unseal endpoint's "unseal" check.
+    // Use mockImplementation (fresh Response per call) — a Response body can only
+    // be read once, so a shared mockResolvedValue instance would fail the SECOND
+    // Turnstile verify (e.g. seal-then-unseal) with a consumed-body read error.
+    globalThis.fetch = vi.fn().mockImplementation(
+      async () => new Response(JSON.stringify({ success: true }), { status: 200 })
+    );
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // (1) Full round-trip ───────────────────────────────────────────────────────
+  it("round-trips a credential-export-bundle: seal then unseal returns the original payload", async () => {
+    const env = makeEnv();
+    const payload = "inner-envelope-ciphertext-abc123";
+    const sealed = await sealViaEndpoint(env, payload);
+
+    const res = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["payload"]).toBe(payload);
+  });
+
+  // (2) Jira blob gains no plaintext-extraction path ────────────────────────────
+  it("rejects a sealed Jira blob submitted to unseal with generic invalid (no new extraction path)", async () => {
+    const env = makeEnv();
+    // Seal as jira-api-token (plain sealToken, different HKDF purpose key).
+    const jiraSealed = await sealViaEndpoint(env, "jira-secret-token", "jira-api-token");
+
+    // Even claiming the allowlisted purpose, the wrong key + missing wrapper reject it.
+    const res = await worker.fetch(
+      makeUnsealRequest({ sealed: jiraSealed, purpose: "credential-export-bundle" }),
+      env
+    );
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json).toEqual({ error: "invalid" });
+    expect(json["payload"]).toBeUndefined();
+  });
+
+  it("rejects a Jira purpose value at the single-value allowlist with generic invalid", async () => {
+    const env = makeEnv();
+    const jiraSealed = await sealViaEndpoint(env, "jira-secret-token", "jira-api-token");
+    const res = await worker.fetch(
+      makeUnsealRequest({ sealed: jiraSealed, purpose: "jira-api-token" }),
+      env
+    );
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json).toEqual({ error: "invalid" });
+  });
+
+  // (3) Turnstile ───────────────────────────────────────────────────────────────
+  it("rejects a missing Turnstile token with 403 turnstile_failed", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(makeUnsealRequest({ turnstileToken: "" }), env);
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["error"]).toBe("turnstile_failed");
+  });
+
+  it("rejects a failed Turnstile verification with 403 turnstile_failed", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      async () => new Response(JSON.stringify({ success: false, "error-codes": ["invalid-input-response"] }), { status: 200 })
+    );
+    const env = makeEnv();
+    const res = await worker.fetch(makeUnsealRequest(), env);
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["error"]).toBe("turnstile_failed");
+  });
+
+  // (4) Rate limit BEFORE Turnstile ─────────────────────────────────────────────
+  it("rate-limits the 6th request from an IP within 60s BEFORE Turnstile is invoked", async () => {
+    const env = makeEnv();
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const fixedIp = "10.6.99.4"; // dedicated IP, used nowhere else
+
+    // Requests 1-5 pass the rate limit and reach Turnstile (each calls fetch once).
+    for (let i = 0; i < 5; i++) {
+      const res = await worker.fetch(makeUnsealRequest({ ip: fixedIp, sealed: "garbage-but-legal-length" }), env);
+      expect(res.status).not.toBe(429);
+    }
+    const callsBefore = fetchMock.mock.calls.length;
+    expect(callsBefore).toBe(5); // exactly one Turnstile verify per allowed request
+
+    // 6th request: rejected by the rate limiter before any Turnstile round-trip.
+    const res = await worker.fetch(makeUnsealRequest({ ip: fixedIp, sealed: "garbage-but-legal-length" }), env);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["error"]).toBe("rate_limited");
+    // Turnstile (fetch) was NOT invoked on the rate-limited request.
+    expect(fetchMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  // (5) Expired bundle ──────────────────────────────────────────────────────────
+  it("rejects an expired bundle with distinct expired, and never consumes the nonce", async () => {
+    const kv = makeNonceKv();
+    const env = makeEnv({ CREDENTIAL_NONCE_KV: kv });
+    const sealed = await craftBundle("inner", Date.now() - CREDENTIAL_BUNDLE_EXPIRY_MS - 10_000);
+
+    const res = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["error"]).toBe("expired");
+    // Expiry is checked before nonce consumption.
+    expect(kv.get).not.toHaveBeenCalled();
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  // (6) Tampered ciphertext ─────────────────────────────────────────────────────
+  it("rejects a tampered ciphertext with generic invalid, indistinguishable from the Jira-rejection case", async () => {
+    const env = makeEnv();
+    const sealed = await sealViaEndpoint(env, "inner-payload-xyz");
+    const bytes = fromBase64Url(sealed);
+    bytes[14] ^= 0xff; // corrupt the outer ciphertext → GCM auth tag fails
+    const tampered = toBase64Url(bytes);
+
+    const res = await worker.fetch(makeUnsealRequest({ sealed: tampered }), env);
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json).toEqual({ error: "invalid" });
+  });
+
+  // (7) Malformed body ──────────────────────────────────────────────────────────
+  it("rejects a body missing 'sealed' with 400 invalid_request (no crash)", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(
+      makeUnsealRequest({ rawBody: JSON.stringify({ purpose: "credential-export-bundle" }) }),
+      env
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["error"]).toBe("invalid_request");
+  });
+
+  it("rejects a non-string 'purpose' with generic 401 invalid (no crash)", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(
+      makeUnsealRequest({ rawBody: JSON.stringify({ sealed: "some-blob", purpose: 42 }) }),
+      env
+    );
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json).toEqual({ error: "invalid" });
+  });
+
+  // (8) Single-use enforcement ──────────────────────────────────────────────────
+  it("rejects a second unseal of the SAME blob as generic invalid (single-use nonce)", async () => {
+    const env = makeEnv();
+    const sealed = await sealViaEndpoint(env, "single-use-payload");
+
+    const first = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(first.status).toBe(200);
+    expect(((await first.json()) as Record<string, unknown>)["payload"]).toBe("single-use-payload");
+
+    const second = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(second.status).toBe(401);
+    expect(await second.json()).toEqual({ error: "invalid" });
+  });
+
+  // (9) Reseal-renewal regression (the vulnerability this nonce closes) ──────────
+  it("rejects a RESEALED copy of an already-unsealed payload despite its fresh createdAt", async () => {
+    const env = makeEnv();
+    const payload = "reseal-renewal-payload";
+
+    const blobA = await sealViaEndpoint(env, payload);
+    const unsealA = await worker.fetch(makeUnsealRequest({ sealed: blobA }), env);
+    expect(unsealA.status).toBe(200);
+    expect(((await unsealA.json()) as Record<string, unknown>)["payload"]).toBe(payload);
+
+    // Reseal the exact same payload → new outer blob, fresh createdAt, SAME nonce.
+    const blobB = await sealViaEndpoint(env, payload);
+    expect(blobB).not.toBe(blobA);
+
+    const unsealB = await worker.fetch(makeUnsealRequest({ sealed: blobB }), env);
+    expect(unsealB.status).toBe(401);
+    expect(await unsealB.json()).toEqual({ error: "invalid" });
+  });
+
+  // (10) Outer length guard fires BEFORE crypto ─────────────────────────────────
+  it("rejects a 'sealed' longer than 6144 chars with 400 invalid_request before any crypto", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(makeUnsealRequest({ sealed: "x".repeat(6145) }), env);
+    // 400 invalid_request comes ONLY from the pre-crypto length guard; the crypto
+    // path can yield only 401 invalid/expired or 200 — so this status proves the
+    // guard rejected before unsealWithExpiry ran.
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["error"]).toBe("invalid_request");
+    // The KV nonce store was never touched.
+    expect((env.CREDENTIAL_NONCE_KV as ReturnType<typeof makeNonceKv>).get).not.toHaveBeenCalled();
+  });
+
+  // (11) Max-size round-trip (caps are correctly sized relative to each other) ───
+  it("round-trips a maximum-size (~4096) inner ciphertext through both caps", async () => {
+    const env = makeEnv();
+    const payload = "c".repeat(4096); // Step 2's inner cap
+    const sealed = await sealViaEndpoint(env, payload);
+
+    // Outer blob exceeds the 4096 inner cap but fits within the 6144 unseal guard.
+    expect(sealed.length).toBeGreaterThan(4096);
+    expect(sealed.length).toBeLessThanOrEqual(6144);
+
+    const res = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["payload"]).toBe(payload);
+  });
+
+  // (12) Near-expiry bundle: the Math.max(60, …) TTL floor holds ─────────────────
+  it("unseals a near-expiry bundle and puts the nonce with a floored (>=60s) TTL", async () => {
+    const kv = makeNonceKv();
+    const env = makeEnv({ CREDENTIAL_NONCE_KV: kv });
+    // ~30s before the expiry cutoff → raw remaining TTL ≈ 30s, below KV's 60s floor.
+    const sealed = await craftBundle("near-expiry-inner", Date.now() - CREDENTIAL_BUNDLE_EXPIRY_MS + 30_000);
+
+    const res = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["payload"]).toBe("near-expiry-inner");
+
+    // put must have been called with a TTL floored to at least 60 (a raw sub-60
+    // TTL would have thrown in the fake, mirroring real Cloudflare KV).
+    expect(kv.put).toHaveBeenCalledTimes(1);
+    const ttl = kv.put.mock.calls[0][2]?.expirationTtl;
+    expect(ttl).toBeGreaterThanOrEqual(60);
+  });
+
+  // (13) Fail-closed on KV error ────────────────────────────────────────────────
+  it("fails closed (generic invalid, no payload) when the KV get throws", async () => {
+    const env = makeEnv({ CREDENTIAL_NONCE_KV: makeNonceKv({ throwOnGet: true }) });
+    const sealed = await sealViaEndpoint(env, "kv-get-throws-payload");
+
+    const res = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json).toEqual({ error: "invalid" });
+    expect(json["payload"]).toBeUndefined();
+  });
+
+  it("fails closed (generic invalid, no payload) when the KV put throws", async () => {
+    const env = makeEnv({ CREDENTIAL_NONCE_KV: makeNonceKv({ throwOnPut: true }) });
+    const sealed = await sealViaEndpoint(env, "kv-put-throws-payload");
+
+    const res = await worker.fetch(makeUnsealRequest({ sealed }), env);
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json).toEqual({ error: "invalid" });
+    expect(json["payload"]).toBeUndefined();
+  });
+
+  // ── Bonus: missing binding surfaces as a deploy error, not a silent import fail ──
+  it("returns 503 internal_error when the CREDENTIAL_NONCE_KV binding is missing", async () => {
+    const env = makeEnv({ CREDENTIAL_NONCE_KV: undefined as unknown as Env["CREDENTIAL_NONCE_KV"] });
+    const res = await worker.fetch(makeUnsealRequest({ sealed: "anything" }), env);
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json["error"]).toBe("internal_error");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,6 +32,14 @@ namespace_id = "1001"
 limit = 10
 period = 10
 
+# Single-use nonce store for /api/proxy/unseal — blocks unseal-then-reseal expiry
+# renewal of a credential-export bundle. Holds only opaque nonce values (never
+# plaintext, ciphertext, or tokens), TTL bounded by the bundle's own expiry window.
+[[kv_namespaces]]
+binding = "CREDENTIAL_NONCE_KV"
+id = "6eb3cac2fc7b416f870e7c28f39aa63f"
+preview_id = "783627e2f20d48e8b9853bc2d2368f6a"
+
 [observability]
 enabled = true
 head_sampling_rate = 1


### PR DESCRIPTION
## Summary
- Adds an "Import settings" counterpart to Export on both the Settings page and (pre-authentication) the Login page, replacing config wholesale via schema validation, with a schema-driven export payload guarded by a drift test.
- Adds an opt-in encrypted-credentials bundle (GitHub + Jira) using client-side one-time-code envelope encryption then a Worker seal (encrypt-then-seal), a new pre-auth `/api/proxy/unseal` endpoint with Turnstile + tightened rate limiting + a single-use KV nonce, and a 30-day expiry.
- Requires a new `CREDENTIAL_NONCE_KV` Worker binding (provisioning documented in DEPLOY.md); missing binding fails closed with a 503 while plaintext-config import still works.

Closes #139

## Notes for reviewers
- Also drops the `JIRA_CLIENT_ID` requirement for API-token Jira proxying (`src/worker/index.ts`): API-token mode authenticates to Atlassian with basic auth and never uses the OAuth client id, so token-mode connections can now proxy on deployments without OAuth client credentials. OAuth exchange/refresh paths still require it.
- The shared import flow is factored into a `src/app/lib/use-credential-import.ts` hook consumed by both the Settings and Login pages (rather than kept inline in `settings-transfer.ts`).
- Addresses the cross-tab identity/config divergence during import: a passive tab now fully reloads on a cross-tab identity switch instead of adopting the new identity in place with stale config/cache.